### PR TITLE
feat(infra): add product-page coverage to post-deploy verification gate

### DIFF
--- a/scripts/deploy-theme.sh
+++ b/scripts/deploy-theme.sh
@@ -68,6 +68,8 @@ usage() {
     echo "  ENV_FILE             Path to .env.wordpress (default: \$PROJECT_ROOT/.env.wordpress)"
     echo "  THEME_DIR_OVERRIDE   Override theme source directory"
     echo "  PUBLIC_URL           Verified URL for post-deploy check (default: https://skyyrose.co/)"
+    echo "  RUN_FULL_VERIFY      'true' to run deep per-page verification after homepage check"
+    echo "                       (default: false; set by npm run deploy)"
     echo ""
     echo "The script will:"
     echo "  1. Run preflight checks (credentials, tools, PHP syntax)"
@@ -613,12 +615,32 @@ verify_live() {
         return 1
     fi
 
-    # Deep per-page + content-marker verification lives in verify-deploy.sh
-    # (called by deploy-pipeline.sh). Keep this function's scope narrow:
-    # homepage-200 + no-PHP-errors is the last-ditch safety when someone
-    # runs deploy-theme.sh directly. For full post-deploy checks, run
-    # `bash scripts/verify-deploy.sh` or `bash scripts/deploy-pipeline.sh`.
-    log_success "Post-deploy verification passed (HTTP $http_code, $size bytes)"
+    log_success "Homepage verification passed (HTTP $http_code, $size bytes)"
+
+    # Deep per-page verification — opt-in via RUN_FULL_VERIFY=true. Calls
+    # verify-deploy.sh which curls a representative set of pages (homepage,
+    # REST, collections, immersive, pre-order, AND product pages) and greps
+    # for content markers. Catches regressions on surfaces the homepage
+    # check above doesn't touch — added 2026-05-05 after a /product/{sku}/
+    # regression slipped past homepage-only verification.
+    #
+    # The npm `deploy` script enables this by default. Disable for one
+    # invocation with: RUN_FULL_VERIFY=false bash scripts/deploy-theme.sh
+    if [[ "${RUN_FULL_VERIFY:-false}" == "true" ]]; then
+        local verify_script
+        verify_script="$(dirname "${BASH_SOURCE[0]}")/verify-deploy.sh"
+        if [[ -x "$verify_script" ]]; then
+            log_info "Running deep verification (verify-deploy.sh)..."
+            if ! WORDPRESS_URL="${public_url%/}" bash "$verify_script"; then
+                log_error "Deep verification FAILED — see output above"
+                return 1
+            fi
+        else
+            log_warn "RUN_FULL_VERIFY=true but verify-deploy.sh not found at: $verify_script"
+        fi
+    fi
+
+    log_success "Post-deploy verification passed"
     return 0
 }
 

--- a/scripts/verify-deploy.sh
+++ b/scripts/verify-deploy.sh
@@ -82,6 +82,12 @@ HEALTH_CHECKS=(
     "Immersive: Signature|/experience-signature/|immersive-signature"
     "Pre-Order Gateway|/pre-order/|pre-order"
     "Experiences Hub|/experience/|Immersive Experiences"
+    # Product pages — added 2026-05-05 after a hotfix regression slipped
+    # past verification because /product/ surface was uncovered. Marker is
+    # "add-to-cart" (WC form) — only present after wp_head() and full body
+    # render, so a fatal anywhere in the product render path fails the check.
+    "Product: BLACK Rose Crewneck|/product/br-001/|add-to-cart"
+    "Product: Kids Red Set|/product/kids-001/|add-to-cart"
 )
 
 # ---------------------------------------------------------------------------

--- a/wordpress-theme/package.json
+++ b/wordpress-theme/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "SkyyRose Flagship WordPress theme — local dev tooling",
   "scripts": {
-    "deploy": "bash ../scripts/deploy-theme.sh",
+    "deploy": "RUN_FULL_VERIFY=true bash ../scripts/deploy-theme.sh",
     "deploy:dry": "bash ../scripts/deploy-theme.sh --dry-run",
     "lint:php": "find skyyrose-flagship -name '*.php' -exec php -l {} \\;",
     "lint:css": "npx stylelint 'skyyrose-flagship/assets/css/**/*.css'",


### PR DESCRIPTION
## Summary

Closes the verification blind spot exposed by bug-097 (2026-05-05). The post-deploy gate previously only checked the homepage — a `wp_head`-time fatal on product pages would pass the gate and go undetected until customer-facing traffic hit it.

## Changes

Three coordinated changes — no theme files touched:

1. **`scripts/verify-deploy.sh`** — Adds two `/product/{sku}/` entries to `HEALTH_CHECKS` (br-001 + kids-001). Uses `add-to-cart` as the content marker (only present after full body render; fails on any `wp_head`-time fatal).

2. **`scripts/deploy-theme.sh`** — `verify_live()` now optionally invokes `verify-deploy.sh` after the homepage check passes, gated on `RUN_FULL_VERIFY=true`. Deep verification failure exits the deploy non-zero.

3. **`wordpress-theme/package.json`** — Sets `RUN_FULL_VERIFY=true` on the `deploy` script so every `npm run deploy` automatically runs the deep verifier.

## Validation

- `bash -n` clean on both scripts
- `jq` valid on `package.json`
- 13/13 health checks pass against live production (was 11 — now includes the two new product entries)
- Adds ~13s to deploy latency

## Test plan

- [ ] Run `npm run deploy` (dry-run) and confirm `verify-deploy.sh` is invoked after homepage check
- [ ] Confirm a simulated product-page failure causes `deploy-theme.sh` to exit non-zero
- [ ] Confirm `RUN_FULL_VERIFY=false npm run deploy` skips deep verifier (opt-out path)
- [ ] Confirm 13/13 checks pass on a clean production state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add product-page coverage to the post-deploy verification and wire deep checks into the deploy script. This closes the homepage-only blind spot and blocks deploys when product pages break.

- New Features
  - `scripts/verify-deploy.sh`: add two `/product/{sku}/` health checks (`br-001`, `kids-001`) using the "add-to-cart" marker to confirm full render.
  - `scripts/deploy-theme.sh`: after homepage passes, run deep verifier when `RUN_FULL_VERIFY=true`; fail deploy on deep-check failures.
  - `wordpress-theme/package.json`: set `RUN_FULL_VERIFY=true` for `npm run deploy` by default; opt out per run with `RUN_FULL_VERIFY=false`.

<sup>Written for commit a75b55304f019e1fcb449208befc66fe446def69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

