### PR TITLE
feat(agent-memory): introduce agent-side memory subsystem

### DIFF
--- a/docs/adr/0001-compositor-is-agent-inside-langgraph-node.md
+++ b/docs/adr/0001-compositor-is-agent-inside-langgraph-node.md
@@ -1,0 +1,6 @@
+# Compositor is an agent inside a LangGraph node, not a procedural script
+
+**Date:** 2026-05-02
+**Status:** accepted
+
+After commit `f25fd25d3` ("Phase B1 scorched earth — rebuild pending") gutted `CompositorAgent` to a 68-line `pass_through` shell on 2026-04-21, compositing functionality migrated to a parallel procedural script (`scripts/run_compositor_pipeline.py`) while the LangGraph `compositor_node` (`skyyrose/elite_studio/graph/nodes.py:318`) continued instantiating the gutted agent. We're treating the LangGraph path as canonical and rebuilding `CompositorAgent` so its `composite()` method actually composes, with the six stages (alpha → prompt-eng → relight → composite → shadows → QA) as private methods on the agent class — because the graph is load-bearing for the rest of the creative pipeline (vision/generator/quality/finalize state, checkpoint/resume, ADK observability via `BaseSuperAgent`), and a script-only design splits pipeline state across two incompatible runtimes. The procedural script is transitional and will be retired (or repointed to invoke the graph) once the rebuild reaches parity. See `docs/superpowers/plans/2026-05-02-compositor-agent-rebuild.md` for the rebuild plan stub.

