### PR TITLE
feat(deploy): structural deploy verification + silent-fail fix

### DIFF
--- a/agents/base_super_agent/learning_module.py
+++ b/agents/base_super_agent/learning_module.py
@@ -298,30 +298,44 @@ class SelfLearningModule:
         """
         Flush RAG ingestion queue to vector store.
 
+        WARNING (P1 #9): this method does NOT write to a vector store. Items
+        are merely copied into an in-memory dict (`self._knowledge_base`) and
+        lost on process restart. The method name promises persistence the
+        implementation does not deliver. Callers depending on durable RAG
+        retrieval will silently see empty results after restart.
+
+        TODO: wire to Pinecone (`skyyrose-catalog` index, us-west-2, 1024-dim,
+        cosine similarity) OR remove this method and update callers. Until then
+        the warning below fires once per process to make the lie auditable.
+
         Returns:
-            Number of items processed
+            Number of items processed (into the in-memory dict, NOT a vector store)
         """
         if not hasattr(self, "_rag_ingestion_queue"):
             return 0
+
+        if not getattr(self.__class__, "_flush_rag_queue_stub_warned", False):
+            logger.warning(
+                "flush_rag_queue is a stub: items are stored in an in-memory dict, "
+                "NOT a vector store. Lost on restart. Wire to Pinecone before relying "
+                "on RAG retrieval persistence. (P1 #9)"
+            )
+            self.__class__._flush_rag_queue_stub_warned = True
 
         queue = self._rag_ingestion_queue
         self._rag_ingestion_queue = []
 
         processed = 0
         try:
-            # Check if RAG components are available
-            from importlib.util import find_spec
-
-            if find_spec("orchestration.document_ingestion") is not None:
-                # RAG pipeline available - could integrate here
-                pass
-
-            # For now, store in knowledge base for retrieval
+            # In-memory only — see WARNING above
             for item in queue:
                 self._knowledge_base[f"rag:{item['key']}"] = item
                 processed += 1
 
-            logger.info(f"Processed {processed} items from RAG ingestion queue")
+            logger.info(
+                f"Processed {processed} items into in-memory knowledge_base "
+                f"(NOT vector store — see WARNING)"
+            )
 
         except ImportError:
             logger.warning("RAG components not available for queue flush")

--- a/agents/base_super_agent/ml_module.py
+++ b/agents/base_super_agent/ml_module.py
@@ -61,21 +61,18 @@ class SklearnModelWrapper:
             X_arr = X_arr.reshape(1, -1)
 
         if not self.fitted:
-            # Auto-fit with synthetic data for demo purposes
-            logger.warning(f"Model not fitted, using synthetic training for {self.task}")
-            n_features = X_arr.shape[1]
-            synthetic_X = np.random.randn(100, n_features)
-            if self.task in ("clustering", "anomaly"):
-                self.model.fit(synthetic_X)
-            else:
-                synthetic_y = (
-                    np.random.randn(100)
-                    if self.task == "regression"
-                    else np.random.randint(0, 2, 100)
-                )
-                self.model.fit(synthetic_X, synthetic_y)
-            self.fitted = True
-            self._last_confidence = 0.6  # Lower confidence for auto-fitted
+            # P1 #10: previously auto-fit with np.random.randn(100, n_features)
+            # synthetic data and returned predictions with confidence=0.6.
+            # This silently produced random output that flowed into production
+            # scoring paths. Fail fast instead — callers must explicitly fit
+            # before predict, or fall back to a non-ML heuristic.
+            raise RuntimeError(
+                f"SklearnModelWrapper({self.task}) is not fitted. "
+                f"Refusing to auto-fit on np.random synthetic data — that path "
+                f"silently produced random predictions with confidence=0.6. "
+                f"Call .fit(X, y) with real training data before .predict(), "
+                f"or branch on .fitted in the caller."
+            )
 
         result = self.model.predict(X_arr)
 
@@ -130,16 +127,15 @@ class ProphetModelWrapper:
         import pandas as pd
 
         if not self.fitted:
-            # Create synthetic historical data for demo
-            logger.warning("Prophet not fitted, using synthetic data")
-            dates = pd.date_range(start="2024-01-01", periods=365, freq="D")
-            import numpy as np
-
-            values = 100 + np.cumsum(np.random.randn(365) * 2)
-            df = pd.DataFrame({"ds": dates, "y": values})
-            self.model.fit(df)
-            self.fitted = True
-            self._last_confidence = 0.6
+            # P1 #10: previously synthesized 365 days of cumulative random-walk
+            # data and fit Prophet on it, then returned a forecast with
+            # confidence=0.6. The forecast was random noise, not a signal.
+            raise RuntimeError(
+                "ProphetModelWrapper is not fitted. Refusing to auto-fit on "
+                "synthetic random-walk data — that path silently produced random "
+                "forecasts with confidence=0.6. Call .fit(df) with real time-series "
+                "data (DataFrame with 'ds' and 'y' columns) before .predict()."
+            )
 
         freq = kwargs.get("freq", "D")
         future = self.model.make_future_dataframe(periods=periods, freq=freq)

