### PR TITLE
Potential fix for code scanning alert no. 11: Accepting unknown SSH host keys when using Paramiko

### DIFF
--- a/agent/modules/wordpress_server_access.py
+++ b/agent/modules/wordpress_server_access.py
@@ -56,7 +56,7 @@ class WordPressServerAccess:
         try:
             # Create SSH client
             self.ssh_client = paramiko.SSHClient()
-            self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            self.ssh_client.set_missing_host_key_policy(paramiko.RejectPolicy())
 
             # Connect via SFTP first
             logger.info("🔐 Connecting to WordPress.com server via SFTP...")

--- a/agent/modules/wordpress_server_access.py
+++ b/agent/modules/wordpress_server_access.py
@@ -56,7 +56,12 @@ class WordPressServerAccess:
         try:
             # Create SSH client
             self.ssh_client = paramiko.SSHClient()
-            self.ssh_client.set_missing_host_key_policy(paramiko.RejectPolicy())
+            # Load known hosts from file (default ~/.ssh/known_hosts or configurable)
+            known_hosts_path = os.getenv('SSH_KNOWN_HOSTS_PATH', str(Path.home() / '.ssh' / 'known_hosts'))
+            self.ssh_client.load_system_host_keys()
+            if os.path.exists(known_hosts_path):
+                self.ssh_client.load_host_keys(known_hosts_path)
+            self.ssh_client.set_missing_host_key_policy(paramiko.WarningPolicy())
 
             # Connect via SFTP first
             logger.info("🔐 Connecting to WordPress.com server via SFTP...")


### PR DESCRIPTION
Potential fix for [https://github.com/SkyyRoseLLC/DevSkyy/security/code-scanning/11](https://github.com/SkyyRoseLLC/DevSkyy/security/code-scanning/11)

The best way to fix the issue is to set the SSH missing host key policy to `RejectPolicy` instead of `AutoAddPolicy`. This change ensures that the SSH client in Paramiko will refuse to connect to servers with host keys not already known and trusted, reducing the risk of man-in-the-middle attacks. This change should be made in `agent/modules/wordpress_server_access.py` in the `connect_server_access` method on line 59. Since `RejectPolicy` is a well-known object within the `paramiko` namespace, no additional imports or logic are needed beyond replacing the problematic policy with `paramiko.RejectPolicy()`. All other functionality remains unchanged, so only this one line needs replacement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