--- a/docs/superpowers/plans/2026-05-02-compositor-agent-rebuild.md
+++ b/docs/superpowers/plans/2026-05-02-compositor-agent-rebuild.md
@@ -1,0 +1,39 @@
+# CompositorAgent Rebuild Implementation Plan
+
+> **Status:** STUB — needs full grilling before execution. Reserved as the prerequisite for `2026-05-01-embedding-quality-gates.md` Task 4 (deferred) and for un-blocking the LangGraph creative pipeline.
+>
+> **For agentic workers:** DO NOT execute this plan as written. Tasks are TBD pending design. Coordinate with the human owner before drafting tasks.
+
+**Goal:** Rebuild `skyyrose/elite_studio/agents/compositor_agent.py` from its current 68-line `pass_through` shell back into a working six-stage compositor that fulfils the contract LangGraph's `compositor_node` already expects (`agent.composite(sku, image_path, scene_name, collection)`). Retire the parallel procedural script `scripts/run_compositor_pipeline.py` once the rebuild reaches parity.
+
+**Architecture:** Per ADR-0001, the compositor is an agent inside a LangGraph node. Stages are private methods on the agent class, not module-level functions in a script. ADK observability ("Back Data") flows through `BaseSuperAgent`. `compositor_node` (the LangGraph wrapper) stays as-is — it's already correctly designed.
+
+**Why this exists:** Commit `f25fd25d3` ("Phase B1 scorched earth — rebuild pending") gutted the agent on 2026-04-21. Today the LangGraph `compositor_node` calls `agent.composite()` and gets a `pass_through` no-op back. Compositing functionality lives in `scripts/run_compositor_pipeline.py` (697L) outside the graph. Two pipelines, only one wired into the rest of the creative flow.
+
+---
+
+## Inputs to bring forward
+
+- `scripts/run_compositor_pipeline.py` (697L) — already-working stage logic to extract into agent methods
+  - `remove_background()` → `_extract_alpha()`
+  - `opus_prompt_for_product()` → `_opus_prompt()`
+  - `composite_product_into_scene()` → `_relight()`, `_composite()`, `_shadows()`
+  - Currently no Gemini QA stage in the script — was retained in the original agent design (`_visual_qa()`)
+- `skyyrose/elite_studio/tests/test_compositor_agent.py` (544L, currently stale) — the de-facto spec for the rebuild's API surface; class structure (`TestAlphaExtraction`, `TestOpusPromptEngineering`, `TestICLightRelighting`, `TestFLUXCompositing`, `TestShadowGeneration`, `TestVisualQA`, `TestFullPipeline`, `TestCheckpointResume`, `TestAuditLog`) maps 1:1 to the methods we need to restore
+- `skyyrose/elite_studio/synthesis/flux_pipeline.py` (374L), `synthesis/stages/{audit_filter,mask_deriver,decoration_inpaint}.py` — supporting helpers already structured per-stage
+- `skyyrose/elite_studio/graph/nodes.py:318` — the canonical contract (`agent.composite(sku, image_path, scene_name, collection) -> CompositorResult`); rebuild MUST satisfy this signature unchanged
+- `skyyrose/elite_studio/coordinator.py` (325L) and `master_registry.py` (288L) — observability and registration surfaces the rebuilt agent should plug into
+- Embedding gate library from `2026-05-01-embedding-quality-gates.md` Tasks 1-3 (once landed) — drop-in `_embedding_gate()` call between Stages 5 and 6
+
+## Open questions for grilling
+
+1. **Stage 6 (Gemini visual QA) — keep or replace?** The original design calls Gemini for every render. The embedding gate (Task 4 of the deferred work) was meant to *precede* Gemini and skip it on rejected renders. Given CLIP alignment scoring (Task 7 of the embedding plan) gives a similar signal cheaper, do we still need Gemini QA? Decision affects whether Stage 6 = Gemini, Stage 6 = embedding gate (replacing Gemini entirely), or Stage 6 = embedding gate → Gemini (current design).
+2. **Async vs sync `composite()`?** `nodes.py:346` has the comment `# composite() is sync since the Phase B2 rewrite — no [...]`. Sync simplifies the LangGraph integration. Async would let stages run concurrently for batches. Default: keep sync.
+3. **Procedural script retirement timing.** Hard cutover (delete in the same PR as rebuild) vs deprecation window (mark deprecated, schedule removal in N weeks). Default: deprecation window, because external runbooks may reference the script.
+4. **Test file salvage strategy.** The 544-line test file mocks every external dep (rembg, Anthropic, fal_client, httpx, Gemini REST, PIL, libcom). Re-pointing it at the rebuilt agent should be possible with minimal fixture changes — but the rebuild may diverge in stage signatures. Default: rebuild the agent first, *then* fix the test file to match, accepting that some test method renames are inevitable.
+5. **Where do retries live?** `BaseSuperAgent` has retry primitives. The script has its own `retry_call()` helper at line 75. Default: use `BaseSuperAgent`'s retry surface, drop the script's helper.
+6. **Audit log format.** The script writes `STAGE_DELAY = 2` and presumably an audit JSON. The agent should produce structured per-stage telemetry that flows through ADK Back Data. Need to align format so existing dashboards keep working.
+
+## Tasks
+
+TBD — grill before drafting.

--- a/skyyrose/core/memory/__init__.py
+++ b/skyyrose/core/memory/__init__.py
@@ -1,0 +1,40 @@
+"""Agent memory layer — three concerns separated by access pattern.
+
+- ``ConversationStore``: chronological turn buffer (SQLite, per-thread)
+- ``AgentMemory``: semantic long-term memory (vector store, per-agent namespace)
+- ``consolidate_thread``: close-of-thread LLM summarization that turns
+  conversation history into durable ``AgentMemory`` entries
+
+The split is deliberate. "Last N turns" is a B-tree-on-timestamp question,
+not a similarity question — embedding turns wastes money and adds latency
+for zero retrieval benefit. The vector store is for "find anything similar
+to this," the SQLite store is for "what just happened."
+"""
+
+from skyyrose.core.memory.agent_memory import (
+    DEFAULT_NAMESPACE_PREFIX,
+    AgentMemory,
+    Memory,
+)
+from skyyrose.core.memory.consolidator import (
+    DEFAULT_PROMPT,
+    SummarizeFn,
+    consolidate_thread,
+)
+from skyyrose.core.memory.conversation import (
+    DEFAULT_DB_PATH,
+    ConversationStore,
+    ConversationTurn,
+)
+
+__all__ = [
+    "AgentMemory",
+    "ConversationStore",
+    "ConversationTurn",
+    "DEFAULT_DB_PATH",
+    "DEFAULT_NAMESPACE_PREFIX",
+    "DEFAULT_PROMPT",
+    "Memory",
+    "SummarizeFn",
+    "consolidate_thread",
+]