--- a/orchestration/threed_round_table.py
+++ b/orchestration/threed_round_table.py
@@ -1310,8 +1310,14 @@ class ThreeDRoundTable:
         scores.web_readiness = min(web_ready, 100)
 
         # Enhancement bonus
+        # P1 #8: previously +5.0 when response.enhanced was True. But .enhanced
+        # is set by _enhance_quality(), which is a stub that records metadata
+        # flags only — no actual mesh/texture processing happens. Awarding +5
+        # for fake enhancement made tournament rankings systematically optimistic
+        # for any provider whose response went through the stub. Zeroed until
+        # real trimesh/pymeshlab integration lands. Re-enable then.
         if response.enhanced:
-            scores.enhancement_bonus = 5.0
+            scores.enhancement_bonus = 0.0
 
         # CLIP text-to-image alignment (Stage 9 wiring) — opt-in: requires a
         # text prompt and a preview image URL/path on the response. Failure

--- a/scripts/deploy-theme.sh
+++ b/scripts/deploy-theme.sh
@@ -619,7 +619,81 @@ verify_live() {
     # runs deploy-theme.sh directly. For full post-deploy checks, run
     # `bash scripts/verify-deploy.sh` or `bash scripts/deploy-pipeline.sh`.
     log_success "Post-deploy verification passed (HTTP $http_code, $size bytes)"
+
+    # Structural DOM verification (Scrapling) — runs AFTER the curl gate.
+    # Asserts template-specific markers like <main class="homepage-v2">,
+    # <nav id="mainNav">, <section id="hero">, <div id="loader">, plus a
+    # universal [data-skyyrose-error] count-must-be-0 beacon. Catches
+    # regressions where WP returns 200 but front-page.php fell back or
+    # stripped a critical section.
+    #
+    # Default: WARN-ONLY (logs failures, does NOT block deploy).
+    # Set STRUCTURE_CHECK_STRICT=1 to promote structural failures into
+    # full deploy failures (triggers auto-rollback via cleanup trap).
+    structural_verify_live "$public_url"
     return 0
+}
+
+# ---------------------------------------------------------------------------
+# Structural verification gate (Scrapling-backed)
+#
+# Exit-code contract from scripts/verify_live_structure.py:
+#   0 - all structural assertions passed
+#   2 - one or more assertions failed (real regression)
+#   3 - environment problem (scrapling missing, network unreachable)
+#       NEVER blocks deploy; logged as warning only.
+#
+# Returns 0 always in warn-only mode (default). Returns 1 only when
+# STRUCTURE_CHECK_STRICT=1 AND the script exits 2 (real failure).
+# ---------------------------------------------------------------------------
+structural_verify_live() {
+    local public_url="$1"
+    local script_path="$SCRIPT_DIR/verify_live_structure.py"
+    local strict="${STRUCTURE_CHECK_STRICT:-0}"
+
+    if [[ ! -f "$script_path" ]]; then
+        log_warn "Structural check skipped: $script_path not found"
+        return 0
+    fi
+
+    # Prefer the project venv's Python (where scrapling is installed).
+    # Fall back to system python3 only if scrapling happens to be there.
+    local py_bin=""
+    if [[ -x "$PROJECT_ROOT/.venv/bin/python3" ]]; then
+        py_bin="$PROJECT_ROOT/.venv/bin/python3"
+    elif command -v python3 >/dev/null 2>&1; then
+        py_bin="$(command -v python3)"
+    else
+        log_warn "Structural check skipped: no python3 found"
+        return 0
+    fi
+
+    log_info "Running structural verification (Scrapling) against $public_url ..."
+    local rc=0
+    "$py_bin" "$script_path" --url "$public_url" --timeout 25 || rc=$?
+
+    case "$rc" in
+        0)
+            log_success "Structural verification passed (Scrapling)"
+            return 0
+            ;;
+        3)
+            log_warn "Structural check skipped: environment unavailable (exit 3)"
+            return 0
+            ;;
+        2)
+            if [[ "$strict" == "1" ]]; then
+                log_error "Structural verification FAILED (strict mode) — triggering rollback"
+                return 1
+            fi
+            log_warn "Structural verification reported failures (warn-only mode — set STRUCTURE_CHECK_STRICT=1 to enforce)"
+            return 0
+            ;;
+        *)
+            log_warn "Structural check exited unexpectedly (rc=$rc) — treating as warning"
+            return 0
+            ;;
+    esac
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/verify_live_structure.py
+++ b/scripts/verify_live_structure.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Structural deploy verification for skyyrose.co.
+
+Called by scripts/deploy-theme.sh::verify_live() AFTER the curl-based
+HTTP / size / PHP-error checks pass. Uses Scrapling to fetch live pages
+and assert that template-specific DOM markers exist - catches regressions
+where WordPress returns HTTP 200 but a template fell back to a default
+page or stripped a critical section.
+
+Usage:
+  python3 verify_live_structure.py                    # homepage only (default)
+  python3 verify_live_structure.py --page black-rose  # one named page
+  python3 verify_live_structure.py --all              # every registered page
+  python3 verify_live_structure.py --list             # print registry, no fetch
+  python3 verify_live_structure.py --url https://staging.skyyrose.co --all
+
+Exit codes:
+  0 - all assertions passed for every page checked
+  2 - one or more assertions failed (real regression) OR usage error
+  3 - environment problem (scrapling missing, total network failure)
+      Bash deploy script logs as warning; does NOT trigger rollback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass, field
+from urllib.parse import urljoin
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASE_URL = "https://skyyrose.co"
+DEFAULT_TIMEOUT = 25
+
+# Cache-bust query param appended to every fetched URL unless --no-cache-bust.
+# Bypasses Jetpack Boost page cache so we observe a fresh render.
+CACHE_BUST_PARAM = "deploy_verify"
+
+# Number of fetch attempts per page (initial + retries). Set to 1 to disable
+# retries. Connection-level errors trigger backoff; HTTP errors do not retry
+# (a 500 won't fix itself in 1.5s, but a TLS handshake hiccup might).
+FETCH_RETRY_ATTEMPTS = 2
+FETCH_RETRY_BACKOFF_SECONDS = 1.5
+
+# Theme slug — extracted because it appears in both the CSS-link selector
+# and the human-readable label, so any rename happens in one place.
+THEME_SLUG = "skyyrose-flagship"
+
+# Per-collection holo-card minimums derived from the canonical CSV at
+# wordpress-theme/skyyrose-flagship/data/skyyrose-catalog.csv.
+# Floors are set ~20% below actual counts so adding/removing one SKU
+# does not auto-fail the gate; the regression mode we are catching is
+# "page rendered ZERO or ONE card", not "catalog drifted by 1".
+COLLECTION_CARD_FLOORS = {
+    "black-rose": 12,  # 15 actual
+    "love-hurts": 3,  # 4 actual
+    "signature": 10,  # 12 actual
+    "kids-capsule": 2,  # 2 actual (cannot go lower without breaking)
+}
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+class FetchError(Exception):
+    """Transport-layer fetch failure (connection, TLS, timeout)."""
+
+
+@dataclass(frozen=True)
+class Assertion:
+    selector: str
+    min_count: int
+    label: str
+    # When set, count must satisfy min_count <= actual <= max_count.
+    # Used by GLOBAL_ASSERTIONS to assert error markers stay at 0.
+    max_count: int | None = None
+
+    def bounds_str(self) -> str:
+        if self.max_count is not None and self.max_count == self.min_count:
+            return f"exactly={self.min_count}"
+        if self.max_count is not None:
+            return f"min={self.min_count}, max={self.max_count}"
+        return f"min={self.min_count}"
+
+
+@dataclass(frozen=True)
+class Page:
+    name: str
+    path: str
+    assertions: tuple[Assertion, ...]
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    assertion: Assertion
+    actual: int
+
+    @property
+    def passed(self) -> bool:
+        if self.actual < self.assertion.min_count:
+            return False
+        return self.assertion.max_count is None or self.actual <= self.assertion.max_count
+
+
+@dataclass
+class PageReport:
+    page: Page
+    url: str
+    http_status: int
+    fetched: bool
+    fetch_error: str | None = None
+    results: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return self.fetched and self.http_status == 200 and all(r.passed for r in self.results)
+
+
+# ---------------------------------------------------------------------------
+# Reusable assertion builders
+# ---------------------------------------------------------------------------
+
+
+# Single instance reused across every page in the registry. Renaming the
+# theme means changing THEME_SLUG above, not editing 8+ scattered strings.
+THEME_CSS_ASSERTION = Assertion(
+    f"link[href*='{THEME_SLUG}']",
+    1,
+    f"theme CSS enqueued ({THEME_SLUG} active)",
+)
+
+
+# Universal assertions applied to every page. Catch render regressions
+# without per-page setup. data-skyyrose-error is a project-wide beacon
+# emitted by template parts that hit a "should not happen" branch (e.g.,
+# template-parts/collection/page.php when content config is missing).
+GLOBAL_ASSERTIONS: tuple[Assertion, ...] = (
+    Assertion(
+        "[data-skyyrose-error]",
+        0,
+        "no skyyrose render-error markers (universal regression beacon)",
+        max_count=0,
+    ),
+)
+
+
+def _main_assertion(class_name: str, what_ran: str) -> Assertion:
+    """Build a `<main class="X">` assertion with a consistent label format."""
+    return Assertion(
+        f"main#primary.{class_name}",
+        1,
+        f"<main class='{class_name}'> ({what_ran})",
+    )
+
+
+def collection_assertions(slug: str) -> tuple[Assertion, ...]:
+    """Build assertion tuple for a collection page (BR/LH/SIG/Kids)."""
+    floor = COLLECTION_CARD_FLOORS[slug]
+    return (
+        Assertion(
+            f"div.col-page[data-collection='{slug}']",
+            1,
+            f"<div class='col-page' data-collection='{slug}'>",
+        ),
+        Assertion("section.col-hero", 1, "<section class='col-hero'> (collection hero)"),
+        Assertion(
+            "div.holo",
+            floor,
+            f">= {floor} <.holo> product cards (universal grid rendered)",
+        ),
+        Assertion(
+            f"div.holo--{slug}",
+            floor,
+            f">= {floor} <.holo--{slug}> cards (collection-specific rendered)",
+        ),
+        THEME_CSS_ASSERTION,
+    )
+
+
+def immersive_assertions(name: str) -> tuple[Assertion, ...]:
+    """Build assertion tuple for the 3 immersive 3D pages.
+
+    `name` is the human-readable collection name (e.g., "Black Rose")
+    used only in the label, not in any selector. All 3 immersive pages
+    share the same template-emitted markup.
+    """
+    return (
+        _main_assertion("immersive-page", f"immersive template ran for {name}"),
+        THEME_CSS_ASSERTION,
+    )
+
+
+HOMEPAGE_ASSERTIONS: tuple[Assertion, ...] = (
+    Assertion("body.home", 1, "<body class='home'> (WP routed to front page)"),
+    _main_assertion("homepage-v2", "front-page.php template ran"),
+    Assertion("nav#mainNav", 1, "<nav id='mainNav'> (header.php rendered)"),
+    Assertion("section#hero", 1, "<section id='hero'> (hero section emitted)"),
+    Assertion("div#loader", 1, "<div id='loader'> (front-page.php loader element)"),
+    THEME_CSS_ASSERTION,
+    Assertion("meta[name='generator']", 1, "<meta name='generator'> (WordPress emitted)"),
+)
+
+
+ABOUT_ASSERTIONS: tuple[Assertion, ...] = (
+    _main_assertion("abt-page", "about template ran"),
+    Assertion("section.abt-hero", 1, "<section class='abt-hero'> (about hero section)"),
+    THEME_CSS_ASSERTION,
+)
+
+
+PREORDER_ASSERTIONS: tuple[Assertion, ...] = (
+    _main_assertion("preorder-gateway", "preorder template ran"),
+    Assertion("section#hero", 1, "<section id='hero'>"),
+    Assertion("section#showcase", 1, "<section id='showcase'> (preorder showcase)"),
+    THEME_CSS_ASSERTION,
+)
+
+
+# ---------------------------------------------------------------------------
+# Page registry
+# ---------------------------------------------------------------------------
+
+PAGE_REGISTRY: dict[str, Page] = {
+    "home": Page("Homepage", "/", HOMEPAGE_ASSERTIONS),
+    "black-rose": Page(
+        "Collection: Black Rose",
+        "/collection-black-rose/",
+        collection_assertions("black-rose"),
+    ),
+    "love-hurts": Page(
+        "Collection: Love Hurts",
+        "/collection-love-hurts/",
+        collection_assertions("love-hurts"),
+    ),
+    "signature": Page(
+        "Collection: Signature",
+        "/collection-signature/",
+        collection_assertions("signature"),
+    ),
+    "kids-capsule": Page(
+        "Collection: Kids Capsule",
+        "/collection-kids-capsule/",
+        collection_assertions("kids-capsule"),
+    ),
+    "about": Page("About", "/about/", ABOUT_ASSERTIONS),
+    "preorder": Page("Pre-Order Gateway", "/pre-order/", PREORDER_ASSERTIONS),
+    "experience-black-rose": Page(
+        "Immersive: Black Rose",
+        "/experience-black-rose/",
+        immersive_assertions("Black Rose"),
+    ),
+    "experience-love-hurts": Page(
+        "Immersive: Love Hurts",
+        "/experience-love-hurts/",
+        immersive_assertions("Love Hurts"),
+    ),
+    "experience-signature": Page(
+        "Immersive: Signature",
+        "/experience-signature/",
+        immersive_assertions("Signature"),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Fetch + evaluate
+# ---------------------------------------------------------------------------
+
+
+def _import_fetcher():
+    """Import-late so missing scrapling triggers exit 3, not crash on argparse."""
+    try:
+        from scrapling.fetchers import Fetcher  # noqa: PLC0415
+    except ImportError as exc:
+        print(f"[SKIP] Scrapling not available: {exc}", file=sys.stderr)
+        print(
+            "[SKIP] Install via: source .venv/bin/activate && pip install 'scrapling[all]'",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+    return Fetcher
+
+
+def _fetch_once(fetcher, url: str, timeout: int):
+    """Single fetch attempt — wraps any exception into a FetchError."""
+    try:
+        return fetcher.get(url, timeout=timeout)
+    except (OSError, TimeoutError) as exc:
+        raise FetchError(f"{type(exc).__name__}: {exc}") from exc
+    except Exception as exc:  # noqa: BLE001 — last-resort wrapper for SDK errors
+        raise FetchError(f"{type(exc).__name__}: {exc}") from exc
+
+
+def fetch_page(fetcher, url: str, timeout: int) -> tuple[object | None, str | None]:
+    """Fetch with one retry on transport errors. Returns (response, error_str)."""
+    last_error: str | None = None
+    for attempt in range(FETCH_RETRY_ATTEMPTS):
+        try:
+            return _fetch_once(fetcher, url, timeout), None
+        except FetchError as exc:
+            last_error = str(exc)
+            is_last = attempt + 1 >= FETCH_RETRY_ATTEMPTS
+            if not is_last:
+                time.sleep(FETCH_RETRY_BACKOFF_SECONDS * (attempt + 1))
+    return None, last_error
+
+
+def evaluate_assertions(response, assertions: tuple[Assertion, ...]) -> list[CheckResult]:
+    """Run every selector against `response` and produce CheckResult per assertion.
+
+    A selector that raises is treated as `count=0` plus a stderr warning —
+    the assertion fails (since min_count >= 1 in nearly all cases) but the
+    rest of the page's checks still run, so the operator gets a complete
+    picture in one pass.
+    """
+    results: list[CheckResult] = []
+    for assertion in assertions:
+        try:
+            matches = response.css(assertion.selector)
+            count = len(matches) if matches is not None else 0
+        except (AttributeError, TypeError, ValueError, RuntimeError) as exc:
+            print(
+                f"  [WARN] Selector {assertion.selector!r} raised {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            count = 0
+        results.append(CheckResult(assertion, count))
+    return results
+
+
+def _build_url(base_url: str, path: str, cache_bust: bool) -> str:
+    url = urljoin(base_url, path)
+    if cache_bust:
+        sep = "&" if "?" in url else "?"
+        url = f"{url}{sep}{CACHE_BUST_PARAM}={int(time.time())}"
+    return url
+
+
+def check_page(fetcher, page: Page, base_url: str, timeout: int, cache_bust: bool) -> PageReport:
+    url = _build_url(base_url, page.path, cache_bust)
+
+    response, err = fetch_page(fetcher, url, timeout)
+    if response is None:
+        return PageReport(page=page, url=url, http_status=0, fetched=False, fetch_error=err)
+
+    # Defensive: a malformed response object without `status` shouldn't be
+    # silently treated as HTTP 0 — it's a transport-layer mismatch worth
+    # flagging as a fetch error so the operator knows the contract broke.
+    if not hasattr(response, "status"):
+        return PageReport(
+            page=page,
+            url=url,
+            http_status=0,
+            fetched=False,
+            fetch_error="response object missing 'status' attribute",
+        )
+
+    status = response.status
+    if status != 200:
+        return PageReport(page=page, url=url, http_status=status, fetched=True)
+
+    results = evaluate_assertions(response, GLOBAL_ASSERTIONS + page.assertions)
+    return PageReport(page=page, url=url, http_status=status, fetched=True, results=results)
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _format_check_line(result: CheckResult) -> str:
+    status = "PASS" if result.passed else "FAIL"
+    a = result.assertion
+    return (
+        f"  [{status}] {a.label}  "
+        f"(selector={a.selector!r}, found={result.actual}, {a.bounds_str()})"
+    )
+
+
+def print_page_report(report: PageReport) -> None:
+    print(f"=== {report.page.name}  ({report.url}) ===")
+    if not report.fetched:
+        print(f"  [FAIL] Fetch error: {report.fetch_error}")
+        return
+    if report.http_status != 200:
+        print(f"  [FAIL] HTTP {report.http_status} (expected 200)")
+        return
+    for r in report.results:
+        print(_format_check_line(r))
+
+
+def _summary_detail(report: PageReport) -> str:
+    if not report.fetched:
+        return "fetch error"
+    if report.http_status != 200:
+        return f"HTTP {report.http_status}"
+    passed_n = sum(1 for r in report.results if r.passed)
+    return f"{passed_n}/{len(report.results)} assertions"
+
+
+def print_summary(reports: list[PageReport]) -> None:
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    for r in reports:
+        status = "PASS" if r.passed else "FAIL"
+        print(f"  [{status}] {r.page.name:<30} {_summary_detail(r)}")
+    failed = [r for r in reports if not r.passed]
+    print(f"\nResult: {len(reports) - len(failed)}/{len(reports)} pages passed")
+    if failed:
+        print(f"Failed pages: {', '.join(r.page.name for r in failed)}")
+
+
+def list_registry() -> None:
+    print("Global assertions (run on every page):")
+    for a in GLOBAL_ASSERTIONS:
+        print(f"  - {a.label}  ({a.bounds_str()})")
+    print()
+    print(f"Registered pages ({len(PAGE_REGISTRY)}):\n")
+    for key, page in PAGE_REGISTRY.items():
+        print(f"  {key:<22} -> {page.path}")
+        print(f"  {'':<22}    {page.name}")
+        for a in page.assertions:
+            print(f"  {'':<22}    - {a.label}  ({a.bounds_str()})")
+        print()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _resolve_pages(args: argparse.Namespace) -> list[Page]:
+    """Translate --all / --page args into the actual page list to verify.
+
+    Raises SystemExit(2) with a useful message on unknown --page values
+    so the operator sees the available registry without re-running --list.
+    """
+    if args.all:
+        return list(PAGE_REGISTRY.values())
+    if args.page not in PAGE_REGISTRY:
+        known = ", ".join(sorted(PAGE_REGISTRY))
+        print(
+            f"Unknown page: {args.page!r}\nKnown pages: {known}\n"
+            f"Run with --list for full assertion details.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return [PAGE_REGISTRY[args.page]]
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--url", default=DEFAULT_BASE_URL, help=f"Base URL (default: {DEFAULT_BASE_URL})"
+    )
+    parser.add_argument(
+        "--page", default="home", help="Page name from registry (default: home). See --list."
+    )
+    parser.add_argument(
+        "--all", action="store_true", help="Verify every registered page (overrides --page)"
+    )
+    parser.add_argument("--list", action="store_true", help="Print page registry and exit")
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"Fetch timeout in seconds (default: {DEFAULT_TIMEOUT})",
+    )
+    parser.add_argument(
+        "--no-cache-bust",
+        action="store_true",
+        help=f"Skip ?{CACHE_BUST_PARAM}=<ts> query string",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _build_arg_parser().parse_args()
+
+    if args.list:
+        list_registry()
+        return 0
+
+    pages = _resolve_pages(args)
+    fetcher = _import_fetcher()
+    base_url = args.url.rstrip("/")
+
+    reports: list[PageReport] = []
+    for page in pages:
+        report = check_page(
+            fetcher, page, base_url, args.timeout, cache_bust=not args.no_cache_bust
+        )
+        print_page_report(report)
+        reports.append(report)
+        print()
+
+    print_summary(reports)
+
+    # Exit 3 if every page failed to fetch (env/network problem),
+    # otherwise exit 2 on any structural failure, else 0.
+    if not any(r.fetched for r in reports):
+        return 3
+    return 2 if any(not r.passed for r in reports) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/image_ingestion.py
+++ b/services/image_ingestion.py
@@ -540,30 +540,15 @@ class ImageIngestionService:
         Returns:
             Processing job ID
         """
-        job_id = str(uuid.uuid4())
-
-        # TODO: Integrate with actual ProcessingQueue
-        # await processing_queue.submit_job(
-        #     job_id=job_id,
-        #     asset_id=asset_id,
-        #     r2_key=r2_key,
-        #     source=source.value,
-        #     product_id=product_id,
-        #     woocommerce_product_id=woocommerce_product_id,
-        #     metadata=metadata,
-        #     callback_url=callback_url,
-        # )
-
-        logger.info(
-            f"Queued job {job_id} for processing",
-            extra={
-                "asset_id": asset_id,
-                "source": source.value,
-                "correlation_id": correlation_id,
-            },
+        # P1 #11: ProcessingQueue integration is not implemented. Returning a
+        # job_id without submission silently dropped every queued asset. Raise
+        # so callers either wire the queue or make an explicit fallback.
+        raise NotImplementedError(
+            "ProcessingQueue integration is not yet wired. _queue_for_processing "
+            "previously generated a uuid and logged it without submitting any work, "
+            "silently losing every ingested asset. Wire to the real processing queue "
+            "or remove this call from ingest_*() entry points before relying on it."
         )
-
-        return job_id
 
     async def ingest_batch(
         self,

--- a/services/ml/enhancement/background_removal.py
+++ b/services/ml/enhancement/background_removal.py
@@ -272,16 +272,25 @@ class BackgroundRemovalService:
                 cause=last_error,
             )
 
-        # For non-transparent backgrounds, we would composite here
-        # This is a simplified implementation - full version would use
-        # PIL/cv2 to composite the transparent result onto new background
+        # P1 #12: SOLID_COLOR and CUSTOM_IMAGE composite paths are not implemented.
+        # Code structure suggested they composite, but they only assigned the value
+        # and returned the transparent result with a misleading background_value.
+        # Callers must use BackgroundType.TRANSPARENT until PIL/cv2 compositing is wired.
         background_value: str | None = None
         if background_type == BackgroundType.SOLID_COLOR:
-            background_value = background_color or "#FFFFFF"
-            # TODO: Composite transparent result onto solid color
-        elif background_type == BackgroundType.CUSTOM_IMAGE:
-            background_value = background_image_url
-            # TODO: Composite transparent result onto custom image
+            raise NotImplementedError(
+                f"BackgroundType.SOLID_COLOR composite path is not implemented "
+                f"(requested color={background_color or '#FFFFFF'}). "
+                f"Use BackgroundType.TRANSPARENT and composite downstream, or wire "
+                f"PIL/cv2 compositing here."
+            )
+        if background_type == BackgroundType.CUSTOM_IMAGE:
+            raise NotImplementedError(
+                f"BackgroundType.CUSTOM_IMAGE composite path is not implemented "
+                f"(requested image={background_image_url}). "
+                f"Use BackgroundType.TRANSPARENT and composite downstream, or wire "
+                f"PIL/cv2 compositing here."
+            )
 
         processing_time_ms = int((time.time() - start_time) * 1000)
 

--- a/skyyrose/elite_studio/agents/color_correction_agent.py
+++ b/skyyrose/elite_studio/agents/color_correction_agent.py
@@ -41,11 +41,17 @@ class ColorCorrectionAgent(BaseSuperAgent):
         logger.info(f"Running Legendary Color Correction for {image_path} via ADK...")
         adk_result = await self.execute(adk_prompt)
 
+        # P1 #7: Pass-through stub. No actual color correction is performed.
+        # The "auto-levels" / "brand-white-balance" labels were misleading.
+        logger.warning(
+            "ColorCorrectionAgent.correct is a stub: returning input image unchanged. "
+            "Wire to a real color-correction backend before relying on output."
+        )
         metadata = adk_result.to_dict() if hasattr(adk_result, "to_dict") else {}
 
         return ColorCorrectionResult(
-            success=True,
+            success=False,
             output_path=image_path,
-            adjustments_applied=("auto-levels", "brand-white-balance"),
-            metadata=metadata,
+            adjustments_applied=(),
+            metadata={**metadata, "stub": True, "reason": "color_correction_not_implemented"},
         )

--- a/skyyrose/elite_studio/agents/tryon_agent.py
+++ b/skyyrose/elite_studio/agents/tryon_agent.py
@@ -50,14 +50,22 @@ class TryOnAgent(BaseSuperAgent):
 
         metadata = adk_result.to_dict() if hasattr(adk_result, "to_dict") else {}
 
+        # P1 #7: Pass-through stub. Real FASHN integration not wired yet.
+        # Returning success=False prevents downstream code from treating the
+        # input image as a transformed try-on result. Callers must check .success
+        # before consuming output_path.
+        logger.warning(
+            "TryOnAgent.execute_tryon is a stub: returning input image unchanged. "
+            "Wire to FASHN provider before relying on output."
+        )
         return TryOnResult(
-            success=True,
-            output_path=garment_image_path,  # Pass-through stub
+            success=False,
+            output_path=garment_image_path,
             garment_sku="unknown",
             model_image_path=model_image_path,
             provider="fashn",
             latency_s=0.5,
-            metadata=metadata,
+            metadata={**metadata, "stub": True, "reason": "tryon_not_implemented"},
         )
 
 

--- a/skyyrose/elite_studio/agents/variant_agent.py
+++ b/skyyrose/elite_studio/agents/variant_agent.py
@@ -46,12 +46,19 @@ class VariantAgent(BaseSuperAgent):
         logger.info(f"Running Legendary Variant Generation for {sku} via ADK...")
         adk_result = await self.execute(adk_prompt)
 
-        # Placeholder: Phase B2 logic (Claude Sonnet + GPT-4o best-of-N)
-        # Return base image as the only variant for now
+        # P1 #7: Pass-through stub. Phase B2 best-of-N logic not wired yet.
+        # success=False so callers don't consume base image as a "variant".
+        logger.warning(
+            "VariantAgent.generate_variants is a stub: returning base image as only variant. "
+            "Wire to Claude Sonnet + GPT-4o best-of-N before relying on output."
+        )
         metadata = adk_result.to_dict() if hasattr(adk_result, "to_dict") else {}
 
         return [
             VariantResult(
-                success=True, variant_name="default", output_path=base_image_path, metadata=metadata
+                success=False,
+                variant_name="default",
+                output_path=base_image_path,
+                metadata={**metadata, "stub": True, "reason": "variants_not_implemented"},
             )
         ]

--- a/wordpress-theme/skyyrose-flagship/template-parts/collection/page.php
+++ b/wordpress-theme/skyyrose-flagship/template-parts/collection/page.php
@@ -19,6 +19,21 @@ $slug = isset( $args['slug'] ) ? sanitize_key( $args['slug'] ) : '';
 $c    = skyyrose_get_collection_content( $slug );
 
 if ( ! $c ) {
+	// Hard-fail: log + emit hidden error marker. Silent return previously
+	// masked a missing kids-capsule config — caught only after a structural
+	// audit ran. data-skyyrose-error is a project-wide beacon picked up by
+	// scripts/verify_live_structure.py to fail deploys on render regressions.
+	error_log(
+		sprintf(
+			"[SkyyRose Collections] Missing content config for slug '%s' in %s. Check inc/collection-content.php.",
+			$slug,
+			__FILE__
+		)
+	);
+	printf(
+		'<div class="skyyrose-render-error" data-skyyrose-error="missing-collection-content" data-collection="%s" hidden></div>',
+		esc_attr( $slug )
+	);
 	return;
 }
 


### PR DESCRIPTION
## feat(deploy): structural deploy verification + collection-page silent-fail fix

Adds DOM-level structural assertions to the post-deploy verify gate so
HTTP-200-but-content-missing regressions get caught. The existing curl
gate (status + size + PHP error markers) cannot distinguish "page
rendered" from "page returned 200 with empty content area" — exactly
the failure mode that's currently live on /collection-kids-capsule/.

scripts/verify_live_structure.py (new):
  Multi-page Scrapling-backed audit, 49 assertions across 10 pages.
  - Homepage, 4 collections (BR/LH/SIG/Kids), about, preorder, 3
    immersive (BR/LH/SIG)
  - Universal [data-skyyrose-error] count-must-be-0 assertion runs
    on every page (project-wide regression beacon)
  - Per-collection holo-card minimums derived from the catalog CSV
    with ~20% headroom so single-SKU drift doesn't auto-fail
  - CLI: --page <name>, --all, --list, --url, --timeout
  - Exit codes: 0 = clean, 2 = real regression, 3 = env problem
  - One retry with 1.5s backoff on transport-layer fetch errors
  - Typed FetchError exception; tightened evaluate_assertions
    exception handling to specific types (no bare Exception)
  - Reusable assertion builders (THEME_CSS_ASSERTION,
    _main_assertion, collection_assertions, immersive_assertions)
    so theme-slug renames + page additions stay DRY

scripts/deploy-theme.sh (verify_live integration):
  - Calls structural_verify_live() AFTER the existing HTTP/size/PHP-
    error gate passes — additive, never replaces the curl checks
  - WARN-ONLY by default: failures log [WARN] but do not block deploy
  - STRUCTURE_CHECK_STRICT=1 promotes failures into rollback triggers
  - Resolves Python via $PROJECT_ROOT/.venv/bin/python3 with system
    python3 fallback; exit-3 from script ALWAYS treated as warning
    so a missing dev env never breaks production deploys

wordpress-theme/skyyrose-flagship/template-parts/collection/page.php:
  - Replaces silent `if (!$c) return;` antipattern with logged
    hard-fail emitting <div data-skyyrose-error="missing-collection-
    content" hidden> for the audit beacon to catch
  - error_log() with [SkyyRose Collections] prefix matches existing
    [SkyyRose Klaviyo] pattern in inc/klaviyo-integration.php
  - Hidden marker means customers see no broken UI; admins/audit
    see explicit failure attribution

Verified: ruff/black/phpcs/php-l/bash-n all clean. Audit caught the
existing kids-capsule production regression (4/6 assertions failing)
when run against live skyyrose.co — exact case this gate was built to
surface that the existing substring-grep verify-deploy.sh would have
falsely passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DOM-level post-deploy verification to catch “HTTP 200 but missing content” regressions and fixes the collection page’s silent-fail by emitting an explicit error beacon. Also replaces multiple silent-success stubs with fail-fast behavior to stop random or no-op outputs (P1 wave‑3).

- **New Features**
  - Added `scripts/verify_live_structure.py` using `scrapling` to assert key DOM markers across 10 pages, plus a universal `[data-skyyrose-error]=0` check.
  - Integrated into `scripts/deploy-theme.sh` after curl checks; warn-only by default, set `STRUCTURE_CHECK_STRICT=1` to enforce. Exit-3 (env) is treated as warning.

- **Bug Fixes**
  - Collection page now logs and emits a hidden `[data-skyyrose-error="missing-collection-content"]` marker instead of silently returning.
  - Silent stubs removed (P1): ML wrappers now error if unfitted (no synthetic auto-fit), try-on/variant/color-correction agents return `success=false` with stub metadata, background compositing paths raise until implemented (use TRANSPARENT), processing-queue stub raises, RAG flush warns it’s in-memory only, and fake enhancement bonus is set to 0.

<sup>Written for commit fbb26a439401441ec42d204aa4b131e79911ef81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Image ingestion now raises errors instead of silently dropping queued items.
  * ML predictions now require proper model training; synthetic data auto-fitting removed.
  * Background removal, color correction, try-on, and variant features now explicitly indicate unavailability.
  * WordPress templates now log errors for missing content configurations.

* **Chores**
  * Enhanced post-deployment verification with automated structural HTML checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->