### PR TITLE
fix(theme): 301 redirect /preorder/ → /pre-order/ canonical slug

### DIFF
--- a/wordpress-theme/skyyrose-flagship/inc/redirects.php
+++ b/wordpress-theme/skyyrose-flagship/inc/redirects.php
@@ -48,3 +48,35 @@ function skyyrose_collection_redirects() {
 	}
 }
 add_action( 'template_redirect', 'skyyrose_collection_redirects', 1 );
+
+/**
+ * Redirect /preorder/ to /pre-order/ (canonical hyphenated slug).
+ *
+ * The Pre-Order Gateway page is published at /pre-order/. External links,
+ * sitemap entries, and social referrers occasionally use the un-hyphenated
+ * /preorder/ form, which 404s. Permanent 301 preserves link equity and
+ * keeps inbound traffic resolving to the gateway. Both trailing-slash
+ * and no-trailing-slash variants are handled.
+ *
+ * @since 6.7.0
+ * @return void
+ */
+function skyyrose_preorder_slug_redirect() {
+	$request_uri = isset( $_SERVER['REQUEST_URI'] )
+		? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) )
+		: '';
+	$path = strtok( $request_uri, '?' );
+
+	if ( '/preorder/' !== $path && '/preorder' !== $path ) {
+		return;
+	}
+
+	$target  = home_url( '/pre-order/' );
+	$qs_pos  = strpos( $request_uri, '?' );
+	if ( false !== $qs_pos ) {
+		$target .= substr( $request_uri, $qs_pos );
+	}
+	wp_safe_redirect( $target, 301 );
+	exit;
+}
+add_action( 'template_redirect', 'skyyrose_preorder_slug_redirect', 1 );


### PR DESCRIPTION
## Summary

Fixes a 404 on `/preorder/` reported by Jetpack Boost during the 2026-05-05 incident.

The canonical Pre-Order Gateway page is at `/pre-order/` (hyphenated). External links, sitemap entries, and social referrers occasionally use the un-hyphenated form `/preorder/`.

## Changes

- `a538bcd7` — Adds `skyyrose_preorder_slug_redirect()` in `inc/redirects.php`, mirroring the existing `skyyrose_collection_redirects()` pattern:
  - Hooked on `template_redirect` priority 1
  - Handles both `/preorder/` and `/preorder` variants
  - Preserves query strings on redirect

## Status

Content is also live via merge into `refactor/wc-product-helper`.

## Test plan

- [ ] Verify GET `/preorder/` → 301 → `/pre-order/`
- [ ] Verify GET `/preorder` → 301 → `/pre-order/`
- [ ] Verify query strings are preserved: `/preorder/?collection=black-rose` → `/pre-order/?collection=black-rose`
- [ ] Verify canonical `/pre-order/` returns 200 (no redirect loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 301 redirect from /preorder/ (and /preorder) to the canonical /pre-order/ to stop 404s and keep link equity. Query strings are preserved, and the redirect runs on template_redirect at priority 1.

<sup>Written for commit a538bcd7bf045b5c179b8788507b68e692a3a6ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