--- a/skyyrose/core/memory/agent_memory.py
+++ b/skyyrose/core/memory/agent_memory.py
@@ -1,0 +1,207 @@
+"""AgentMemory — per-agent semantic long-term memory.
+
+Each agent has an isolated namespace in the shared vector store
+(``"memory:agent:<agent_id>"``). Memories are embedded with the configured
+embedding engine and stored alongside metadata (importance, tags, source,
+created_at). Recall is semantic — for chronological "last N turns" use
+``ConversationStore`` instead.
+
+The split between ``AgentMemory`` (semantic, vector-backed) and
+``ConversationStore`` (chronological, SQLite-backed) is deliberate. Embedding
+every conversation turn for chronological recall wastes money and adds
+latency for zero retrieval benefit. Use the right tool for the access pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from orchestration.embedding_engine import BaseEmbeddingEngine
+from orchestration.vector_store import BaseVectorStore, Document
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_NAMESPACE_PREFIX = "memory:agent"
+
+
+@dataclass
+class Memory:
+    """A single durable agent memory."""
+
+    memory_id: str
+    agent_id: str
+    content: str
+    importance: float
+    tags: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    score: float = 0.0  # similarity score from recall (0 if unset)
+
+
+class AgentMemory:
+    """Per-agent semantic memory store backed by a vector store namespace.
+
+    Usage:
+        memory = AgentMemory(
+            agent_id="compositor_agent",
+            vector_store=store,  # already initialized
+            embedder=embedder,   # already initialized
+        )
+        mid = await memory.remember(
+            "Corey prefers Black Rose embroidery on left chest, not centered",
+            tags=["preferences", "embroidery"],
+            importance=0.9,
+        )
+        relevant = await memory.recall("where should the BR logo go?", k=3)
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        vector_store: BaseVectorStore,
+        embedder: BaseEmbeddingEngine,
+        namespace_prefix: str = DEFAULT_NAMESPACE_PREFIX,
+    ) -> None:
+        if not agent_id or ":" in agent_id:
+            raise ValueError(f"agent_id must be a non-empty string without ':' (got {agent_id!r})")
+        self.agent_id = agent_id
+        self._store = vector_store
+        self._embedder = embedder
+        self._namespace = f"{namespace_prefix}:{agent_id}"
+
+    @property
+    def namespace(self) -> str:
+        """The vector-store namespace this AgentMemory writes to."""
+        return self._namespace
+
+    async def remember(
+        self,
+        content: str,
+        *,
+        tags: list[str] | None = None,
+        importance: float = 0.5,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """Store a new memory, returning its memory_id.
+
+        Args:
+            content: the memory text (will be embedded with the configured engine)
+            tags: optional categorical tags for filtering or future analysis
+            importance: 0.0..1.0; higher means "keep this longer when consolidating"
+            metadata: arbitrary structured attachments (e.g. source thread_id).
+                Only str/int/float/bool values survive — other types are dropped
+                because Pinecone metadata only supports those primitives.
+        """
+        if not 0.0 <= importance <= 1.0:
+            raise ValueError(f"importance must be in [0.0, 1.0], got {importance}")
+
+        memory_id = f"mem:{self.agent_id}:{uuid4().hex[:16]}"
+        created_at = datetime.now(UTC)
+
+        embedding = await self._embedder.embed_text(content)
+
+        # Filter metadata to vector-store-safe types (str/int/float/bool)
+        safe_metadata: dict[str, Any] = {
+            "agent_id": self.agent_id,
+            "importance": float(importance),
+            "tags_csv": ",".join(tags) if tags else "",
+            "created_at_ts": created_at.timestamp(),
+        }
+        if metadata:
+            safe_metadata.update(
+                {k: v for k, v in metadata.items() if isinstance(v, (str, int, float, bool))}
+            )
+
+        document = Document(
+            id=memory_id,
+            content=content,
+            metadata=safe_metadata,
+            source=f"agent_memory:{self.agent_id}",
+            created_at=created_at,
+        )
+
+        await self._store.add_documents([document], [embedding], namespace=self._namespace)
+        logger.info(
+            "AgentMemory.remember: stored %s (importance=%.2f, ns=%s)",
+            memory_id,
+            importance,
+            self._namespace,
+        )
+        return memory_id
+
+    async def recall(
+        self,
+        query: str,
+        *,
+        k: int = 5,
+        min_importance: float | None = None,
+    ) -> list[Memory]:
+        """Semantically retrieve the top-k memories matching ``query``.
+
+        Args:
+            query: free-form natural language
+            k: max memories to return (post-filter)
+            min_importance: optional floor on importance (filtered post-search,
+                so the underlying top_k may pull more candidates to compensate)
+        """
+        # If min_importance is set, pull a wider net to survive post-filtering
+        search_k = k * 3 if min_importance is not None else k
+
+        query_embedding = await self._embedder.embed_query(query)
+
+        results = await self._store.search(
+            query_embedding=query_embedding,
+            top_k=search_k,
+            namespace=self._namespace,
+        )
+
+        memories: list[Memory] = []
+        for r in results:
+            if len(memories) >= k:
+                break
+            meta = r.document.metadata or {}
+            importance = float(meta.get("importance", 0.5))
+            if min_importance is not None and importance < min_importance:
+                continue
+
+            tags_csv = meta.get("tags_csv", "")
+            tags = [t for t in tags_csv.split(",") if t] if tags_csv else []
+
+            ts = meta.get("created_at_ts")
+            created_at = datetime.fromtimestamp(ts, tz=UTC) if ts else datetime.now(UTC)
+
+            memories.append(
+                Memory(
+                    memory_id=r.document.id,
+                    agent_id=meta.get("agent_id", self.agent_id),
+                    content=r.document.content,
+                    importance=importance,
+                    tags=tags,
+                    metadata={
+                        k: v
+                        for k, v in meta.items()
+                        if k not in {"agent_id", "importance", "tags_csv", "created_at_ts"}
+                    },
+                    created_at=created_at,
+                    score=r.score,
+                )
+            )
+        return memories
+
+    async def forget(self, memory_id: str) -> int:
+        """Delete a single memory by id; returns rows deleted (0 or 1)."""
+        return await self._store.delete_documents([memory_id], namespace=self._namespace)
+
+    async def forget_many(self, memory_ids: list[str]) -> int:
+        """Delete multiple memories by id; returns rows deleted."""
+        if not memory_ids:
+            return 0
+        return await self._store.delete_documents(memory_ids, namespace=self._namespace)
+
+
+__all__ = ["AgentMemory", "Memory", "DEFAULT_NAMESPACE_PREFIX"]

--- a/skyyrose/core/memory/consolidator.py
+++ b/skyyrose/core/memory/consolidator.py
@@ -1,0 +1,140 @@
+"""Consolidator — close a conversation thread into durable agent memories.
+
+The pattern:
+    1. Read the full chronological thread log from ``ConversationStore``
+    2. Ask an LLM to summarize into 3-5 durable facts (preferences, decisions,
+       commitments — not chitchat)
+    3. Write each fact as a high-importance ``Memory`` in the agent's namespace
+
+This is what separates "chat with retention" from "agent that learns."
+Without consolidation, the agent's long-term namespace fills with raw
+conversation chunks and recall returns noise; with it, the namespace becomes
+a curated set of durable facts that improves agent behavior over time.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from skyyrose.core.memory.agent_memory import AgentMemory
+from skyyrose.core.memory.conversation import ConversationStore
+
+logger = logging.getLogger(__name__)
+
+
+# Type alias for the LLM summarization callable. Decouples this module from
+# any specific LLM client (Anthropic / OpenAI / Gemini / local) — the caller
+# wires up whichever one they want.
+SummarizeFn = Callable[[str], Awaitable[str]]
+
+
+DEFAULT_PROMPT = """\
+Summarize the following conversation transcript into 3-5 durable facts that \
+capture the user's preferences, decisions, and key context. Each fact should \
+be:
+- A single self-contained sentence
+- About the USER or the project, not about the conversation itself
+- Specific enough to be useful in a future conversation
+
+Format: each fact on its own line, prefixed with '- '.
+
+Skip chitchat, acknowledgments, and information already captured in the \
+project's source code or docs.
+
+<transcript>
+{transcript}
+</transcript>
+
+Facts:
+"""
+
+
+async def consolidate_thread(
+    thread_id: str,
+    *,
+    conversation_store: ConversationStore,
+    agent_memory: AgentMemory,
+    summarize_fn: SummarizeFn,
+    importance: float = 0.8,
+    prompt_template: str = DEFAULT_PROMPT,
+) -> list[str]:
+    """Read a thread, summarize it via LLM, write durable agent memories.
+
+    Args:
+        thread_id: the conversation thread to consolidate
+        conversation_store: source of the chronological log
+        agent_memory: destination for the durable facts (writes to its namespace)
+        summarize_fn: async callable that takes a prompt and returns a completion
+        importance: importance score for each consolidated fact (default 0.8 —
+            consolidated facts are intentionally above the 0.5 ``remember`` default
+            so they survive future importance-floored recalls)
+        prompt_template: format string with a ``{transcript}`` placeholder
+
+    Returns:
+        List of memory_ids that were written to ``agent_memory``.
+    """
+    turns = await conversation_store.thread_log(thread_id)
+    if not turns:
+        logger.info(
+            "consolidate_thread: thread %s has no turns; nothing to consolidate",
+            thread_id,
+        )
+        return []
+
+    transcript = "\n".join(f"{t.role}: {t.content}" for t in turns)
+    prompt = prompt_template.format(transcript=transcript)
+
+    summary = await summarize_fn(prompt)
+    facts = _parse_facts(summary)
+
+    if not facts:
+        logger.warning(
+            "consolidate_thread: summarizer returned no parseable facts for "
+            "thread %s. Raw summary length=%d.",
+            thread_id,
+            len(summary),
+        )
+        return []
+
+    memory_ids: list[str] = []
+    for fact in facts:
+        mid = await agent_memory.remember(
+            content=fact,
+            importance=importance,
+            tags=["consolidated"],
+            metadata={"source": "consolidator", "thread_id": thread_id},
+        )
+        memory_ids.append(mid)
+
+    logger.info(
+        "consolidate_thread: wrote %d facts for thread %s into ns=%s",
+        len(memory_ids),
+        thread_id,
+        agent_memory.namespace,
+    )
+    return memory_ids
+
+
+def _parse_facts(summary: str) -> list[str]:
+    """Extract bullet-prefixed facts from a free-form summary.
+
+    Tolerates ``- ``, ``* ``, ``• `` prefixes and trims whitespace. Lines
+    without a recognized prefix are dropped — keeps "Facts:" preambles or
+    closing paragraphs out of the output.
+    """
+    facts: list[str] = []
+    for raw in summary.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        for prefix in ("- ", "* ", "• "):
+            if line.startswith(prefix):
+                stripped = line[len(prefix) :].strip()
+                if stripped:
+                    facts.append(stripped)
+                break
+    return facts
+
+
+__all__ = ["consolidate_thread", "SummarizeFn", "DEFAULT_PROMPT"]

--- a/skyyrose/core/memory/conversation.py
+++ b/skyyrose/core/memory/conversation.py
@@ -1,0 +1,216 @@
+"""ConversationStore — SQLite-backed chronological turn buffer.
+
+Per-thread isolation, per-agent indexing, append-only. Designed to answer
+"what did we say in the last N turns?" — the question vector stores can't
+answer cheaply.
+
+For semantic recall ("when did we discuss X?"), use ``AgentMemory`` and the
+shared vector store. For close-of-conversation summarization that promotes
+chronological turns into durable semantic memories, use
+``skyyrose.core.memory.consolidator.consolidate_thread``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# Default location: <project_root>/data/memory/conversations.db
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "memory" / "conversations.db"
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS conversation_turns (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    thread_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    metadata_json TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_thread_time
+    ON conversation_turns(thread_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_agent_time
+    ON conversation_turns(agent_id, created_at);
+"""
+
+
+@dataclass(frozen=True)
+class ConversationTurn:
+    """A single chronological turn in a conversation thread."""
+
+    id: int
+    thread_id: str
+    agent_id: str
+    role: str
+    content: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+class ConversationStore:
+    """SQLite-backed chronological conversation log.
+
+    Async by wrapping sync sqlite3 calls in ``asyncio.to_thread()``. Avoids
+    the aiosqlite dependency for code that mostly does small append + recent-N
+    queries. If you ever need long-running streaming reads, swap in aiosqlite.
+    """
+
+    def __init__(self, db_path: Path | str | None = None) -> None:
+        self.db_path = Path(db_path) if db_path else DEFAULT_DB_PATH
+        self._initialized = False
+
+    async def initialize(self) -> None:
+        """Create the parent directory + run schema migration."""
+        await asyncio.to_thread(self._sync_init)
+        self._initialized = True
+        logger.info("ConversationStore initialized at %s", self.db_path)
+
+    def _sync_init(self) -> None:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executescript(SCHEMA)
+            conn.commit()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    async def append_turn(
+        self,
+        thread_id: str,
+        agent_id: str,
+        role: str,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> int:
+        """Append a turn to the thread; returns the new turn ID."""
+        self._require_init()
+        return await asyncio.to_thread(
+            self._sync_append, thread_id, agent_id, role, content, metadata
+        )
+
+    def _sync_append(
+        self,
+        thread_id: str,
+        agent_id: str,
+        role: str,
+        content: str,
+        metadata: dict[str, Any] | None,
+    ) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                INSERT INTO conversation_turns
+                    (thread_id, agent_id, role, content, metadata_json, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    thread_id,
+                    agent_id,
+                    role,
+                    content,
+                    json.dumps(metadata) if metadata else None,
+                    datetime.now(UTC).isoformat(),
+                ),
+            )
+            conn.commit()
+            return cur.lastrowid or 0
+
+    async def recent(self, thread_id: str, n: int = 10) -> list[ConversationTurn]:
+        """Last n turns of a thread, oldest-first (chronological)."""
+        self._require_init()
+        return await asyncio.to_thread(self._sync_recent, thread_id, n)
+
+    def _sync_recent(self, thread_id: str, n: int) -> list[ConversationTurn]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, thread_id, agent_id, role, content, metadata_json, created_at
+                FROM conversation_turns
+                WHERE thread_id = ?
+                ORDER BY created_at DESC
+                LIMIT ?
+                """,
+                (thread_id, n),
+            ).fetchall()
+        # Reverse so oldest-first
+        return [self._row_to_turn(r) for r in reversed(rows)]
+
+    async def thread_log(self, thread_id: str) -> list[ConversationTurn]:
+        """Full chronological log of a thread (oldest first)."""
+        self._require_init()
+        return await asyncio.to_thread(self._sync_thread_log, thread_id)
+
+    def _sync_thread_log(self, thread_id: str) -> list[ConversationTurn]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, thread_id, agent_id, role, content, metadata_json, created_at
+                FROM conversation_turns
+                WHERE thread_id = ?
+                ORDER BY created_at ASC
+                """,
+                (thread_id,),
+            ).fetchall()
+        return [self._row_to_turn(r) for r in rows]
+
+    async def list_threads(self, agent_id: str | None = None) -> list[str]:
+        """Distinct thread_ids, optionally filtered by agent."""
+        self._require_init()
+        return await asyncio.to_thread(self._sync_list_threads, agent_id)
+
+    def _sync_list_threads(self, agent_id: str | None) -> list[str]:
+        with self._connect() as conn:
+            if agent_id is not None:
+                rows = conn.execute(
+                    "SELECT DISTINCT thread_id FROM conversation_turns WHERE agent_id = ?",
+                    (agent_id,),
+                ).fetchall()
+            else:
+                rows = conn.execute("SELECT DISTINCT thread_id FROM conversation_turns").fetchall()
+        return [r["thread_id"] for r in rows]
+
+    async def delete_thread(self, thread_id: str) -> int:
+        """Delete all turns of a thread; returns rows deleted."""
+        self._require_init()
+        return await asyncio.to_thread(self._sync_delete_thread, thread_id)
+
+    def _sync_delete_thread(self, thread_id: str) -> int:
+        with self._connect() as conn:
+            cur = conn.execute("DELETE FROM conversation_turns WHERE thread_id = ?", (thread_id,))
+            conn.commit()
+            return cur.rowcount
+
+    @staticmethod
+    def _row_to_turn(row: sqlite3.Row) -> ConversationTurn:
+        return ConversationTurn(
+            id=row["id"],
+            thread_id=row["thread_id"],
+            agent_id=row["agent_id"],
+            role=row["role"],
+            content=row["content"],
+            metadata=json.loads(row["metadata_json"]) if row["metadata_json"] else {},
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+    def _require_init(self) -> None:
+        if not self._initialized:
+            raise RuntimeError("ConversationStore not initialized — await initialize() first.")
+
+
+__all__ = ["ConversationStore", "ConversationTurn", "DEFAULT_DB_PATH"]


### PR DESCRIPTION
## Summary
Introduces `skyyrose/core/memory/` — a new agent-side memory subsystem with conversation history, consolidation, and persistent agent memory. Includes ADR-0001 (compositor-as-agent inside LangGraph node) and a compositor-agent rebuild plan.

## Wave
This PR is part of **Wave 2** (parallel-safe) of a 4-wave branch split. Recommended merge order:
1. chore/scope-system (foundational tooling)
2. **feat/agent-memory**, feat/mascot, feat/wp-storefront, feat/a2a ← this PR (Wave 2 parallel)
3. feat/wp-similarity, feat/phase-b2-c3-pipeline-eval-architecture
4. chore/meta (pre-commit hook needs Wave 1 first)

## Files (6 total)
- `docs/adr/0001-compositor-is-agent-inside-langgraph-node.md` — architecture decision record
- `docs/superpowers/plans/2026-05-02-compositor-agent-rebuild.md` — rebuild plan
- `skyyrose/core/memory/__init__.py` — package init
- `skyyrose/core/memory/agent_memory.py` — persistent agent memory
- `skyyrose/core/memory/consolidator.py` — memory consolidation logic
- `skyyrose/core/memory/conversation.py` — conversation history management

## Verification
- [ ] CI green
- [ ] No merge conflicts with main
- [ ] Reviewed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `skyyrose/core/memory/` — an agent-side memory layer with a SQLite conversation buffer, a vector-backed long‑term store, and an LLM-based consolidator to turn threads into durable facts. Also adds ADR‑0001 (compositor-as-agent in LangGraph) and a rebuild plan stub.

- **New Features**
  - `ConversationStore` (SQLite): per-thread chronological log with `append`, `recent`, `thread_log`, `list_threads`, `delete_thread` (default DB at `data/memory/conversations.db`; async via `asyncio.to_thread`).
  - `AgentMemory`: per-agent semantic memory in namespace `memory:agent:<agent_id>` with `remember`, `recall`, `forget`; stores importance, tags, and metadata using your `BaseVectorStore` and `BaseEmbeddingEngine`.
  - `consolidate_thread`: summarizes a thread with an injected `SummarizeFn` (uses `DEFAULT_PROMPT`) and writes 3–5 high-importance facts tagged `consolidated` to `AgentMemory`.

<sup>Written for commit a4ae034a70ea25c51e2b5f27bef263721c0cc916. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

