### PR TITLE
Add test ensuring main orchestrates modules sequentially

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,46 @@
+import runpy
+import sys
+import types
+from unittest.mock import patch
+
+
+def test_main_calls_functions_in_sequence():
+    # Create dummy modules to satisfy imports in main.py
+    modules = {
+        "agent": types.ModuleType("agent"),
+        "agent.modules": types.ModuleType("agent.modules"),
+        "agent.modules.scanner": types.ModuleType("agent.modules.scanner"),
+        "agent.modules.fixer": types.ModuleType("agent.modules.fixer"),
+        "agent.scheduler": types.ModuleType("agent.scheduler"),
+        "agent.scheduler.cron": types.ModuleType("agent.scheduler.cron"),
+        "agent.git_commit": types.ModuleType("agent.git_commit"),
+    }
+    sys.modules.update(modules)
+
+    call_order = []
+
+    def scan_side_effect():
+        call_order.append("scan")
+        return "raw"
+
+    def fix_side_effect(_):
+        call_order.append("fix")
+        return "fixed"
+
+    def commit_side_effect(_):
+        call_order.append("commit")
+
+    def schedule_side_effect():
+        call_order.append("schedule")
+
+    with patch("agent.modules.scanner.scan_site", side_effect=scan_side_effect, create=True) as mock_scan, \
+         patch("agent.modules.fixer.fix_code", side_effect=fix_side_effect, create=True) as mock_fix, \
+         patch("agent.git_commit.commit_fixes", side_effect=commit_side_effect, create=True) as mock_commit, \
+         patch("agent.scheduler.cron.schedule_hourly_job", side_effect=schedule_side_effect, create=True) as mock_schedule:
+        runpy.run_module("main", run_name="__main__")
+
+    assert call_order == ["scan", "fix", "commit", "schedule"]
+    mock_scan.assert_called_once_with()
+    mock_fix.assert_called_once_with("raw")
+    mock_commit.assert_called_once_with("fixed")
+    mock_schedule.assert_called_once_with()


### PR DESCRIPTION
## Summary
- add unit test verifying `main.py` invokes scanning, fixing, committing, and scheduling in sequence

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a27b3f8a7c8333b3105bfd331b138a