### PR TITLE
fix(vercel): drop outputFileTracingRoot override on Vercel to unblock deploys

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,16 +1,22 @@
 import path from 'path'
 import type { NextConfig } from 'next'
 
+// On Vercel, rootDirectory=frontend so only this dir is uploaded; the
+// repo-root lockfile isn't in build scope and there's no ambiguous-root
+// warning to suppress. Setting outputFileTracingRoot above the project
+// root on Vercel causes a doubled-path bug in the post-build trace step
+// (looks for .next/routes-manifest.json at /vercel/path1/path1/.next/...
+// and crashes with ENOENT).
+//
+// Locally, both lockfiles are present, so we still set the override —
+// but only when not running on Vercel.
+const isVercel = !!process.env.VERCEL
+const tracingRoot = isVercel ? undefined : path.resolve(__dirname, '..')
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  // Workspace root for file tracing — must match turbopack.root below.
-  // The repo has lockfiles at both / and /frontend, so Next.js requires
-  // an explicit shared root to avoid divergent module resolution between
-  // Turbopack (dev) and the Webpack tracer (production builds).
-  outputFileTracingRoot: path.resolve(__dirname, '..'),
-  turbopack: {
-    root: path.resolve(__dirname, '..'),
-  },
+  ...(tracingRoot && { outputFileTracingRoot: tracingRoot }),
+  ...(tracingRoot && { turbopack: { root: tracingRoot } }),
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary

Every Vercel deploy in the last 20+ attempts has failed — including the merge commit for #493 and prior production merges (#492, #490). Production currently serves an older successful deployment because Vercel keeps the alias on the last green build, but new code can't ship.

PR #493 unblocked `next build` (Cache Components Suspense). With the build now succeeding, the next stage — Vercel's post-build file tracing — fails with:

> Error: ENOENT: no such file or directory, lstat `/vercel/path1/path1/.next/routes-manifest.json`

The doubled `path1/path1/` is the diagnostic: with `rootDirectory=frontend`, Vercel's project cwd is `/vercel/path1/`. `next.config.ts` sets `outputFileTracingRoot` to `path.resolve(__dirname, '..')` = `/vercel/` (one level above). Vercel's trace stage emits paths relative to the tracing root (`path1/.next/...`), then re-prepends the project cwd when resolving — `/vercel/path1/` + `path1/.next/...` = `/vercel/path1/path1/.next/...` → ENOENT.

## Why the override was there

The repo has lockfiles at both `/` (Python + monorepo tooling) and `/frontend` (the dashboard). Without an explicit workspace root, Next.js emits an ambiguous-root warning between Turbopack (dev) and the Webpack tracer (build). The previous owner wanted to silence it.

## Why we can drop it on Vercel

On Vercel, `rootDirectory=frontend` means only `frontend/` is uploaded. The root lockfile isn't in build scope, so there's no ambiguity to suppress. Locally, both lockfiles are visible, so the override stays — gated on `process.env.VERCEL`.

## Diff

```ts
// before
outputFileTracingRoot: path.resolve(__dirname, '..'),
turbopack: { root: path.resolve(__dirname, '..') },

// after
const isVercel = !!process.env.VERCEL
const tracingRoot = isVercel ? undefined : path.resolve(__dirname, '..')
const nextConfig: NextConfig = {
  reactStrictMode: true,
  ...(tracingRoot && { outputFileTracingRoot: tracingRoot }),
  ...(tracingRoot && { turbopack: { root: tracingRoot } }),
  // ...
}
```

## Verification

- `npm run build` (local, no VERCEL env): clean — 62/62 pages, override applied
- `VERCEL=1 npm run build` (local, simulating Vercel): clean — 62/62 pages, override skipped
- Real Vercel build: this PR is the test

## Test plan

- [ ] Vercel preview build succeeds (the actual fix verification)
- [ ] After merge, devskyy.app gets a new green production deploy
- [ ] Local `npm run dev` and `npm run build` still work without the VERCEL env var

## Severity

P1, not P0 — production at devskyy.app is up (HTTP 200, serving deployment `dpl_CFF3tqRqJurSETX6G2Ce6UMKDD3x`). The deploy pipeline is blocked, not the live site.

Stacked on #493 (already merged to main).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the `outputFileTracingRoot`/Turbopack root override on Vercel to fix the doubled-path `routes-manifest.json` ENOENT and unblock deploys. Keep the override locally to silence lockfile root ambiguity.

- **Bug Fixes**
  - Detect Vercel via `process.env.VERCEL`; when set, omit `outputFileTracingRoot` and `turbopack: { root }` in `next.config.ts`.
  - Prevents Vercel post-build tracing from resolving to `/vercel/path1/path1/.next/...` due to combining the project cwd (`rootDirectory=frontend`) with an above-root override.

<sup>Written for commit 6ebd6cf4d56af71d987c16b99e6827f9da1fb2b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js build configuration to optimize settings based on the deployment environment, adjusting file-tracing and build parameters for improved efficiency across different hosting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->