### PR TITLE
fix(theme): guard $product type + stop false global write in hero preload

### DIFF
--- a/wordpress-theme/skyyrose-flagship/inc/enqueue-performance.php
+++ b/wordpress-theme/skyyrose-flagship/inc/enqueue-performance.php
@@ -163,12 +163,18 @@ function skyyrose_preload_hero_image() {
 		$image_url = get_theme_mod( 'skyyrose_hero_image', '' );
 	} elseif ( function_exists( 'is_product' ) && is_product() ) {
 		// Single product: the main gallery image is the LCP element.
-		// $GLOBALS['product'] can hold non-WC_Product values (string, false, etc.)
-		// when third-party callbacks fire before wp_head priority 4 — guard with
-		// instanceof rather than a truthy check.
+		// $GLOBALS['product'] can hold non-WC_Product values when third-party
+		// callbacks fire before wp_head priority 4. Guard with instanceof, and
+		// only overwrite the global when wc_get_product() returns a valid
+		// WC_Product — it returns false on draft/trashed/non-product posts, and
+		// writing false back to the global would pollute any downstream readers
+		// that still use truthy checks.
 		global $product;
 		if ( ! $product instanceof WC_Product && function_exists( 'wc_get_product' ) ) {
-			$product = wc_get_product( get_the_ID() );
+			$fetched = wc_get_product( get_the_ID() );
+			if ( $fetched instanceof WC_Product ) {
+				$product = $fetched;
+			}
 		}
 		if ( $product instanceof WC_Product && $product->get_image_id() ) {
 			$image_url = wp_get_attachment_url( $product->get_image_id() );

--- a/wordpress-theme/skyyrose-flagship/inc/enqueue-performance.php
+++ b/wordpress-theme/skyyrose-flagship/inc/enqueue-performance.php
@@ -163,11 +163,14 @@ function skyyrose_preload_hero_image() {
 		$image_url = get_theme_mod( 'skyyrose_hero_image', '' );
 	} elseif ( function_exists( 'is_product' ) && is_product() ) {
 		// Single product: the main gallery image is the LCP element.
+		// $GLOBALS['product'] can hold non-WC_Product values (string, false, etc.)
+		// when third-party callbacks fire before wp_head priority 4 — guard with
+		// instanceof rather than a truthy check.
 		global $product;
-		if ( ! $product && function_exists( 'wc_get_product' ) ) {
+		if ( ! $product instanceof WC_Product && function_exists( 'wc_get_product' ) ) {
 			$product = wc_get_product( get_the_ID() );
 		}
-		if ( $product && $product->get_image_id() ) {
+		if ( $product instanceof WC_Product && $product->get_image_id() ) {
 			$image_url = wp_get_attachment_url( $product->get_image_id() );
 		}
 	} elseif ( is_page() ) {


### PR DESCRIPTION
## Summary

Production hotfix for the 2026-05-05 incident where every `/product/{sku}/` page returned HTTP 500 across all four collections (BR/LH/SG/Kids).

**Root cause:** `skyyrose_preload_hero_image()` in `inc/enqueue-performance.php` called `->get_image_id()` on `$GLOBALS['product']` after a truthy check. A third-party callback was writing a non-empty string to the global before `wp_head` priority 4, causing the truthy check to pass and the method call to fatal.

## Changes

- `7031acae` — Replace truthy check with `instanceof WC_Product` (canonical WC pattern)
- `ffe4c629` — Follow-up: don't write `false` back to the global when `wc_get_product()` returns false on draft/trashed posts

## Status

**Already deployed and verified live.** All 8/8 product SKUs returned HTTP 200 post-hotfix at 18:40 UTC 2026-05-05. All commits are live in production.

This PR is a **review-record only** — merging to `main` captures git history but does not change live state.

## Test plan

- [ ] Verify `/product/br-001/` returns HTTP 200
- [ ] Verify `/product/kids-001/` returns HTTP 200
- [ ] Verify no PHP fatals in error log after merge
- [ ] Confirm `$GLOBALS['product']` is only written when `wc_get_product()` returns a valid `WC_Product`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a fatal on single product pages by guarding the `$product` type in the hero image preload and avoiding invalid writes to the global. This stops 500s on `/product/{sku}/` and keeps downstream code stable.

- **Bug Fixes**
  - In `skyyrose_preload_hero_image()`, use `instanceof WC_Product` before calling `get_image_id()`.
  - Fetch via `wc_get_product( get_the_ID() )` into a local variable and only assign to `$GLOBALS['product']` if it is a `WC_Product` (do not write `false`).

<sup>Written for commit ffe4c62905c9b53caa4870da3d63aead88f6ad92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of hero image preloading on product pages with enhanced validation checks to prevent loading errors and ensure reliable handling of product image data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->