### PR TITLE
Expose DevSkyy agent via FastAPI for Replit deployment

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,1 @@
+run = "uvicorn main:app --host=0.0.0.0 --port=8000"

--- a/README.md
+++ b/README.md
@@ -7,3 +7,19 @@ An AI-powered, auto-fixing, self-healing dev agent for The Skyy Rose Collection.
 - Optimizes Divi layout blocks
 - Auto-commits fixes to GitHub
 
+## FastAPI Server
+
+The agent workflow is exposed through a FastAPI application in `main.py`. The
+`/run` endpoint triggers a scan, applies fixes, commits them, and schedules the
+next run.
+
+### Running
+
+Start the server locally with:
+
+```bash
+uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
+On Replit, the included `.replit` file runs this command automatically.
+

--- a/main.py
+++ b/main.py
@@ -1,11 +1,35 @@
+from fastapi import FastAPI
 from agent.modules.scanner import scan_site
 from agent.modules.fixer import fix_code
 from agent.scheduler.cron import schedule_hourly_job
 from agent.git_commit import commit_fixes
 
-if __name__ == "__main__":
-    print("🔁 Launching DevSkyy Agent...")
+
+app = FastAPI()
+
+
+def run_agent() -> dict:
+    """Execute the full DevSkyy agent workflow."""
     raw_code = scan_site()
     fixed_code = fix_code(raw_code)
     commit_fixes(fixed_code)
     schedule_hourly_job()
+    return {"status": "completed"}
+
+
+@app.post("/run")
+def run() -> dict:
+    """Endpoint to trigger the DevSkyy agent workflow."""
+    return run_agent()
+
+
+@app.get("/")
+def root() -> dict:
+    """Health check endpoint."""
+    return {"message": "DevSkyy Agent online"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 requests
 PyGithub
+fastapi
+uvicorn
+httpx

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,13 @@
-import runpy
+import importlib
 import sys
 import types
+from pathlib import Path
 from unittest.mock import patch
 
+from fastapi.testclient import TestClient
 
-def test_main_calls_functions_in_sequence():
-    # Create dummy modules to satisfy imports in main.py
+
+def test_run_endpoint_calls_functions_in_sequence():
     modules = {
         "agent": types.ModuleType("agent"),
         "agent.modules": types.ModuleType("agent.modules"),
@@ -16,6 +18,7 @@ def test_main_calls_functions_in_sequence():
         "agent.git_commit": types.ModuleType("agent.git_commit"),
     }
     sys.modules.update(modules)
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
     call_order = []
 
@@ -37,10 +40,15 @@ def test_main_calls_functions_in_sequence():
          patch("agent.modules.fixer.fix_code", side_effect=fix_side_effect, create=True) as mock_fix, \
          patch("agent.git_commit.commit_fixes", side_effect=commit_side_effect, create=True) as mock_commit, \
          patch("agent.scheduler.cron.schedule_hourly_job", side_effect=schedule_side_effect, create=True) as mock_schedule:
-        runpy.run_module("main", run_name="__main__")
+        main = importlib.import_module("main")
+        importlib.reload(main)
+        client = TestClient(main.app)
+        response = client.post("/run")
 
+    assert response.json() == {"status": "completed"}
     assert call_order == ["scan", "fix", "commit", "schedule"]
     mock_scan.assert_called_once_with()
     mock_fix.assert_called_once_with("raw")
     mock_commit.assert_called_once_with("fixed")
     mock_schedule.assert_called_once_with()
+


### PR DESCRIPTION
## Summary
- serve DevSkyy workflow through a FastAPI app with `/run` trigger and health check
- document FastAPI usage and add Replit run configuration
- update tests and dependencies for FastAPI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a341f044fc8333a5d21900eeada2a1