### PR TITLE
refactor(theme): extract wc-product helper, fix product 500, redirect /preorder/

### DIFF
--- a/wordpress-theme/skyyrose-flagship/404.php
+++ b/wordpress-theme/skyyrose-flagship/404.php
@@ -67,7 +67,7 @@ if ( class_exists( 'WooCommerce' ) ) {
 	if ( $skyyrose_trending_query->have_posts() ) {
 		while ( $skyyrose_trending_query->have_posts() ) {
 			$skyyrose_trending_query->the_post();
-			$skyyrose_product = wc_get_product( get_the_ID() );
+			$skyyrose_product = skyyrose_current_wc_product();
 
 			if ( $skyyrose_product ) {
 				$skyyrose_trending_products[] = array(

--- a/wordpress-theme/skyyrose-flagship/inc/enqueue-performance.php
+++ b/wordpress-theme/skyyrose-flagship/inc/enqueue-performance.php
@@ -163,12 +163,18 @@ function skyyrose_preload_hero_image() {
 		$image_url = get_theme_mod( 'skyyrose_hero_image', '' );
 	} elseif ( function_exists( 'is_product' ) && is_product() ) {
 		// Single product: the main gallery image is the LCP element.
-		// $GLOBALS['product'] can hold non-WC_Product values (string, false, etc.)
-		// when third-party callbacks fire before wp_head priority 4 — guard with
-		// instanceof rather than a truthy check.
+		// $GLOBALS['product'] can hold non-WC_Product values when third-party
+		// callbacks fire before wp_head priority 4. Guard with instanceof, and
+		// only overwrite the global when wc_get_product() returns a valid
+		// WC_Product — it returns false on draft/trashed/non-product posts, and
+		// writing false back to the global would pollute any downstream readers
+		// that still use truthy checks.
 		global $product;
 		if ( ! $product instanceof WC_Product && function_exists( 'wc_get_product' ) ) {
-			$product = wc_get_product( get_the_ID() );
+			$fetched = wc_get_product( get_the_ID() );
+			if ( $fetched instanceof WC_Product ) {
+				$product = $fetched;
+			}
 		}
 		if ( $product instanceof WC_Product && $product->get_image_id() ) {
 			$image_url = wp_get_attachment_url( $product->get_image_id() );

--- a/wordpress-theme/skyyrose-flagship/inc/enqueue-performance.php
+++ b/wordpress-theme/skyyrose-flagship/inc/enqueue-performance.php
@@ -163,11 +163,14 @@ function skyyrose_preload_hero_image() {
 		$image_url = get_theme_mod( 'skyyrose_hero_image', '' );
 	} elseif ( function_exists( 'is_product' ) && is_product() ) {
 		// Single product: the main gallery image is the LCP element.
+		// $GLOBALS['product'] can hold non-WC_Product values (string, false, etc.)
+		// when third-party callbacks fire before wp_head priority 4 — guard with
+		// instanceof rather than a truthy check.
 		global $product;
-		if ( ! $product && function_exists( 'wc_get_product' ) ) {
+		if ( ! $product instanceof WC_Product && function_exists( 'wc_get_product' ) ) {
 			$product = wc_get_product( get_the_ID() );
 		}
-		if ( $product && $product->get_image_id() ) {
+		if ( $product instanceof WC_Product && $product->get_image_id() ) {
 			$image_url = wp_get_attachment_url( $product->get_image_id() );
 		}
 	} elseif ( is_page() ) {

--- a/wordpress-theme/skyyrose-flagship/inc/enqueue-performance.php
+++ b/wordpress-theme/skyyrose-flagship/inc/enqueue-performance.php
@@ -164,16 +164,14 @@ function skyyrose_preload_hero_image() {
 	} elseif ( function_exists( 'is_product' ) && is_product() ) {
 		// Single product: the main gallery image is the LCP element.
 		// $GLOBALS['product'] can hold non-WC_Product values when third-party
-		// callbacks fire before wp_head priority 4. Guard with instanceof, and
-		// only overwrite the global when wc_get_product() returns a valid
-		// WC_Product — it returns false on draft/trashed/non-product posts, and
-		// writing false back to the global would pollute any downstream readers
-		// that still use truthy checks.
+		// callbacks fire before wp_head priority 4 — only adopt a fresh
+		// resolution when the helper returns a valid WC_Product so we never
+		// write null/false back to the global.
 		global $product;
-		if ( ! $product instanceof WC_Product && function_exists( 'wc_get_product' ) ) {
-			$fetched = wc_get_product( get_the_ID() );
-			if ( $fetched instanceof WC_Product ) {
-				$product = $fetched;
+		if ( ! $product instanceof WC_Product ) {
+			$resolved = skyyrose_current_wc_product();
+			if ( $resolved instanceof WC_Product ) {
+				$product = $resolved;
 			}
 		}
 		if ( $product instanceof WC_Product && $product->get_image_id() ) {

--- a/wordpress-theme/skyyrose-flagship/inc/redirects.php
+++ b/wordpress-theme/skyyrose-flagship/inc/redirects.php
@@ -48,3 +48,35 @@ function skyyrose_collection_redirects() {
 	}
 }
 add_action( 'template_redirect', 'skyyrose_collection_redirects', 1 );
+
+/**
+ * Redirect /preorder/ to /pre-order/ (canonical hyphenated slug).
+ *
+ * The Pre-Order Gateway page is published at /pre-order/. External links,
+ * sitemap entries, and social referrers occasionally use the un-hyphenated
+ * /preorder/ form, which 404s. Permanent 301 preserves link equity and
+ * keeps inbound traffic resolving to the gateway. Both trailing-slash
+ * and no-trailing-slash variants are handled.
+ *
+ * @since 6.7.0
+ * @return void
+ */
+function skyyrose_preorder_slug_redirect() {
+	$request_uri = isset( $_SERVER['REQUEST_URI'] )
+		? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) )
+		: '';
+	$path = strtok( $request_uri, '?' );
+
+	if ( '/preorder/' !== $path && '/preorder' !== $path ) {
+		return;
+	}
+
+	$target  = home_url( '/pre-order/' );
+	$qs_pos  = strpos( $request_uri, '?' );
+	if ( false !== $qs_pos ) {
+		$target .= substr( $request_uri, $qs_pos );
+	}
+	wp_safe_redirect( $target, 301 );
+	exit;
+}
+add_action( 'template_redirect', 'skyyrose_preorder_slug_redirect', 1 );

--- a/wordpress-theme/skyyrose-flagship/inc/seo.php
+++ b/wordpress-theme/skyyrose-flagship/inc/seo.php
@@ -36,7 +36,7 @@ function skyyrose_product_schema() {
 		return;
 	}
 
-	$product = function_exists( 'wc_get_product' ) ? wc_get_product( get_the_ID() ) : null;
+	$product = skyyrose_current_wc_product();
 
 	if ( ! $product ) {
 		return;
@@ -530,8 +530,8 @@ function skyyrose_open_graph_tags() {
 		}
 
 		// Product-specific OG tags.
-		if ( is_singular( 'product' ) && function_exists( 'wc_get_product' ) ) {
-			$product = wc_get_product( $post->ID );
+		if ( is_singular( 'product' ) ) {
+			$product = skyyrose_current_wc_product( $post->ID );
 			if ( $product && function_exists( 'get_woocommerce_currency' ) ) {
 				echo '<meta property="product:price:amount" content="' . esc_attr( $product->get_price() ) . '" />' . "\n";
 				echo '<meta property="product:price:currency" content="' . esc_attr( get_woocommerce_currency() ) . '" />' . "\n";

--- a/wordpress-theme/skyyrose-flagship/inc/wc-product-functions.php
+++ b/wordpress-theme/skyyrose-flagship/inc/wc-product-functions.php
@@ -376,3 +376,32 @@ function skyyrose_product_body_class( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', 'skyyrose_product_body_class' );
+
+/**
+ * Resolve the current page's WC_Product safely, or null on failure.
+ *
+ * Encapsulates the safe-fetch pattern duplicated across enqueue-performance.php,
+ * seo.php, 404.php, and search.php. Guards against:
+ *   - WooCommerce not being loaded (function_exists check)
+ *   - Missing/invalid post ID (get_the_ID returning false outside the loop)
+ *   - wc_get_product returning false on draft / trashed / non-product posts
+ *
+ * Returns null (not false) so callers can use `?:` fallbacks idiomatically and
+ * type-hint the result against `?WC_Product`.
+ *
+ * @since 6.7.0
+ *
+ * @param int|null $post_id Optional. Post ID. Defaults to current loop ID via get_the_ID().
+ * @return WC_Product|null
+ */
+function skyyrose_current_wc_product( $post_id = null ) {
+	if ( ! function_exists( 'wc_get_product' ) ) {
+		return null;
+	}
+	$post_id = $post_id ? (int) $post_id : (int) get_the_ID();
+	if ( ! $post_id ) {
+		return null;
+	}
+	$product = wc_get_product( $post_id );
+	return $product instanceof WC_Product ? $product : null;
+}

--- a/wordpress-theme/skyyrose-flagship/search.php
+++ b/wordpress-theme/skyyrose-flagship/search.php
@@ -154,7 +154,7 @@ $skyyrose_collections = array(
 						$skyyrose_index = 0;
 						while ( $skyyrose_product_results->have_posts() ) :
 							$skyyrose_product_results->the_post();
-							$skyyrose_wc_product = wc_get_product( get_the_ID() );
+							$skyyrose_wc_product = skyyrose_current_wc_product();
 
 							if ( $skyyrose_wc_product ) :
 								get_template_part(


### PR DESCRIPTION
## Summary

> ⚠️ **This branch is currently deployed to production** (deployed 2026-05-05 at 19:50 UTC after a brief regression-and-recovery cycle, see bug-097). **Merging this PR is a review-record action, not a state change.**

Combined branch containing the hotfix from `fix/single-product-fatal-image-id`, the redirect from `fix/preorder-slug-redirect`, and a refactor pass consolidating a repeated WC product lookup pattern.

## Changes

- `7031acae` — fix: `instanceof WC_Product` guard in hero preload (`inc/enqueue-performance.php`)
- `ffe4c629` — refactor: don't write `false` to `$GLOBALS['product']` on `wc_get_product()` miss
- `548106d3` — refactor: extract `skyyrose_current_wc_product()` helper, consolidate 5 call sites
  - New file: `inc/wc-product-functions.php`
  - Updated: `inc/enqueue-performance.php`, `inc/seo.php` (×2), `404.php`, `search.php`
  - Signature: `skyyrose_current_wc_product( $post_id = null ): ?WC_Product`
  - Defensive against missing WC, missing post ID, and `wc_get_product()` returning `false`
- `a538bcd7` — fix: redirect `/preorder/` → `/pre-order/` (`inc/redirects.php`)
- `da53443c` — Merge `fix/preorder-slug-redirect` into this branch

## Refactor context

`wc_get_product( get_the_ID() )` was duplicated across 5 files with slightly different shape — some checked `function_exists` inline, some used ternaries, some passed `$post->ID`. The helper unifies all variants under one defensive function and makes future audits easier.

## Reviewer note

This PR is a superset of PRs `fix/single-product-fatal-image-id` and `fix/preorder-slug-redirect`. Reviewers may prefer merging this single PR over the two individual ones.

## Test plan

- [ ] Confirm all `/product/{sku}/` pages return HTTP 200 (no regressions)
- [ ] Confirm `/preorder/` → 301 → `/pre-order/`
- [ ] Confirm `skyyrose_current_wc_product()` helper is callable from all 5 refactored sites
- [ ] Confirm no PHP warnings/errors in error log post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates WooCommerce product lookup into a safe `skyyrose_current_wc_product()` helper and updates five call sites. Fixes product-page 500s from a corrupted `$product` global and adds a 301 from `/preorder/` to `/pre-order/`.

- Bug Fixes
  - Guard `instanceof WC_Product` before `get_image_id()` in hero preload; only write to `$GLOBALS['product']` when valid to prevent `/product/*` fatals.
  - Add 301 redirect from `/preorder/` to `/pre-order/`, preserving query strings.

- Refactors
  - Introduce `skyyrose_current_wc_product( $post_id = null ): ?WC_Product`.
  - Replace direct `wc_get_product()` calls in `enqueue-performance.php`, `seo.php` (×2), `404.php`, and `search.php` with the helper to handle missing WooCommerce, missing IDs, and false returns.

<sup>Written for commit da53443c26de9ece38425c29feafa1bcb5e73fa3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

