### PR TITLE
fix(dashboard): wrap dynamic-data hooks in Suspense for Next 16 Cache Components

### DIFF
--- a/frontend/app/admin/elite-studio/layout.tsx
+++ b/frontend/app/admin/elite-studio/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
@@ -18,9 +19,38 @@ const ELITE_NAV = [
   { title: 'Design Co-Pilot', href: '/admin/elite-studio/design', icon: Pencil },
 ];
 
-export default function EliteStudioLayout({ children }: { children: React.ReactNode }) {
+function EliteStudioNav() {
   const pathname = usePathname();
 
+  return (
+    <nav className="flex gap-1" aria-label="Elite Studio navigation">
+      {ELITE_NAV.map((item) => {
+        const isActive = item.exact
+          ? pathname === item.href
+          : pathname.startsWith(item.href);
+        const Icon = item.icon;
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+              isActive
+                ? 'bg-[#B76E79]/15 text-[#B76E79]'
+                : 'text-gray-400 hover:bg-gray-800 hover:text-white'
+            )}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+            {item.title}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+export default function EliteStudioLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="space-y-6">
       {/* Section header with sub-navigation */}
@@ -35,30 +65,9 @@ export default function EliteStudioLayout({ children }: { children: React.ReactN
           </div>
         </div>
 
-        <nav className="flex gap-1" aria-label="Elite Studio navigation">
-          {ELITE_NAV.map((item) => {
-            const isActive = item.exact
-              ? pathname === item.href
-              : pathname.startsWith(item.href);
-            const Icon = item.icon;
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={cn(
-                  'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-                  isActive
-                    ? 'bg-[#B76E79]/15 text-[#B76E79]'
-                    : 'text-gray-400 hover:bg-gray-800 hover:text-white'
-                )}
-                aria-current={isActive ? 'page' : undefined}
-              >
-                <Icon className="h-3.5 w-3.5" aria-hidden="true" />
-                {item.title}
-              </Link>
-            );
-          })}
-        </nav>
+        <Suspense fallback={<div className="h-8" aria-hidden="true" />}>
+          <EliteStudioNav />
+        </Suspense>
       </div>
 
       {children}

--- a/frontend/app/admin/elite-studio/operations/[id]/page.tsx
+++ b/frontend/app/admin/elite-studio/operations/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { use } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
@@ -123,7 +123,25 @@ function ResultPanel({ intent, result }: { intent: string; result: Record<string
   );
 }
 
+function OperationDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-10 w-48 bg-gray-800" />
+      <Skeleton className="h-40 w-full bg-gray-800" />
+      <Skeleton className="h-64 w-full bg-gray-800" />
+    </div>
+  );
+}
+
 export default function OperationDetailPage({ params }: Props) {
+  return (
+    <Suspense fallback={<OperationDetailSkeleton />}>
+      <OperationDetailContent params={params} />
+    </Suspense>
+  );
+}
+
+function OperationDetailContent({ params }: Props) {
   const { id } = use(params);
   const [showRaw, setShowRaw] = useState(false);
 

--- a/frontend/app/admin/elite-studio/operations/page.tsx
+++ b/frontend/app/admin/elite-studio/operations/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { Suspense, useState, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
@@ -59,7 +59,33 @@ function formatAgo(dateStr: string): string {
   }
 }
 
+function OperationsListSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-white">Operations</h1>
+        <p className="text-gray-400 mt-1">All Elite Studio creative operations</p>
+      </div>
+      <Card className="bg-gray-900 border-gray-800">
+        <CardContent className="p-6 space-y-3">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full bg-gray-800" />
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 export default function OperationsListPage() {
+  return (
+    <Suspense fallback={<OperationsListSkeleton />}>
+      <OperationsListContent />
+    </Suspense>
+  );
+}
+
+function OperationsListContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
 

--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import { SessionProvider } from 'next-auth/react';
 import { SidebarProvider, SidebarInset, SidebarTrigger } from '@/components/ui/sidebar';
 import { AppSidebar } from '@/components/dashboard/app-sidebar';
@@ -13,7 +14,9 @@ export default function AdminLayout({
   return (
     <SessionProvider>
       <SidebarProvider>
-        <AppSidebar />
+        <Suspense fallback={null}>
+          <AppSidebar />
+        </Suspense>
         <SidebarInset className="bg-gray-950">
           <header className="flex h-14 shrink-0 items-center gap-2 border-b border-gray-800 bg-gray-900/50 backdrop-blur-sm">
             <div className="flex items-center gap-2 px-4">

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import { Inter } from 'next/font/google'
 import { playfair, cormorant, spaceMono } from '@/lib/fonts'
 import { SyncStatusToast } from '@/components/wordpress/sync-status-toast'
@@ -35,7 +36,9 @@ export default function RootLayout({
         <QueryProvider>
           {children}
         </QueryProvider>
-        <MascotBubble />
+        <Suspense fallback={null}>
+          <MascotBubble />
+        </Suspense>
         <SyncStatusToast />
         <Analytics />
         <SpeedInsights />

--- a/frontend/components/collections/CollectionTabBar.tsx
+++ b/frontend/components/collections/CollectionTabBar.tsx
@@ -1,11 +1,20 @@
 'use client';
 
+import { Suspense } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { getAllCollections, type CollectionSlug } from '@/lib/collections';
 
 export default function CollectionTabBar() {
+  return (
+    <Suspense fallback={null}>
+      <CollectionTabBarContent />
+    </Suspense>
+  );
+}
+
+function CollectionTabBarContent() {
   const pathname = usePathname();
   const collections = getAllCollections();
 


### PR DESCRIPTION
## Summary

The Vercel preview build for `dependabot/npm_and_yarn/skyyrose/path-to-regexp-8.4.2` failed with a Next.js 16 Cache Components error:

> Route \"/admin/elite-studio/operations/[id]\": Uncached data was accessed outside of \<Suspense\>. This delays the entire page from rendering, resulting in a slow user experience.

The error has nothing to do with `path-to-regexp` — it's pre-existing on `main`. With `cacheComponents: true` in `next.config.ts`, every request-time data reader (`usePathname`, `useSearchParams`, `use(params)`) must live inside a `<Suspense>` boundary so the static shell can prerender. Without it, the route falls back to dynamic rendering and the build flags it as `blocking-route`.

## Files changed (6)

| File | Hook flagged | Fix |
|---|---|---|
| `app/layout.tsx` | `MascotBubble` calls `usePathname` | Wrap in `<Suspense fallback={null}>` |
| `app/admin/layout.tsx` | `AppSidebar` calls `usePathname` | Wrap in `<Suspense fallback={null}>` |
| `app/admin/elite-studio/layout.tsx` | layout calls `usePathname` | Extract `EliteStudioNav` subcomponent, wrap in `<Suspense>` |
| `app/admin/elite-studio/operations/page.tsx` | `useSearchParams()` at top of page | Split into `OperationsListContent`, wrap default export in `<Suspense>` |
| `app/admin/elite-studio/operations/[id]/page.tsx` | `use(params)` at top of page | Split into `OperationDetailContent`, wrap default export in `<Suspense>` |
| `components/collections/CollectionTabBar.tsx` | inner `usePathname` | Internal Suspense wrap so both consumers benefit |

## Why this pattern

Next.js 16's **Cache Components** mode introduces a static-shell + dynamic-island architecture. Hooks that read request-time data (path, query string, dynamic params, cookies, headers) become explicit boundaries the build needs to discover. Wrapping them in `<Suspense>` tells Next \"prerender the fallback statically, stream the dynamic content at request time.\"

For decorative chrome (sidebar, mascot, tab bar), `fallback={null}` is fine — the same client component would have rendered nothing pre-hydration anyway. For data-heavy pages, the fallback is a skeleton matching the eventual content shape.

## Build evidence

Before:
> Error occurred prerendering page \"/admin/elite-studio/operations/[id]\". Export encountered an error... exiting the build.

After:
> ✓ Generating static pages using 7 workers (62/62) in 2.1s

The detail route correctly transitions to `◐ (Partial Prerender)` — static shell + streaming dynamic content, exactly the Cache Components contract.

## Test plan

- [x] `npm run build` succeeds locally on a fresh checkout off `main` + this patch (62/62 pages)
- [x] `npm run type-check` clean (no new errors)
- [x] `npm run lint` no new warnings introduced
- [ ] Vercel preview build green
- [ ] After merge, rebase `dependabot/npm_and_yarn/skyyrose/path-to-regexp-8.4.2` to pick up this fix
- [ ] Smoke-test in preview: open `/admin/elite-studio/operations`, click a row → detail page renders, no hydration warnings in console
- [ ] Smoke-test: `/collections/black-rose` tab bar still highlights active collection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrapped all request‑time hooks in `<Suspense>` to comply with Next.js 16 Cache Components, fixing the “Uncached data was accessed outside of <Suspense>” build error. Admin routes now prerender a static shell and stream dynamic content as intended.

- **Bug Fixes**
  - Wrapped `MascotBubble`, `AppSidebar`, Elite Studio nav, operations list/detail pages, and `CollectionTabBar` in `<Suspense>`.
  - Split operations pages into `OperationsListContent` and `OperationDetailContent` so `useSearchParams` and `use(params)` run inside `<Suspense>`.
  - Added small skeleton fallbacks for operations pages; used `fallback={null}` for chrome.
  - Result: static shells render, dynamic parts stream, and builds complete without blocking routes.

<sup>Written for commit 0516145c2c94bcb74ac43d88fde56e9344b3b22c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved loading states across admin pages with skeleton screens and progressive content rendering.
  * Enhanced initial page load experience with optimized component initialization and streamlined navigation rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->