### PR TITLE
feat: end-to-end TRELLIS clothing 3D pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,8 +329,11 @@ open-claude-code/
 wordpress-theme/skyyrose-flagship/assets/images/immersive/test/
 scripts/nano-banana-composite-results.json
 
-# Vendored third-party repos (cloned via git, not authored here)
-vendor/
+# Vendored third-party repos (cloned via git, not authored here).
+# Track the scaffolding (README + .gitignore) so contributors can bootstrap.
+vendor/*
+!vendor/.gitignore
+!vendor/README.md
 
 # === Added by Claude optimization pass (20260424-190053) ===
 # These were missing from the original .gitignore.

--- a/api/v1/clothing_3d/__init__.py
+++ b/api/v1/clothing_3d/__init__.py
@@ -1,0 +1,13 @@
+"""FastAPI surface for the clothing 3D pipeline.
+
+Mount this router in ``main_enterprise.py``:
+
+.. code-block:: python
+
+    from api.v1.clothing_3d.router import router as clothing_3d_router
+    app.include_router(clothing_3d_router, prefix="/v1/clothing-3d")
+"""
+
+from api.v1.clothing_3d.router import router
+
+__all__ = ["router"]

--- a/api/v1/clothing_3d/router.py
+++ b/api/v1/clothing_3d/router.py
@@ -254,15 +254,23 @@ async def health_endpoint(
     pipeline: Annotated[ClothingPipeline, Depends(get_pipeline)],
 ) -> HealthResponse:
     health = await pipeline.provider.health_check()
+    # Report the live backend (which respects test-injection), with the
+    # configured backend as a secondary signal.
+    live_backend = getattr(
+        pipeline.provider._backend,  # type: ignore[attr-defined]
+        "backend_name",
+        pipeline.provider.config.backend.value,
+    )
     return HealthResponse(
         ok=health.is_available,
         provider=health.provider,
         status=health.status.value,
         capabilities=[c.value for c in health.capabilities],
-        backend=pipeline.provider.config.backend.value,
+        backend=live_backend,
         latency_ms=health.latency_ms,
         error=health.error_message,
         detail={
+            "configured_backend": pipeline.provider.config.backend.value,
             "quality_preset": pipeline.provider.config.quality.value,
             "output_dir": pipeline.provider.config.output_dir,
         },

--- a/api/v1/clothing_3d/router.py
+++ b/api/v1/clothing_3d/router.py
@@ -1,0 +1,252 @@
+"""FastAPI router for the clothing 3D pipeline.
+
+Endpoints:
+
+- ``POST /generate`` — synchronous run. Returns the full :class:`PipelineResult`.
+- ``POST /generate/async`` — fire-and-forget; returns a job ID for polling.
+- ``GET  /jobs/{job_id}`` — fetch a previously submitted async job.
+- ``GET  /health`` — provider/backend health.
+
+The async path uses an in-process job store; for multi-worker deployments,
+swap in the existing :mod:`services.ml.processing_queue` or Celery worker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+
+from api.v1.clothing_3d.schemas import (
+    GenerateRequest,
+    GenerateResponse,
+    HealthResponse,
+    JobAcceptedResponse,
+    JobStatusResponse,
+)
+from pipelines.clothing_3d.models import PipelineResult, PipelineStatus
+from pipelines.clothing_3d.pipeline import ClothingPipeline
+from services.three_d.trellis.config import TrellisConfig
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Clothing 3D Pipeline"])
+
+
+# =============================================================================
+# Singletons (one pipeline per process)
+# =============================================================================
+
+
+_pipeline: ClothingPipeline | None = None
+
+
+def get_pipeline() -> ClothingPipeline:
+    global _pipeline
+    if _pipeline is None:
+        _pipeline = ClothingPipeline(config=TrellisConfig.from_env())
+    return _pipeline
+
+
+# =============================================================================
+# In-process job store
+# =============================================================================
+
+
+@dataclass(slots=True)
+class _Job:
+    job_id: str
+    status: str = "queued"
+    result: PipelineResult | None = None
+    error: str | None = None
+    submitted_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    finished_at: datetime | None = None
+
+
+_jobs: dict[str, _Job] = {}
+_jobs_lock = asyncio.Lock()
+
+# Cap at 256 entries to avoid unbounded growth — older jobs evicted FIFO.
+_JOB_LIMIT = 256
+
+
+async def _put_job(job: _Job) -> None:
+    async with _jobs_lock:
+        if len(_jobs) >= _JOB_LIMIT:
+            oldest = min(_jobs, key=lambda k: _jobs[k].submitted_at)
+            _jobs.pop(oldest, None)
+        _jobs[job.job_id] = job
+
+
+async def _get_job(job_id: str) -> _Job | None:
+    async with _jobs_lock:
+        return _jobs.get(job_id)
+
+
+# =============================================================================
+# Endpoints
+# =============================================================================
+
+
+@router.post(
+    "/generate",
+    response_model=GenerateResponse,
+    summary="Generate a 3D garment model (synchronous)",
+)
+async def generate_endpoint(
+    body: GenerateRequest,
+    pipeline: ClothingPipeline = Depends(get_pipeline),
+) -> GenerateResponse:
+    """Run the full clothing 3D pipeline and return the result.
+
+    Use this for one-off calls. For batch workloads or long-running runs
+    (PRODUCTION quality preset, 60+ second backend latency), prefer
+    :func:`generate_async_endpoint`.
+    """
+    try:
+        result = await pipeline.run(body)
+    except Exception as exc:  # noqa: BLE001 — convert to HTTP error
+        logger.exception("clothing-3d generate failed")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Pipeline error: {exc}",
+        ) from exc
+
+    if result.status == PipelineStatus.FAILED:
+        # Body still returned so the caller sees per-stage detail.
+        return GenerateResponse(ok=False, result=result)
+    return GenerateResponse(ok=result.succeeded, result=result)
+
+
+@router.post(
+    "/generate/async",
+    response_model=JobAcceptedResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Submit a clothing 3D job for background processing",
+)
+async def generate_async_endpoint(
+    body: GenerateRequest,
+    request: Request,
+    background: BackgroundTasks,
+    pipeline: ClothingPipeline = Depends(get_pipeline),
+) -> JobAcceptedResponse:
+    """Submit a job and immediately return a polling URL."""
+    job_id = f"job_{uuid.uuid4().hex[:16]}"
+    body.correlation_id = body.correlation_id or job_id
+
+    job = _Job(job_id=job_id, status="queued")
+    await _put_job(job)
+
+    background.add_task(_run_async_job, job_id, body, pipeline)
+
+    base_url = str(request.url).rstrip("/")
+    # /generate/async → /jobs/{job_id}
+    base = base_url.rsplit("/generate/async", 1)[0]
+    return JobAcceptedResponse(
+        job_id=job_id,
+        correlation_id=body.correlation_id,
+        status_url=f"{base}/jobs/{job_id}",
+    )
+
+
+async def _run_async_job(
+    job_id: str,
+    body: GenerateRequest,
+    pipeline: ClothingPipeline,
+) -> None:
+    job = await _get_job(job_id)
+    if job is None:
+        logger.warning("async job vanished before execution: %s", job_id)
+        return
+
+    job.status = "running"
+    await _put_job(job)
+
+    try:
+        result = await pipeline.run(body)
+        job.result = result
+        job.status = result.status.value
+    except Exception as exc:  # noqa: BLE001 — captured on the job
+        logger.exception("async clothing-3d job failed: %s", job_id)
+        job.status = PipelineStatus.FAILED.value
+        job.error = str(exc)
+    finally:
+        job.finished_at = datetime.now(UTC)
+        await _put_job(job)
+
+
+@router.get(
+    "/jobs/{job_id}",
+    response_model=JobStatusResponse,
+    summary="Fetch the status of an async clothing 3D job",
+)
+async def get_job_endpoint(job_id: str) -> JobStatusResponse:
+    job = await _get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"job not found: {job_id}")
+    return JobStatusResponse(
+        ok=job.status in {PipelineStatus.SUCCEEDED.value, "queued", "running"},
+        job_id=job.job_id,
+        status=job.status,
+        result=job.result,
+        error=job.error,
+        submitted_at=job.submitted_at.isoformat() if job.submitted_at else None,
+        finished_at=job.finished_at.isoformat() if job.finished_at else None,
+    )
+
+
+@router.get(
+    "/health",
+    response_model=HealthResponse,
+    summary="TRELLIS provider health check",
+)
+async def health_endpoint(
+    pipeline: ClothingPipeline = Depends(get_pipeline),
+) -> HealthResponse:
+    health = await pipeline.provider.health_check()
+    return HealthResponse(
+        ok=health.is_available,
+        provider=health.provider,
+        status=health.status.value,
+        capabilities=[c.value for c in health.capabilities],
+        backend=pipeline.provider.config.backend.value,
+        latency_ms=health.latency_ms,
+        error=health.error_message,
+        detail={
+            "quality_preset": pipeline.provider.config.quality.value,
+            "output_dir": pipeline.provider.config.output_dir,
+        },
+    )
+
+
+@router.get("/info", summary="Pipeline configuration & capabilities")
+async def info_endpoint(
+    pipeline: ClothingPipeline = Depends(get_pipeline),
+) -> dict[str, Any]:
+    config = pipeline.provider.config
+    return {
+        "ok": True,
+        "version": "1.0.0",
+        "backend": config.backend.value,
+        "quality": config.quality.value,
+        "capabilities": [c.value for c in pipeline.provider.capabilities],
+        "sampling": {
+            "ss_steps": config.sampling.ss_sampling_steps,
+            "slat_steps": config.sampling.slat_sampling_steps,
+            "mesh_simplify": config.sampling.mesh_simplify,
+            "texture_size": config.sampling.texture_size,
+        },
+        "outputs": {
+            "glb": True,
+            "usdz": config.export_usdz_for_ios,
+            "thumbnail": True,
+        },
+    }
+
+
+__all__ = ["router", "get_pipeline"]

--- a/api/v1/clothing_3d/router.py
+++ b/api/v1/clothing_3d/router.py
@@ -2,25 +2,35 @@
 
 Endpoints:
 
-- ``POST /generate`` — synchronous run. Returns the full :class:`PipelineResult`.
-- ``POST /generate/async`` — fire-and-forget; returns a job ID for polling.
-- ``GET  /jobs/{job_id}`` — fetch a previously submitted async job.
-- ``GET  /health`` — provider/backend health.
+- ``POST /generate``               synchronous run
+- ``POST /generate/async``         enqueue, returns ``job_id`` + ``status_url``
+- ``GET  /jobs/{job_id}``          poll an async job
+- ``GET  /jobs``                   list recent jobs (capped at 100)
+- ``GET  /health``                 liveness — provider/backend health
+- ``GET  /ready``                  readiness — queue+store reachable
+- ``GET  /info``                   active config + capabilities
+- ``GET  /metrics``                Prometheus text payload
 
-The async path uses an in-process job store; for multi-worker deployments,
-swap in the existing :mod:`services.ml.processing_queue` or Celery worker.
+Production wiring:
+
+- Async submissions are pushed to :class:`JobQueue` (Redis Streams when
+  ``REDIS_URL`` is set, in-memory otherwise) and processed by the worker
+  (``python -m pipelines.clothing_3d.worker``). The router never blocks on
+  the pipeline.
+- Sync ``/generate`` still runs in-process; use it from internal callers that
+  need the result immediately and accept the latency.
+- Both paths share :class:`IdempotencyCache` so identical inputs return the
+  cached result instead of re-running.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import uuid
-from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
 from api.v1.clothing_3d.schemas import (
     GenerateRequest,
@@ -29,8 +39,24 @@ from api.v1.clothing_3d.schemas import (
     JobAcceptedResponse,
     JobStatusResponse,
 )
-from pipelines.clothing_3d.models import PipelineResult, PipelineStatus
+from pipelines.clothing_3d.job_store import JobRecord, JobStore, build_job_store
+from pipelines.clothing_3d.models import (
+    PipelineRequest,
+    PipelineResult,
+    PipelineStatus,
+)
+from pipelines.clothing_3d.observability import (
+    get_metrics,
+    metrics_event_subscriber,
+    render_metrics,
+)
 from pipelines.clothing_3d.pipeline import ClothingPipeline
+from pipelines.clothing_3d.queue import JobQueue, build_queue
+from pipelines.clothing_3d.reliability import (
+    IdempotencyCache,
+    QuotaExceededError,
+    request_fingerprint,
+)
 from services.three_d.trellis.config import TrellisConfig
 
 logger = logging.getLogger(__name__)
@@ -39,53 +65,44 @@ router = APIRouter(tags=["Clothing 3D Pipeline"])
 
 
 # =============================================================================
-# Singletons (one pipeline per process)
+# Process-level singletons
 # =============================================================================
 
 
 _pipeline: ClothingPipeline | None = None
+_queue: JobQueue | None = None
+_store: JobStore | None = None
+_idempotency: IdempotencyCache | None = None
 
 
 def get_pipeline() -> ClothingPipeline:
     global _pipeline
     if _pipeline is None:
         _pipeline = ClothingPipeline(config=TrellisConfig.from_env())
+        # Wire pipeline events into Prometheus metrics for sync runs too.
+        _pipeline.event_bus.subscribe(metrics_event_subscriber())
     return _pipeline
 
 
-# =============================================================================
-# In-process job store
-# =============================================================================
+def get_queue() -> JobQueue:
+    global _queue
+    if _queue is None:
+        _queue = build_queue()
+    return _queue
 
 
-@dataclass(slots=True)
-class _Job:
-    job_id: str
-    status: str = "queued"
-    result: PipelineResult | None = None
-    error: str | None = None
-    submitted_at: datetime = field(default_factory=lambda: datetime.now(UTC))
-    finished_at: datetime | None = None
+def get_store() -> JobStore:
+    global _store
+    if _store is None:
+        _store = build_job_store()
+    return _store
 
 
-_jobs: dict[str, _Job] = {}
-_jobs_lock = asyncio.Lock()
-
-# Cap at 256 entries to avoid unbounded growth — older jobs evicted FIFO.
-_JOB_LIMIT = 256
-
-
-async def _put_job(job: _Job) -> None:
-    async with _jobs_lock:
-        if len(_jobs) >= _JOB_LIMIT:
-            oldest = min(_jobs, key=lambda k: _jobs[k].submitted_at)
-            _jobs.pop(oldest, None)
-        _jobs[job.job_id] = job
-
-
-async def _get_job(job_id: str) -> _Job | None:
-    async with _jobs_lock:
-        return _jobs.get(job_id)
+def get_idempotency() -> IdempotencyCache:
+    global _idempotency
+    if _idempotency is None:
+        _idempotency = IdempotencyCache()
+    return _idempotency
 
 
 # =============================================================================
@@ -100,25 +117,32 @@ async def _get_job(job_id: str) -> _Job | None:
 )
 async def generate_endpoint(
     body: GenerateRequest,
-    pipeline: ClothingPipeline = Depends(get_pipeline),
+    pipeline: Annotated[ClothingPipeline, Depends(get_pipeline)],
+    idempotency: Annotated[IdempotencyCache, Depends(get_idempotency)],
 ) -> GenerateResponse:
-    """Run the full clothing 3D pipeline and return the result.
+    """Run the full clothing 3D pipeline and return the result."""
 
-    Use this for one-off calls. For batch workloads or long-running runs
-    (PRODUCTION quality preset, 60+ second backend latency), prefer
-    :func:`generate_async_endpoint`.
-    """
+    async def _runner(req: PipelineRequest) -> PipelineResult:
+        return await pipeline.run(req)
+
     try:
-        result = await pipeline.run(body)
-    except Exception as exc:  # noqa: BLE001 — convert to HTTP error
+        result, hit = await idempotency.get_or_run(body, runner=_runner)
+    except QuotaExceededError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"backend cost cap exceeded: {exc}",
+        ) from exc
+    except Exception as exc:  # noqa: BLE001
         logger.exception("clothing-3d generate failed")
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"Pipeline error: {exc}",
         ) from exc
 
+    metrics = get_metrics()
+    metrics.cache_total.labels(outcome="hit" if hit else "miss").inc()
+
     if result.status == PipelineStatus.FAILED:
-        # Body still returned so the caller sees per-stage detail.
         return GenerateResponse(ok=False, result=result)
     return GenerateResponse(ok=result.succeeded, result=result)
 
@@ -132,20 +156,38 @@ async def generate_endpoint(
 async def generate_async_endpoint(
     body: GenerateRequest,
     request: Request,
-    background: BackgroundTasks,
-    pipeline: ClothingPipeline = Depends(get_pipeline),
+    queue: Annotated[JobQueue, Depends(get_queue)],
+    store: Annotated[JobStore, Depends(get_store)],
 ) -> JobAcceptedResponse:
-    """Submit a job and immediately return a polling URL."""
+    """Enqueue a job; the worker picks it up.
+
+    With ``REDIS_URL`` set, the job survives restarts and any worker in the
+    pool can pick it up. Without Redis, the job runs against the in-process
+    queue and is lost on restart.
+    """
     job_id = f"job_{uuid.uuid4().hex[:16]}"
     body.correlation_id = body.correlation_id or job_id
 
-    job = _Job(job_id=job_id, status="queued")
-    await _put_job(job)
-
-    background.add_task(_run_async_job, job_id, body, pipeline)
+    record = JobRecord(
+        job_id=job_id,
+        status=PipelineStatus.PENDING,
+        request=body,
+        idempotency_key=request_fingerprint(body),
+    )
+    await store.put(record)
+    try:
+        await queue.enqueue(job_id)
+    except Exception as exc:  # noqa: BLE001 — failed enqueue = failed job
+        record.status = PipelineStatus.FAILED
+        record.error = f"enqueue failed: {exc}"
+        record.finished_at = datetime.now(UTC)
+        await store.update(record)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Queue unavailable: {exc}",
+        ) from exc
 
     base_url = str(request.url).rstrip("/")
-    # /generate/async → /jobs/{job_id}
     base = base_url.rsplit("/generate/async", 1)[0]
     return JobAcceptedResponse(
         job_id=job_id,
@@ -154,59 +196,62 @@ async def generate_async_endpoint(
     )
 
 
-async def _run_async_job(
-    job_id: str,
-    body: GenerateRequest,
-    pipeline: ClothingPipeline,
-) -> None:
-    job = await _get_job(job_id)
-    if job is None:
-        logger.warning("async job vanished before execution: %s", job_id)
-        return
-
-    job.status = "running"
-    await _put_job(job)
-
-    try:
-        result = await pipeline.run(body)
-        job.result = result
-        job.status = result.status.value
-    except Exception as exc:  # noqa: BLE001 — captured on the job
-        logger.exception("async clothing-3d job failed: %s", job_id)
-        job.status = PipelineStatus.FAILED.value
-        job.error = str(exc)
-    finally:
-        job.finished_at = datetime.now(UTC)
-        await _put_job(job)
-
-
 @router.get(
     "/jobs/{job_id}",
     response_model=JobStatusResponse,
     summary="Fetch the status of an async clothing 3D job",
 )
-async def get_job_endpoint(job_id: str) -> JobStatusResponse:
-    job = await _get_job(job_id)
+async def get_job_endpoint(
+    job_id: str,
+    store: Annotated[JobStore, Depends(get_store)],
+) -> JobStatusResponse:
+    job = await store.get(job_id)
     if not job:
         raise HTTPException(status_code=404, detail=f"job not found: {job_id}")
     return JobStatusResponse(
-        ok=job.status in {PipelineStatus.SUCCEEDED.value, "queued", "running"},
+        ok=job.status in {PipelineStatus.SUCCEEDED, PipelineStatus.PENDING, PipelineStatus.RUNNING},
         job_id=job.job_id,
-        status=job.status,
+        status=job.status.value,
         result=job.result,
         error=job.error,
-        submitted_at=job.submitted_at.isoformat() if job.submitted_at else None,
+        submitted_at=job.submitted_at.isoformat(),
         finished_at=job.finished_at.isoformat() if job.finished_at else None,
     )
 
 
 @router.get(
+    "/jobs",
+    summary="List recent clothing 3D jobs",
+)
+async def list_jobs_endpoint(
+    store: Annotated[JobStore, Depends(get_store)],
+    limit: int = 50,
+) -> dict[str, Any]:
+    jobs = await store.list(limit=min(max(limit, 1), 100))
+    return {
+        "ok": True,
+        "count": len(jobs),
+        "jobs": [
+            {
+                "job_id": j.job_id,
+                "status": j.status.value,
+                "submitted_at": j.submitted_at.isoformat(),
+                "finished_at": j.finished_at.isoformat() if j.finished_at else None,
+                "worker_id": j.worker_id,
+                "error": j.error,
+            }
+            for j in jobs
+        ],
+    }
+
+
+@router.get(
     "/health",
     response_model=HealthResponse,
-    summary="TRELLIS provider health check",
+    summary="Liveness — TRELLIS provider health",
 )
 async def health_endpoint(
-    pipeline: ClothingPipeline = Depends(get_pipeline),
+    pipeline: Annotated[ClothingPipeline, Depends(get_pipeline)],
 ) -> HealthResponse:
     health = await pipeline.provider.health_check()
     return HealthResponse(
@@ -224,14 +269,47 @@ async def health_endpoint(
     )
 
 
+@router.get("/ready", summary="Readiness — queue + store reachable")
+async def ready_endpoint(
+    queue: Annotated[JobQueue, Depends(get_queue)],
+    store: Annotated[JobStore, Depends(get_store)],
+) -> dict[str, Any]:
+    """Reports OK only when the worker dependencies are reachable."""
+    detail: dict[str, Any] = {}
+    ok = True
+
+    try:
+        detail["queue_depth"] = await queue.depth()
+        detail["queue"] = type(queue).__name__
+    except Exception as exc:  # noqa: BLE001
+        ok = False
+        detail["queue_error"] = str(exc)
+
+    try:
+        await store.list(limit=1)
+        detail["store"] = type(store).__name__
+    except Exception as exc:  # noqa: BLE001
+        ok = False
+        detail["store_error"] = str(exc)
+
+    if not ok:
+        return Response(
+            content=str({"ok": False, **detail}),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            media_type="application/json",
+        )
+    return {"ok": True, **detail}
+
+
 @router.get("/info", summary="Pipeline configuration & capabilities")
 async def info_endpoint(
-    pipeline: ClothingPipeline = Depends(get_pipeline),
+    pipeline: Annotated[ClothingPipeline, Depends(get_pipeline)],
+    queue: Annotated[JobQueue, Depends(get_queue)],
 ) -> dict[str, Any]:
     config = pipeline.provider.config
     return {
         "ok": True,
-        "version": "1.0.0",
+        "version": "1.1.0",
         "backend": config.backend.value,
         "quality": config.quality.value,
         "capabilities": [c.value for c in pipeline.provider.capabilities],
@@ -246,7 +324,21 @@ async def info_endpoint(
             "usdz": config.export_usdz_for_ios,
             "thumbnail": True,
         },
+        "queue": {
+            "type": type(queue).__name__,
+            "depth": await queue.depth(),
+        },
     }
 
 
-__all__ = ["router", "get_pipeline"]
+@router.get(
+    "/metrics",
+    summary="Prometheus metrics scrape endpoint",
+    include_in_schema=False,
+)
+async def metrics_endpoint() -> Response:
+    body, content_type = render_metrics()
+    return Response(content=body, media_type=content_type)
+
+
+__all__ = ["router", "get_pipeline", "get_queue", "get_store", "get_idempotency"]

--- a/api/v1/clothing_3d/schemas.py
+++ b/api/v1/clothing_3d/schemas.py
@@ -1,0 +1,63 @@
+"""API schemas — thin Pydantic wrappers over the pipeline models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from pipelines.clothing_3d.models import PipelineRequest, PipelineResult
+
+
+class GenerateRequest(PipelineRequest):
+    """Request body for ``POST /v1/clothing-3d/generate``."""
+
+
+class GenerateResponse(BaseModel):
+    """Synchronous response envelope."""
+
+    ok: bool
+    result: PipelineResult
+
+
+class JobAcceptedResponse(BaseModel):
+    """Async-style accepted response (when ``async=true`` is passed)."""
+
+    ok: bool = True
+    job_id: str
+    correlation_id: str
+    status_url: str
+
+
+class JobStatusResponse(BaseModel):
+    """Job status payload returned by the polling endpoint."""
+
+    ok: bool
+    job_id: str
+    status: str
+    result: PipelineResult | None = None
+    error: str | None = None
+    submitted_at: str | None = None
+    finished_at: str | None = None
+
+
+class HealthResponse(BaseModel):
+    """Provider health payload."""
+
+    ok: bool
+    provider: str
+    status: str
+    capabilities: list[str]
+    backend: str | None = None
+    latency_ms: float | None = None
+    error: str | None = None
+    detail: dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = [
+    "GenerateRequest",
+    "GenerateResponse",
+    "HealthResponse",
+    "JobAcceptedResponse",
+    "JobStatusResponse",
+]

--- a/deploy/clothing_3d/Dockerfile
+++ b/deploy/clothing_3d/Dockerfile
@@ -1,0 +1,59 @@
+# Clothing 3D Worker — TRELLIS pipeline background processor.
+#
+# Build:
+#   docker build -f deploy/clothing_3d/Dockerfile -t devskyy/clothing-3d-worker:latest .
+#
+# Run (HF Space backend, in-memory queue/store):
+#   docker run --rm -e TRELLIS_BACKEND=hf_space devskyy/clothing-3d-worker:latest
+#
+# Run (Replicate backend, Redis queue/store):
+#   docker run --rm \
+#     -e TRELLIS_BACKEND=replicate \
+#     -e REPLICATE_API_TOKEN=$REPLICATE_API_TOKEN \
+#     -e REDIS_URL=redis://redis:6379/0 \
+#     -e CLOTHING_3D_CONCURRENCY=4 \
+#     devskyy/clothing-3d-worker:latest
+
+FROM python:3.13-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    THREE_D_OUTPUT_DIR=/var/data/3d-models-generated \
+    TRELLIS_CACHE_DIR=/var/cache/trellis \
+    LOG_LEVEL=INFO
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python deps first so layer cache survives source changes.
+COPY requirements.txt requirements-trellis.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt -r requirements-trellis.txt redis
+
+# Application source (only what the worker actually needs).
+COPY pyproject.toml /app/
+COPY core/ /app/core/
+COPY services/ /app/services/
+COPY pipelines/ /app/pipelines/
+COPY agents/ /app/agents/
+COPY security/ /app/security/
+
+RUN mkdir -p "$THREE_D_OUTPUT_DIR" "$TRELLIS_CACHE_DIR"
+
+# Run as unprivileged user.
+RUN useradd --create-home --uid 10001 worker \
+    && chown -R worker:worker /app /var/data /var/cache
+USER worker
+
+# Healthcheck: exit-code from `cli health` — non-zero when no backend is healthy.
+HEALTHCHECK --interval=30s --timeout=15s --start-period=20s --retries=3 \
+    CMD python -m pipelines.clothing_3d.cli health || exit 1
+
+ENTRYPOINT ["python", "-m", "pipelines.clothing_3d.worker"]

--- a/deploy/clothing_3d/docker-compose.yml
+++ b/deploy/clothing_3d/docker-compose.yml
@@ -1,0 +1,83 @@
+# Clothing 3D worker stack — drop-in compose file for the TRELLIS pipeline.
+#
+# Compose with the main DevSkyy stack:
+#   docker compose -f docker-compose.yml -f deploy/clothing_3d/docker-compose.yml up -d
+#
+# Standalone (queue + worker only, no main stack):
+#   docker compose -f deploy/clothing_3d/docker-compose.yml up -d
+
+version: "3.9"
+
+x-shared-env: &shared_env
+  REDIS_URL: redis://redis:6379/0
+  TRELLIS_BACKEND: ${TRELLIS_BACKEND:-hf_space}
+  TRELLIS_QUALITY: ${TRELLIS_QUALITY:-standard}
+  TRELLIS_EXPORT_USDZ: "true"
+  THREE_D_OUTPUT_DIR: /var/data/3d-models-generated
+  TRELLIS_CACHE_DIR: /var/cache/trellis
+  HUGGINGFACE_TOKEN: ${HUGGINGFACE_TOKEN:-}
+  REPLICATE_API_TOKEN: ${REPLICATE_API_TOKEN:-}
+  LOG_LEVEL: INFO
+
+services:
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - clothing3d-redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  clothing-3d-worker:
+    build:
+      context: ../../
+      dockerfile: deploy/clothing_3d/Dockerfile
+    image: devskyy/clothing-3d-worker:latest
+    environment:
+      <<: *shared_env
+      CLOTHING_3D_CONCURRENCY: "${CLOTHING_3D_CONCURRENCY:-2}"
+    volumes:
+      - clothing3d-artifacts:/var/data/3d-models-generated
+      - clothing3d-cache:/var/cache/trellis
+    depends_on:
+      redis:
+        condition: service_healthy
+    deploy:
+      replicas: ${CLOTHING_3D_REPLICAS:-2}
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
+
+  clothing-3d-api:
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+    image: devskyy/api:latest
+    command: ["uvicorn", "main_enterprise:app", "--host", "0.0.0.0", "--port", "8000"]
+    environment:
+      <<: *shared_env
+    ports:
+      - "${CLOTHING_3D_API_PORT:-8000}:8000"
+    volumes:
+      - clothing3d-artifacts:/app/assets/3d-models-generated
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/v1/clothing-3d/ready"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  clothing3d-redis:
+  clothing3d-artifacts:
+  clothing3d-cache:

--- a/deploy/clothing_3d/k8s.yaml
+++ b/deploy/clothing_3d/k8s.yaml
@@ -1,0 +1,190 @@
+# Clothing 3D pipeline — Kubernetes manifests.
+#
+# Apply:
+#   kubectl apply -f deploy/clothing_3d/k8s.yaml
+#
+# Configures three resources:
+#   1. ConfigMap   — non-secret env knobs (backend, quality, dirs).
+#   2. Deployment  — clothing-3d-worker, scaled by HPA.
+#   3. HPA         — autoscales on queue_depth (custom metric) + CPU.
+#
+# Secrets (REPLICATE_API_TOKEN, HUGGINGFACE_TOKEN, REDIS_URL) MUST already
+# exist as `clothing-3d-secrets` in the namespace.
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clothing-3d-config
+  labels:
+    app: clothing-3d
+data:
+  TRELLIS_BACKEND: "hf_space"
+  TRELLIS_QUALITY: "standard"
+  TRELLIS_EXPORT_USDZ: "true"
+  THREE_D_OUTPUT_DIR: "/var/data/3d-models-generated"
+  TRELLIS_CACHE_DIR: "/var/cache/trellis"
+  CLOTHING_3D_CONCURRENCY: "2"
+  CLOTHING_3D_QUEUE: "redis"
+  CLOTHING_3D_JOB_STORE: "redis"
+  LOG_LEVEL: "INFO"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clothing-3d-worker
+  labels:
+    app: clothing-3d
+    component: worker
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: clothing-3d
+      component: worker
+  template:
+    metadata:
+      labels:
+        app: clothing-3d
+        component: worker
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/v1/clothing-3d/metrics"
+    spec:
+      terminationGracePeriodSeconds: 60  # let in-flight jobs drain
+      containers:
+        - name: worker
+          image: devskyy/clothing-3d-worker:latest
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: clothing-3d-config
+            - secretRef:
+                name: clothing-3d-secrets
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: artifacts
+              mountPath: /var/data/3d-models-generated
+            - name: cache
+              mountPath: /var/cache/trellis
+          livenessProbe:
+            exec:
+              command:
+                - python
+                - -m
+                - pipelines.clothing_3d.cli
+                - health
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            timeoutSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - python
+                - -c
+                - |
+                  import asyncio
+                  from pipelines.clothing_3d.queue import build_queue
+                  asyncio.run(build_queue().depth())
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+      volumes:
+        - name: artifacts
+          persistentVolumeClaim:
+            claimName: clothing-3d-artifacts
+        - name: cache
+          emptyDir: {}
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: clothing-3d-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: clothing-3d-worker
+  minReplicas: 2
+  maxReplicas: 12
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300  # don't thrash; allow soak time
+      policies:
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 30   # respond fast to burst load
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+        - type: Pods
+          value: 4
+          periodSeconds: 30
+        - type: Pods   # pick the faster of the two
+          value: 4
+          periodSeconds: 30
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Pods
+      pods:
+        metric:
+          name: clothing_3d_queue_depth_per_pod  # exposed via Prometheus adapter
+        target:
+          type: AverageValue
+          averageValue: "5"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: clothing-3d-artifacts
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  # storageClassName intentionally omitted — pick per-cluster.
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clothing-3d-api
+  labels:
+    app: clothing-3d
+    component: api
+spec:
+  selector:
+    app: clothing-3d
+    component: api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+    - name: metrics
+      port: 9090
+      targetPort: 8000

--- a/docs/CLOTHING_3D_PIPELINE.md
+++ b/docs/CLOTHING_3D_PIPELINE.md
@@ -1,0 +1,296 @@
+# Clothing 3D Pipeline
+
+End-to-end image/text → garment 3D asset pipeline, built on
+[Microsoft TRELLIS](https://github.com/microsoft/TRELLIS).
+
+## Why
+
+E-commerce garment photography needs to become 3D for AR try-on, immersive
+collection pages, and richer PDP renders. TRELLIS produces the best mesh +
+texture quality for clothing among open models, but raw TRELLIS output is
+not e-commerce-ready: backgrounds bleed in, polycount is unbounded, USDZ
+isn't emitted, and there's no QC gate. This pipeline closes that gap.
+
+## Architecture
+
+```
+┌─────────────┐   ┌──────────────┐   ┌───────────────────────────────┐
+│  PipelineRequest │   │ ClothingPipeline │   │     services/three_d/trellis/         │
+│  (image | text)  ├──▶│  orchestrator    ├──▶│  preprocess → backend → postprocess   │
+│  garment meta    │   │  (events, QC)    │   │  ┌─────────┐  ┌──────┐  ┌──────────┐  │
+└─────────────┘   └──────┬───────┘   │  │ rembg + │→ │ HF   │→ │ trimesh  │  │
+                          │           │  │ resize  │  │Space │  │ + USDZ   │  │
+                          │           │  └─────────┘  └──────┘  └──────────┘  │
+                          │           └──────────────────────────────────────┘
+                          ▼
+                ┌──────────────────┐
+                │  ArtifactStore   │  Local FS (dev) or S3-compatible (prod)
+                │  GLB + USDZ +    │
+                │  thumbnail       │
+                └─────────┬────────┘
+                          ▼
+                ┌──────────────────┐     ┌───────────────────┐
+                │ PipelineResult   │ ←── │ FastAPI /v1/clothing-3d
+                │ + stage reports  │     │   /generate                │
+                └──────────────────┘     │   /generate/async + /jobs  │
+                                         │   /health + /info          │
+                                         └────────────────────────────┘
+```
+
+## Layout
+
+```
+services/three_d/trellis/
+├── __init__.py
+├── config.py          # TrellisConfig, quality presets, sampling params
+├── garment_aware.py   # category classifier + prompt builder
+├── preprocess.py      # background removal, crop, normalize, quality score
+├── client.py          # HF Space / Local / Replicate / Stub backends
+├── postprocess.py     # mesh cleanup, decimate, USDZ, thumbnail
+└── provider.py        # I3DProvider implementation
+
+pipelines/clothing_3d/
+├── __init__.py
+├── models.py          # PipelineRequest / Result / StageReport
+├── events.py          # pub/sub event bus (log + webhook subscribers)
+├── stages.py          # ingest / generate / qc / store stage callables
+├── storage.py         # LocalArtifactStore + S3ArtifactStore
+├── pipeline.py        # ClothingPipeline orchestrator
+└── cli.py             # python -m pipelines.clothing_3d.cli
+
+api/v1/clothing_3d/
+├── __init__.py
+├── schemas.py         # request/response Pydantic models
+└── router.py          # FastAPI endpoints (sync + async job)
+
+tests/
+├── three_d/trellis/   # unit tests
+└── pipelines/clothing_3d/  # integration tests
+
+scripts/
+├── setup_trellis.sh   # clone microsoft/TRELLIS into vendor/trellis/
+└── trellis_demo.py    # end-to-end smoke test
+
+vendor/
+└── trellis/           # vendored microsoft/TRELLIS (git-ignored)
+```
+
+## Backends
+
+The TRELLIS provider supports four backends — pick with
+`TRELLIS_BACKEND` env var or per-request `backend` field.
+
+| Backend     | GPU? | Cost              | Latency  | Best for                      |
+|-------------|------|-------------------|----------|-------------------------------|
+| `hf_space`  | no   | free              | 60–180 s | dev, low-volume production    |
+| `local`     | yes  | hardware          | 15–30 s  | high-volume self-hosted       |
+| `replicate` | no   | ~$0.05 / model    | 30–60 s  | bursty workloads              |
+| `modal`     | no   | per GPU sec       | 10–20 s  | strict-SLA production         |
+| `stub`      | no   | free              | <0.1 s   | tests, dry runs, CI           |
+
+## Quality presets
+
+`TrellisQualityPreset` (also exposed as `quality` on the request) maps to
+sampling steps + mesh detail:
+
+| Preset       | SS / SLAT steps | Mesh simplify | Texture | Polycount target |
+|--------------|------------------|----------------|---------|------------------|
+| `draft`      | 8 / 8            | 0.85           | 1024²   | 40k              |
+| `standard`   | 12 / 12          | 0.95           | 1024²   | 80k              |
+| `production` | 20 / 20          | 0.97           | 2048²   | 150k             |
+
+The QC stage tightens or relaxes its acceptance thresholds based on the
+selected preset — see `pipelines/clothing_3d/stages.py:default_thresholds_for`.
+
+## Setup
+
+### 1. Install Python deps
+
+```bash
+pip install -r requirements-trellis.txt
+```
+
+`rembg`, `trimesh`, `usd-core` are optional but recommended — the pipeline
+degrades gracefully (emits warnings) when they're missing.
+
+### 2. (Optional) Vendor TRELLIS for local GPU inference
+
+```bash
+bash scripts/setup_trellis.sh --with-weights
+pip install -e vendor/trellis
+```
+
+This is only needed for `TRELLIS_BACKEND=local`. The default `hf_space`
+backend works with just `pip install gradio_client`.
+
+### 3. Configure
+
+Add to `.env`:
+
+```bash
+TRELLIS_BACKEND=hf_space             # or local | replicate | modal
+TRELLIS_QUALITY=standard             # draft | standard | production
+TRELLIS_OUTPUT_DIR=./assets/3d-models-generated
+TRELLIS_EXPORT_USDZ=true
+HUGGINGFACE_TOKEN=hf_xxx              # optional, raises HF Space rate limits
+REPLICATE_API_TOKEN=r8_xxx            # only when backend=replicate
+```
+
+### 4. Smoke test
+
+```bash
+# Stub backend — no network required
+python scripts/trellis_demo.py
+
+# HF Space backend — needs network, ~2 min
+python scripts/trellis_demo.py --backend hf_space --image path/to/garment.jpg
+```
+
+## Programmatic usage
+
+```python
+from pipelines.clothing_3d import ClothingPipeline, PipelineRequest
+from services.three_d.trellis import TrellisQualityPreset
+
+pipeline = ClothingPipeline()
+
+result = await pipeline.run(
+    PipelineRequest(
+        image_url="https://skyyrose.co/wp-content/uploads/2024/hoodie.jpg",
+        product_name="Black Rose Hoodie",
+        product_sku="br-001",
+        collection="black_rose",
+        garment_type="hoodie",
+        quality=TrellisQualityPreset.PRODUCTION,
+    )
+)
+
+print(result.glb_url)        # /assets/3d-models-generated/br-001_*.glb
+print(result.usdz_url)       # /assets/3d-models-generated/br-001_*.usdz
+print(result.quality.score)  # 0..1
+```
+
+## HTTP API
+
+| Method | Path                               | Purpose                          |
+|--------|------------------------------------|----------------------------------|
+| POST   | `/v1/clothing-3d/generate`         | synchronous run                  |
+| POST   | `/v1/clothing-3d/generate/async`   | enqueue, returns job_id          |
+| GET    | `/v1/clothing-3d/jobs/{job_id}`    | poll an async job                |
+| GET    | `/v1/clothing-3d/health`           | provider/backend health          |
+| GET    | `/v1/clothing-3d/info`             | active config + capabilities     |
+
+To mount on the enterprise app:
+
+```python
+# main_enterprise.py
+from api.v1.clothing_3d import router as clothing_3d_router
+app.include_router(clothing_3d_router, prefix="/v1/clothing-3d")
+```
+
+## CLI
+
+```bash
+# Single image
+python -m pipelines.clothing_3d.cli generate \
+  --image ./uploads/hoodie.jpg \
+  --product "Black Rose Hoodie" \
+  --collection black_rose \
+  --garment-type hoodie \
+  --quality production
+
+# Batch
+echo '{"image_path":"a.jpg","product_name":"A","quality":"draft"}' > batch.jsonl
+echo '{"image_path":"b.jpg","product_name":"B","quality":"draft"}' >> batch.jsonl
+python -m pipelines.clothing_3d.cli batch batch.jsonl --max-concurrent 2
+
+# Health probe
+python -m pipelines.clothing_3d.cli health
+```
+
+## Event bus
+
+The pipeline emits structured events at each stage boundary:
+
+| Event              | Stage          | Meaning                       |
+|--------------------|----------------|-------------------------------|
+| `pipeline.started` | —              | Run accepted                  |
+| `stage.started`    | every stage    | Stage beginning execution     |
+| `stage.finished`   | every stage    | Stage emitting detail payload |
+| `pipeline.rejected`| —              | QC vetoed the artifact        |
+| `pipeline.failed`  | —              | Any stage failed              |
+| `pipeline.succeeded`| —             | Artifact stored               |
+
+Subscribe with `bus.subscribe(coroutine_fn)`. Built-in subscribers:
+
+- `log_event_subscriber()` — stdlib logging
+- `webhook_subscriber(url)` — POSTs each event to ``url`` (httpx)
+
+## QC gate
+
+The QC stage runs after generation/postprocessing and checks:
+
+- Polycount within `[min_polycount, max_polycount]` for the preset
+- File size within `[min_file_kb, max_file_kb]`
+- Thumbnail present (production only, optional)
+
+Failures trigger a `REJECTED` status — the artifact is still produced
+and stored in metadata, but the API marks the run as not shippable. Wire
+the `pipeline.rejected` event into your approval queue.
+
+Override thresholds:
+
+```python
+from pipelines.clothing_3d.stages import QCThresholds
+
+pipeline = ClothingPipeline(
+    thresholds=QCThresholds(min_polycount=20_000, max_file_kb=15_000)
+)
+```
+
+## Storage backends
+
+| Backend             | Use case                                    |
+|---------------------|---------------------------------------------|
+| `LocalArtifactStore`| Dev + the existing FastAPI static mount     |
+| `S3ArtifactStore`   | Prod: S3, R2, or any S3-compatible store    |
+
+Both implement `ArtifactStore`. Bring your own by implementing the
+`store(bundle) -> StoredArtifact` async method.
+
+```python
+from pipelines.clothing_3d.storage import S3ArtifactStore
+
+pipeline = ClothingPipeline(
+    store=S3ArtifactStore(
+        bucket="skyyrose-3d",
+        prefix="garments",
+        public_base_url="https://cdn.skyyrose.co/3d",
+    )
+)
+```
+
+## Testing
+
+```bash
+# All tests
+pytest tests/three_d/trellis tests/pipelines/clothing_3d -v
+
+# Just the deterministic stub-backed integration test
+pytest tests/pipelines/clothing_3d -v
+
+# Run the CLI in dry-run mode (uses the stub backend)
+python -m pipelines.clothing_3d.cli generate --prompt "demo" --dry-run
+```
+
+The stub backend writes a tiny placeholder GLB and returns immediately, so
+tests run in <1 s and don't require GPU, network, or any optional deps.
+
+## Roadmap
+
+- [ ] Modal backend implementation (placeholder in `client.py`)
+- [ ] TRELLIS-text-large weights for true text-to-3D
+- [ ] Auto-rigging via `Rigify` for try-on animation
+- [ ] Per-garment material library (PBR overrides for known fabrics)
+- [ ] WebSocket progress stream on the `/generate/async` endpoint
+- [ ] Multi-view input (front + back + side) — TRELLIS supports `multiimages`

--- a/docs/CLOTHING_3D_PRODUCTION.md
+++ b/docs/CLOTHING_3D_PRODUCTION.md
@@ -1,0 +1,226 @@
+# Clothing 3D — Production Deployment Guide
+
+Complements [`CLOTHING_3D_PIPELINE.md`](./CLOTHING_3D_PIPELINE.md) with the
+operational layer: queue + worker + persistent job store + idempotency +
+metrics + deploy manifests. This is what turns "runs on my laptop" into
+"runs at scale 24/7 with kill switches."
+
+## Topology
+
+```
+                ┌──────────────────────────────────────┐
+                │            API replicas              │
+                │  /v1/clothing-3d/generate            │
+                │  /v1/clothing-3d/generate/async ─┐   │
+                │  /v1/clothing-3d/jobs/{id}       │   │
+                │  /v1/clothing-3d/{health,ready,  │   │
+                │                   info,metrics}  │   │
+                └──────────────────────────────────┼───┘
+                                                   ▼
+                                       ┌────────────────────┐
+                                       │   Redis Streams    │
+                                       │  clothing3d:queue  │
+                                       └────────┬───────────┘
+                                                ▼
+                ┌────────────────────────────────────────────────┐
+                │                Worker pool                      │
+                │   PipelineWorker × N (HPA-scaled)              │
+                │   xreadgroup → run → xack                      │
+                └────────┬───────────────────────────────────────┘
+                         ▼
+              ┌──────────────────────┐
+              │  ClothingPipeline    │  Stub | HF Space | Local | Replicate
+              │  (with TRELLIS)      │
+              └────────┬─────────────┘
+                       ▼
+              ┌──────────────────────┐       ┌────────────────────┐
+              │  RedisJobStore       │ ◀──── │  /v1/...jobs/{id}  │
+              │  clothing3d:job:{id} │       └────────────────────┘
+              └────────┬─────────────┘
+                       ▼
+              ┌──────────────────────┐
+              │  ArtifactStore       │  LocalArtifactStore (dev)
+              │  S3 / R2 in prod     │
+              └──────────────────────┘
+```
+
+## Components shipped
+
+| Module                                  | What it does                                         |
+|-----------------------------------------|------------------------------------------------------|
+| `pipelines.clothing_3d.queue`           | `JobQueue` Protocol + `InMemoryQueue` / `RedisStreamsQueue` |
+| `pipelines.clothing_3d.job_store`       | `JobStore` Protocol + in-memory + Redis backends     |
+| `pipelines.clothing_3d.worker`          | `PipelineWorker` long-running async worker           |
+| `pipelines.clothing_3d.reliability`     | `RetryPolicy` · `IdempotencyCache` · `CostQuota`     |
+| `pipelines.clothing_3d.observability`   | JSON logging · Prometheus metrics · event-bus bridge |
+| `deploy/clothing_3d/Dockerfile`         | Worker container (Python 3.13-slim, non-root)        |
+| `deploy/clothing_3d/docker-compose.yml` | API + worker + Redis (drop-in)                       |
+| `deploy/clothing_3d/k8s.yaml`           | Deployment + HPA + ConfigMap + PVC + Service         |
+| `scripts/smoke_test_clothing_3d.sh`     | <5s end-to-end CI check (stub backend)               |
+
+## Environment matrix
+
+| Variable | Default | Effect |
+|---|---|---|
+| `TRELLIS_BACKEND` | `hf_space` | `hf_space` · `local` · `replicate` · `modal` · `stub` |
+| `TRELLIS_QUALITY` | `standard` | `draft` · `standard` · `production` |
+| `TRELLIS_OUTPUT_DIR` | `./assets/3d-models-generated` | Where GLB/USDZ land |
+| `TRELLIS_EXPORT_USDZ` | `true` | Emit iOS AR USDZ alongside GLB |
+| `TRELLIS_RETRIES` | `2` | Per-generation retries inside the provider |
+| `TRELLIS_TIMEOUT` | `420` | Hard timeout per generation call (s) |
+| `REDIS_URL` | unset | Set → Redis queue + Redis job store automatically |
+| `CLOTHING_3D_QUEUE` | `auto` | Force `memory` or `redis` |
+| `CLOTHING_3D_JOB_STORE` | `auto` | Force `memory` or `redis` |
+| `CLOTHING_3D_CONCURRENCY` | `1` | In-flight jobs per worker |
+| `CLOTHING_3D_METRICS_NS` | `clothing_3d` | Prometheus metric namespace |
+| `LOG_LEVEL` | `INFO` | Stdlib log level |
+| `HUGGINGFACE_TOKEN` | — | Raises HF Space rate limits (recommended) |
+| `REPLICATE_API_TOKEN` | — | Required when `TRELLIS_BACKEND=replicate` |
+
+## Reliability primitives
+
+### Retry policy
+Wrap any external call:
+```python
+from pipelines.clothing_3d import RetryPolicy
+
+policy = RetryPolicy(max_attempts=3, base_delay_seconds=2.0, max_delay_seconds=60.0)
+result = await policy.run(lambda: backend.generate(req))
+```
+Exponential backoff with **full jitter** so a horde of retrying workers
+doesn't synchronize on a backend recovery.
+
+### Idempotency cache
+Skip duplicate runs (e.g. retried webhooks, accidental double-clicks):
+```python
+from pipelines.clothing_3d import IdempotencyCache
+
+cache = IdempotencyCache(ttl_seconds=86_400)
+result, was_cache_hit = await cache.get_or_run(req, runner=pipeline.run)
+```
+- Keys: SHA-256 of input image bytes + prompt + product/collection/quality.
+- Failures never cached. Only `SUCCEEDED` results are kept.
+- Swap the in-memory store for a shared `RedisIdempotencyStore` to share
+  hits across workers.
+
+### Cost quota
+Stop runaway spend on paid backends:
+```python
+from pipelines.clothing_3d import CostQuota
+
+quota = CostQuota(caps_usd={"replicate": 50.00, "modal": 200.00})
+quota.charge("replicate")  # raises QuotaExceededError when cap hit
+```
+Window resets every 24h by default. The worker calls `charge()` before
+dispatching, so a hot SKU can't drain the monthly budget in an hour.
+
+## Observability
+
+Every component emits structured events:
+
+| Event name             | Payload keys                                  |
+|------------------------|-----------------------------------------------|
+| `pipeline.started`     | (just `correlation_id`)                       |
+| `stage.started`        | `stage`                                       |
+| `stage.finished`       | `stage`, stage `detail`                       |
+| `pipeline.rejected`    | `issues`, `score`                             |
+| `pipeline.failed`      | `error`                                       |
+| `pipeline.succeeded`   | `artifact_id`, `glb_url`, `duration`          |
+
+### Prometheus metrics
+Exposed at `GET /v1/clothing-3d/metrics`:
+
+| Metric (with `clothing_3d_` namespace prefix) | Type | Labels |
+|---|---|---|
+| `runs_total` | counter | `status` · `backend` |
+| `run_duration_seconds` | histogram | `status` · `backend` |
+| `stage_duration_seconds` | histogram | `stage` |
+| `stage_failures_total` | counter | `stage` |
+| `queue_depth` | gauge | — |
+| `backend_cost_usd_total` | counter | `backend` |
+| `cache_total` | counter | `outcome` (`hit` \| `miss`) |
+
+Alerting recipes:
+- **High failure rate**: `sum(rate(clothing_3d_runs_total{status="failed"}[5m])) / sum(rate(clothing_3d_runs_total[5m])) > 0.05`
+- **Backlog growing**: `clothing_3d_queue_depth > 50` for 10m
+- **p95 latency regression**: `histogram_quantile(0.95, rate(clothing_3d_run_duration_seconds_bucket[5m])) > 90`
+- **Spend overflow**: `increase(clothing_3d_backend_cost_usd_total{backend="replicate"}[1h]) > 5`
+
+### Structured logging
+Every record is a JSON object with `ts`, `level`, `logger`, `msg`, plus
+arbitrary `extra={...}` keys. Auto-enabled when stdout isn't a TTY
+(Docker, k8s, systemd).
+
+## Deployment
+
+### Docker Compose (single host)
+
+```bash
+# Build the worker image
+docker build -f deploy/clothing_3d/Dockerfile -t devskyy/clothing-3d-worker:latest .
+
+# Start API + 2× worker + Redis
+docker compose -f deploy/clothing_3d/docker-compose.yml up -d
+```
+
+Scale workers without restarting the API:
+```bash
+docker compose -f deploy/clothing_3d/docker-compose.yml \
+  up -d --scale clothing-3d-worker=8
+```
+
+### Kubernetes
+
+```bash
+# One-time: create the secrets the manifest expects
+kubectl create secret generic clothing-3d-secrets \
+  --from-literal=REDIS_URL=redis://redis.default.svc:6379/0 \
+  --from-literal=REPLICATE_API_TOKEN=$REPLICATE_API_TOKEN \
+  --from-literal=HUGGINGFACE_TOKEN=$HUGGINGFACE_TOKEN
+
+# Apply manifests
+kubectl apply -f deploy/clothing_3d/k8s.yaml
+```
+
+HPA scales 2 → 12 replicas based on CPU + queue depth. Tune
+`averageValue` on the `clothing_3d_queue_depth_per_pod` metric for your
+desired backlog tolerance.
+
+## Smoke testing
+
+Drop into CI:
+```bash
+bash scripts/smoke_test_clothing_3d.sh
+```
+
+Exercises imports, garment classifier, full pipeline, idempotency cache,
+cost quota, retry policy, and a worker-round-trip — all against the Stub
+backend in <5 s with no network, GPU, or paid credits.
+
+## Operations runbook
+
+### Symptom → action
+
+| Symptom | First investigation | Likely cause |
+|---|---|---|
+| `/ready` returning 503 | Check Redis: `redis-cli -u $REDIS_URL ping` | Redis unreachable |
+| Workers stuck `running` | Compare `started_at` to now in `/v1/clothing-3d/jobs` | Worker crashed before ACK — Redis Streams will reclaim after `reclaim_idle_ms`; manually `xautoclaim` if urgent |
+| `quota exceeded` errors | `GET /v1/clothing-3d/info` → cost snapshot | Bump cap or switch backend |
+| HF Space cold starts | Check provider `latency_ms` in `/health` | Pre-warm with a synthetic request every 5 min |
+| `queue_depth` growing | `kubectl scale deploy/clothing-3d-worker --replicas=N` | Demand spike — HPA should already be scaling |
+
+### Graceful shutdown
+
+The worker installs `SIGINT` / `SIGTERM` handlers. On signal, it stops
+pulling new messages and waits up to `terminationGracePeriodSeconds: 60`
+(see k8s.yaml) for in-flight jobs to drain. Unfinished jobs land back on
+the stream and another worker picks them up.
+
+### Killswitch
+
+Stop dispatching to a specific backend without redeploying:
+```bash
+kubectl set env deployment/clothing-3d-worker TRELLIS_BACKEND=stub
+```
+Workers will run with the stub (artifacts marked failed by QC), giving
+you a clean way to halt spend while debugging.

--- a/pipelines/__init__.py
+++ b/pipelines/__init__.py
@@ -1,0 +1,9 @@
+"""Cross-service orchestration pipelines.
+
+Each submodule packages a multi-stage workflow that composes services from
+``services/``, ``agents/``, and ``llm/`` into a single end-to-end operation.
+
+Currently shipped:
+- :mod:`pipelines.clothing_3d` — image/text → preprocessed → TRELLIS →
+  postprocessed GLB/USDZ → stored artifact, with QC gates and event emission.
+"""

--- a/pipelines/clothing_3d/__init__.py
+++ b/pipelines/clothing_3d/__init__.py
@@ -1,0 +1,62 @@
+"""Clothing 3D pipeline.
+
+End-to-end orchestration around the
+:class:`~services.three_d.trellis.provider.TrellisProvider`. Coordinates:
+
+1. Ingestion + validation (:func:`pipelines.clothing_3d.stages.ingest`)
+2. Preprocessing
+3. TRELLIS generation
+4. Postprocessing (mesh cleanup, USDZ, thumbnail)
+5. Quality gate
+6. Artifact storage
+7. Event emission
+
+Entry point:
+
+.. code-block:: python
+
+    from pipelines.clothing_3d import ClothingPipeline, PipelineRequest
+
+    pipeline = ClothingPipeline()
+    result = await pipeline.run(
+        PipelineRequest(
+            image_url="https://...",
+            product_name="Black Rose Hoodie",
+            collection="black_rose",
+            garment_type="hoodie",
+        )
+    )
+"""
+
+from __future__ import annotations
+
+from pipelines.clothing_3d.events import PipelineEvent, PipelineEventBus
+from pipelines.clothing_3d.models import (
+    PipelineQualityReport,
+    PipelineRequest,
+    PipelineResult,
+    PipelineStage,
+    PipelineStatus,
+    StageReport,
+)
+from pipelines.clothing_3d.pipeline import ClothingPipeline
+from pipelines.clothing_3d.storage import (
+    ArtifactBundle,
+    ArtifactStore,
+    LocalArtifactStore,
+)
+
+__all__ = [
+    "ArtifactBundle",
+    "ArtifactStore",
+    "ClothingPipeline",
+    "LocalArtifactStore",
+    "PipelineEvent",
+    "PipelineEventBus",
+    "PipelineQualityReport",
+    "PipelineRequest",
+    "PipelineResult",
+    "PipelineStage",
+    "PipelineStatus",
+    "StageReport",
+]

--- a/pipelines/clothing_3d/__init__.py
+++ b/pipelines/clothing_3d/__init__.py
@@ -31,6 +31,13 @@ Entry point:
 from __future__ import annotations
 
 from pipelines.clothing_3d.events import PipelineEvent, PipelineEventBus
+from pipelines.clothing_3d.job_store import (
+    InMemoryJobStore,
+    JobRecord,
+    JobStore,
+    RedisJobStore,
+    build_job_store,
+)
 from pipelines.clothing_3d.models import (
     PipelineQualityReport,
     PipelineRequest,
@@ -39,24 +46,71 @@ from pipelines.clothing_3d.models import (
     PipelineStatus,
     StageReport,
 )
+from pipelines.clothing_3d.observability import (
+    PipelineMetrics,
+    configure_logging,
+    get_metrics,
+    metrics_event_subscriber,
+    render_metrics,
+)
 from pipelines.clothing_3d.pipeline import ClothingPipeline
+from pipelines.clothing_3d.queue import (
+    InMemoryQueue,
+    JobQueue,
+    QueueMessage,
+    RedisStreamsQueue,
+    build_queue,
+)
+from pipelines.clothing_3d.reliability import (
+    CostQuota,
+    IdempotencyCache,
+    IdempotencyStore,
+    InMemoryIdempotencyStore,
+    QuotaExceededError,
+    RetryPolicy,
+    request_fingerprint,
+)
 from pipelines.clothing_3d.storage import (
     ArtifactBundle,
     ArtifactStore,
     LocalArtifactStore,
 )
+from pipelines.clothing_3d.worker import PipelineWorker
 
 __all__ = [
     "ArtifactBundle",
     "ArtifactStore",
     "ClothingPipeline",
+    "CostQuota",
+    "IdempotencyCache",
+    "IdempotencyStore",
+    "InMemoryIdempotencyStore",
+    "InMemoryJobStore",
+    "InMemoryQueue",
+    "JobQueue",
+    "JobRecord",
+    "JobStore",
     "LocalArtifactStore",
     "PipelineEvent",
     "PipelineEventBus",
+    "PipelineMetrics",
     "PipelineQualityReport",
     "PipelineRequest",
     "PipelineResult",
     "PipelineStage",
     "PipelineStatus",
+    "PipelineWorker",
+    "QueueMessage",
+    "QuotaExceededError",
+    "RedisJobStore",
+    "RedisStreamsQueue",
+    "RetryPolicy",
     "StageReport",
+    "build_job_store",
+    "build_queue",
+    "configure_logging",
+    "get_metrics",
+    "metrics_event_subscriber",
+    "render_metrics",
+    "request_fingerprint",
 ]

--- a/pipelines/clothing_3d/cli.py
+++ b/pipelines/clothing_3d/cli.py
@@ -1,0 +1,250 @@
+"""CLI entry point for the clothing 3D pipeline.
+
+Usage:
+    python -m pipelines.clothing_3d.cli generate \\
+        --image path/to/hoodie.jpg \\
+        --product "Black Rose Hoodie" \\
+        --collection black_rose \\
+        --garment-type hoodie \\
+        --quality production
+
+    python -m pipelines.clothing_3d.cli generate \\
+        --prompt "luxury silver chrome bomber jacket" \\
+        --collection black_rose \\
+        --quality standard
+
+    python -m pipelines.clothing_3d.cli batch ./catalog.jsonl
+
+    python -m pipelines.clothing_3d.cli health
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from pipelines.clothing_3d.models import (
+    PipelineRequest,
+    PipelineStatus,
+)
+from pipelines.clothing_3d.pipeline import ClothingPipeline, run_clothing_pipeline
+from services.three_d.trellis.config import (
+    TrellisBackend,
+    TrellisConfig,
+    TrellisQualityPreset,
+)
+from services.three_d.trellis.provider import TrellisProvider, make_stub_provider
+
+logger = logging.getLogger("clothing_3d.cli")
+
+
+# =============================================================================
+# Parser
+# =============================================================================
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="clothing_3d",
+        description="End-to-end TRELLIS-backed clothing 3D pipeline.",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # generate -------------------------------------------------------------
+    gen = sub.add_parser("generate", help="Generate a single 3D model")
+    src = gen.add_mutually_exclusive_group(required=True)
+    src.add_argument("--image", help="Local image path", default=None)
+    src.add_argument("--image-url", help="Public image URL", default=None)
+    src.add_argument("--prompt", help="Text prompt", default=None)
+    gen.add_argument("--product", help="Product name", default=None)
+    gen.add_argument("--sku", help="Product SKU", default=None)
+    gen.add_argument("--collection", default=None)
+    gen.add_argument("--garment-type", default=None)
+    gen.add_argument(
+        "--quality",
+        choices=[q.value for q in TrellisQualityPreset],
+        default=TrellisQualityPreset.STANDARD.value,
+    )
+    gen.add_argument(
+        "--backend",
+        choices=[b.value for b in TrellisBackend],
+        default=None,
+        help="Force a TRELLIS backend",
+    )
+    gen.add_argument("--dry-run", action="store_true", help="Use the stub backend")
+    gen.add_argument("--skip-qc", action="store_true")
+    gen.add_argument("--out", help="Where to write the JSON result", default=None)
+
+    # batch ----------------------------------------------------------------
+    batch = sub.add_parser("batch", help="Process a JSONL of requests")
+    batch.add_argument("jsonl", help="Path to JSONL with one PipelineRequest per line")
+    batch.add_argument(
+        "--quality",
+        choices=[q.value for q in TrellisQualityPreset],
+        default=TrellisQualityPreset.STANDARD.value,
+    )
+    batch.add_argument("--max-concurrent", type=int, default=2)
+    batch.add_argument("--out", help="Where to write results JSONL", default="-")
+    batch.add_argument("--dry-run", action="store_true")
+
+    # health ---------------------------------------------------------------
+    sub.add_parser("health", help="Run provider health check")
+
+    return parser
+
+
+# =============================================================================
+# Commands
+# =============================================================================
+
+
+async def cmd_generate(args: argparse.Namespace) -> int:
+    config = _build_config(args)
+    provider = _build_provider(config, dry_run=args.dry_run)
+    pipeline = ClothingPipeline(config=config, provider=provider)
+
+    try:
+        request = PipelineRequest(
+            image_path=args.image,
+            image_url=args.image_url,
+            prompt=args.prompt,
+            product_name=args.product,
+            product_sku=args.sku,
+            collection=args.collection,
+            garment_type=args.garment_type,
+            quality=TrellisQualityPreset(args.quality),
+            skip_qc=args.skip_qc,
+        )
+        result = await pipeline.run(request)
+    finally:
+        await pipeline.close()
+
+    payload = result.model_dump(mode="json")
+    _emit_result(payload, args.out)
+    return 0 if result.status == PipelineStatus.SUCCEEDED else 1
+
+
+async def cmd_batch(args: argparse.Namespace) -> int:
+    config = _build_config(args)
+    provider = _build_provider(config, dry_run=args.dry_run)
+    pipeline = ClothingPipeline(config=config, provider=provider)
+
+    sem = asyncio.Semaphore(max(1, args.max_concurrent))
+    requests = _load_jsonl(args.jsonl, default_quality=args.quality)
+    results: list[dict[str, Any]] = []
+
+    async def _one(req: PipelineRequest) -> None:
+        async with sem:
+            res = await pipeline.run(req)
+            results.append(res.model_dump(mode="json"))
+
+    try:
+        await asyncio.gather(*(_one(r) for r in requests))
+    finally:
+        await pipeline.close()
+
+    if args.out == "-":
+        for r in results:
+            print(json.dumps(r, default=str))
+    else:
+        Path(args.out).write_text(
+            "\n".join(json.dumps(r, default=str) for r in results) + "\n",
+            encoding="utf-8",
+        )
+
+    failed = sum(1 for r in results if r["status"] != "succeeded")
+    logger.info("batch complete: %d ok, %d failed", len(results) - failed, failed)
+    return 0 if failed == 0 else 1
+
+
+async def cmd_health(_args: argparse.Namespace) -> int:
+    config = TrellisConfig.from_env()
+    provider = TrellisProvider(config)
+    try:
+        health = await provider.health_check()
+    finally:
+        await provider.close()
+
+    print(json.dumps(health.model_dump(mode="json"), indent=2, default=str))
+    return 0 if health.is_available else 1
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _build_config(args: argparse.Namespace) -> TrellisConfig:
+    config = TrellisConfig.from_env()
+    config.quality = TrellisQualityPreset(getattr(args, "quality", config.quality.value))
+    backend = getattr(args, "backend", None)
+    if backend:
+        config.backend = TrellisBackend(backend)
+    config.ensure_dirs()
+    return config
+
+
+def _build_provider(config: TrellisConfig, *, dry_run: bool) -> TrellisProvider:
+    if dry_run or os.getenv("TRELLIS_DRY_RUN") == "1":
+        logger.info("dry-run: using stub backend")
+        return make_stub_provider(config)
+    return TrellisProvider(config)
+
+
+def _load_jsonl(path: str, *, default_quality: str) -> list[PipelineRequest]:
+    requests: list[PipelineRequest] = []
+    text = Path(path).read_text(encoding="utf-8")
+    for line_no, raw in enumerate(text.splitlines(), start=1):
+        raw = raw.strip()
+        if not raw or raw.startswith("#"):
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"{path}:{line_no} invalid JSON — {exc}") from exc
+        payload.setdefault("quality", default_quality)
+        requests.append(PipelineRequest.model_validate(payload))
+    return requests
+
+
+def _emit_result(payload: dict[str, Any], out: str | None) -> None:
+    text = json.dumps(payload, indent=2, default=str)
+    if not out or out == "-":
+        print(text)
+    else:
+        Path(out).write_text(text + "\n", encoding="utf-8")
+
+
+# =============================================================================
+# Entry
+# =============================================================================
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    coro_map = {
+        "generate": cmd_generate,
+        "batch": cmd_batch,
+        "health": cmd_health,
+    }
+    coro = coro_map[args.command]
+    return asyncio.run(coro(args))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/pipelines/clothing_3d/events.py
+++ b/pipelines/clothing_3d/events.py
@@ -1,0 +1,157 @@
+"""Pipeline event bus.
+
+Pipelines emit structured events at each stage boundary so external systems
+(metrics, audit logs, webhooks, dashboards, the elite studio approval queue)
+can react without coupling to the pipeline internals.
+
+The bus is intentionally tiny: a list of async subscribers, no broker. For
+cross-process delivery, plug a webhook subscriber that forwards to the
+existing :mod:`api.webhooks` infrastructure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from pipelines.clothing_3d.models import PipelineStage, PipelineStatus
+
+logger = logging.getLogger(__name__)
+
+Subscriber = Callable[["PipelineEvent"], Awaitable[None]]
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineEvent:
+    """Event emitted by the pipeline.
+
+    Use :attr:`stage` for stage boundaries (``stage_started`` / ``stage_finished``)
+    and :attr:`status` for overall pipeline state transitions.
+    """
+
+    correlation_id: str
+    timestamp: datetime
+    name: str
+    stage: PipelineStage | None = None
+    status: PipelineStatus | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+class PipelineEventBus:
+    """In-process pub/sub for pipeline events.
+
+    Subscribers are called concurrently for each event; one failing subscriber
+    does not block the others. Subscriber exceptions are logged but never
+    propagate.
+    """
+
+    def __init__(self) -> None:
+        self._subscribers: list[Subscriber] = []
+
+    def subscribe(self, sub: Subscriber) -> None:
+        self._subscribers.append(sub)
+
+    def unsubscribe(self, sub: Subscriber) -> None:
+        try:
+            self._subscribers.remove(sub)
+        except ValueError:
+            pass
+
+    async def emit(
+        self,
+        *,
+        correlation_id: str,
+        name: str,
+        stage: PipelineStage | None = None,
+        status: PipelineStatus | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        if not self._subscribers:
+            return
+
+        event = PipelineEvent(
+            correlation_id=correlation_id,
+            timestamp=datetime.now(UTC),
+            name=name,
+            stage=stage,
+            status=status,
+            payload=payload or {},
+        )
+
+        results = await asyncio.gather(
+            *(self._safe_invoke(sub, event) for sub in self._subscribers),
+            return_exceptions=False,
+        )
+        del results  # silence linters
+
+    async def _safe_invoke(self, sub: Subscriber, event: PipelineEvent) -> None:
+        try:
+            await sub(event)
+        except Exception:  # noqa: BLE001 — subscriber errors must not bubble
+            logger.exception("Pipeline event subscriber failed for event %s", event.name)
+
+
+# =============================================================================
+# Built-in subscribers
+# =============================================================================
+
+
+def log_event_subscriber(level: int = logging.INFO) -> Subscriber:
+    """Subscriber that just logs each event — useful as a default."""
+
+    async def _sub(event: PipelineEvent) -> None:
+        logger.log(
+            level,
+            "pipeline.event name=%s stage=%s status=%s corr=%s",
+            event.name,
+            event.stage.value if event.stage else "",
+            event.status.value if event.status else "",
+            event.correlation_id,
+        )
+
+    return _sub
+
+
+def webhook_subscriber(
+    url: str,
+    *,
+    timeout_seconds: float = 5.0,
+) -> Subscriber:
+    """Subscriber that POSTs each event to ``url``.
+
+    Uses :mod:`httpx` if installed; silently no-ops otherwise so the pipeline
+    doesn't fail just because httpx is missing in a slim environment.
+    """
+
+    async def _sub(event: PipelineEvent) -> None:
+        try:
+            import httpx
+        except ImportError:
+            logger.debug("httpx not installed; skipping webhook %s", url)
+            return
+
+        payload = {
+            "correlation_id": event.correlation_id,
+            "timestamp": event.timestamp.isoformat(),
+            "name": event.name,
+            "stage": event.stage.value if event.stage else None,
+            "status": event.status.value if event.status else None,
+            "payload": event.payload,
+        }
+        async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+            await client.post(url, json=payload)
+
+    return _sub
+
+
+__all__ = [
+    "PipelineEvent",
+    "PipelineEventBus",
+    "Subscriber",
+    "log_event_subscriber",
+    "webhook_subscriber",
+]

--- a/pipelines/clothing_3d/job_store.py
+++ b/pipelines/clothing_3d/job_store.py
@@ -1,0 +1,303 @@
+"""Persistent job state for the clothing 3D pipeline.
+
+A single :class:`JobStore` interface backed by either an in-memory dict
+(dev / tests) or Redis (prod). The store survives worker restarts when
+Redis-backed, so the ``/v1/clothing-3d/jobs/{id}`` endpoint can return
+state even after the API replica that received the submission has died.
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections.abc import AsyncIterator
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Protocol, runtime_checkable
+
+from pipelines.clothing_3d.models import (
+    PipelineRequest,
+    PipelineResult,
+    PipelineStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Job record
+# =============================================================================
+
+
+@dataclass(slots=True)
+class JobRecord:
+    """Persisted state for one pipeline submission.
+
+    Attributes:
+        job_id: External identifier returned to the caller.
+        status: Pipeline status — flows ``queued → running → succeeded |
+            failed | rejected``.
+        request: The original request (used by the worker to actually run).
+        result: Set once the run terminates.
+        error: String error if the run failed outside the pipeline (e.g.
+            worker crash).
+        submitted_at: Wall-clock submission time.
+        started_at: When the worker picked up the job.
+        finished_at: When the worker emitted the result.
+        attempt: 1-indexed retry counter (incremented per retry).
+        worker_id: Identifier of the worker that processed the job.
+        idempotency_key: Optional caller-supplied dedupe key (echoed back).
+    """
+
+    job_id: str
+    status: PipelineStatus = PipelineStatus.PENDING
+    request: PipelineRequest | None = None
+    result: PipelineResult | None = None
+    error: str | None = None
+    submitted_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    attempt: int = 0
+    worker_id: str | None = None
+    idempotency_key: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["status"] = self.status.value
+        payload["submitted_at"] = self.submitted_at.isoformat()
+        payload["started_at"] = self.started_at.isoformat() if self.started_at else None
+        payload["finished_at"] = self.finished_at.isoformat() if self.finished_at else None
+        if self.request is not None:
+            payload["request"] = self.request.model_dump(mode="json")
+        if self.result is not None:
+            payload["result"] = self.result.model_dump(mode="json")
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> JobRecord:
+        return cls(
+            job_id=payload["job_id"],
+            status=PipelineStatus(payload["status"]),
+            request=(
+                PipelineRequest.model_validate(payload["request"])
+                if payload.get("request")
+                else None
+            ),
+            result=(
+                PipelineResult.model_validate(payload["result"])
+                if payload.get("result")
+                else None
+            ),
+            error=payload.get("error"),
+            submitted_at=datetime.fromisoformat(payload["submitted_at"]),
+            started_at=(
+                datetime.fromisoformat(payload["started_at"])
+                if payload.get("started_at")
+                else None
+            ),
+            finished_at=(
+                datetime.fromisoformat(payload["finished_at"])
+                if payload.get("finished_at")
+                else None
+            ),
+            attempt=payload.get("attempt", 0),
+            worker_id=payload.get("worker_id"),
+            idempotency_key=payload.get("idempotency_key"),
+        )
+
+
+# =============================================================================
+# Protocol
+# =============================================================================
+
+
+@runtime_checkable
+class JobStore(Protocol):
+    """Async key-value store of :class:`JobRecord`."""
+
+    async def put(self, job: JobRecord) -> None: ...
+
+    async def get(self, job_id: str) -> JobRecord | None: ...
+
+    async def update(self, job: JobRecord) -> None: ...
+
+    async def list(self, *, limit: int = 100) -> list[JobRecord]: ...
+
+    async def close(self) -> None: ...
+
+
+# =============================================================================
+# In-memory implementation
+# =============================================================================
+
+
+class InMemoryJobStore:
+    """Single-process job store. Used in dev, tests, and as the default for the API."""
+
+    def __init__(self, *, capacity: int = 1024) -> None:
+        self._jobs: dict[str, JobRecord] = {}
+        self._capacity = capacity
+        self._lock = asyncio.Lock()
+
+    async def put(self, job: JobRecord) -> None:
+        async with self._lock:
+            if len(self._jobs) >= self._capacity and job.job_id not in self._jobs:
+                # FIFO eviction by submission time
+                oldest = min(self._jobs, key=lambda k: self._jobs[k].submitted_at)
+                self._jobs.pop(oldest, None)
+            self._jobs[job.job_id] = job
+
+    async def get(self, job_id: str) -> JobRecord | None:
+        async with self._lock:
+            return self._jobs.get(job_id)
+
+    async def update(self, job: JobRecord) -> None:
+        await self.put(job)
+
+    async def list(self, *, limit: int = 100) -> list[JobRecord]:
+        async with self._lock:
+            return sorted(
+                self._jobs.values(),
+                key=lambda j: j.submitted_at,
+                reverse=True,
+            )[:limit]
+
+    async def close(self) -> None:
+        self._jobs.clear()
+
+
+# =============================================================================
+# Redis implementation
+# =============================================================================
+
+
+class RedisJobStore:
+    """Redis-backed job store. Use for multi-worker deployments.
+
+    Schema:
+        - One Redis key per job: ``{prefix}:job:{job_id}`` (string with JSON value)
+        - A sorted set ``{prefix}:jobs`` for chronological listing
+            (score = submitted_at unix timestamp)
+
+    Both keys auto-expire via ``ttl_seconds`` so stale jobs don't accrue.
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str | None = None,
+        prefix: str = "clothing3d",
+        ttl_seconds: int = 7 * 24 * 3600,
+    ) -> None:
+        self._url = url or os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        self._prefix = prefix
+        self._ttl = ttl_seconds
+        self._client: Any = None
+        self._lock = asyncio.Lock()
+
+    async def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        async with self._lock:
+            if self._client is not None:
+                return self._client
+            try:
+                import redis.asyncio as redis  # type: ignore[import-not-found]
+            except ImportError as e:
+                raise RuntimeError("RedisJobStore requires `redis>=5` — pip install redis") from e
+            self._client = redis.from_url(self._url, decode_responses=True)
+            return self._client
+
+    def _key(self, job_id: str) -> str:
+        return f"{self._prefix}:job:{job_id}"
+
+    @property
+    def _index_key(self) -> str:
+        return f"{self._prefix}:jobs"
+
+    async def put(self, job: JobRecord) -> None:
+        client = await self._get_client()
+        payload = json.dumps(job.to_dict(), default=str)
+        pipe = client.pipeline()
+        pipe.set(self._key(job.job_id), payload, ex=self._ttl)
+        pipe.zadd(self._index_key, {job.job_id: job.submitted_at.timestamp()})
+        await pipe.execute()
+
+    async def get(self, job_id: str) -> JobRecord | None:
+        client = await self._get_client()
+        raw = await client.get(self._key(job_id))
+        if not raw:
+            return None
+        return JobRecord.from_dict(json.loads(raw))
+
+    async def update(self, job: JobRecord) -> None:
+        await self.put(job)
+
+    async def list(self, *, limit: int = 100) -> list[JobRecord]:
+        client = await self._get_client()
+        ids = await client.zrevrange(self._index_key, 0, limit - 1)
+        if not ids:
+            return []
+        raw_payloads = await client.mget(*[self._key(i) for i in ids])
+        out: list[JobRecord] = []
+        for raw in raw_payloads:
+            if raw:
+                out.append(JobRecord.from_dict(json.loads(raw)))
+        return out
+
+    async def stream_updates(
+        self,
+        *,
+        interval_seconds: float = 1.0,
+    ) -> AsyncIterator[JobRecord]:
+        """Poll-based stream of recent job updates. Useful for dashboards."""
+        last_seen: dict[str, datetime | None] = {}
+        while True:
+            jobs = await self.list(limit=50)
+            for j in jobs:
+                fp = j.finished_at or j.started_at or j.submitted_at
+                if last_seen.get(j.job_id) != fp:
+                    last_seen[j.job_id] = fp
+                    yield j
+            await asyncio.sleep(interval_seconds)
+
+    async def close(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            except AttributeError:  # older redis-py
+                await self._client.close()
+            self._client = None
+
+
+# =============================================================================
+# Factory
+# =============================================================================
+
+
+def build_job_store() -> JobStore:
+    """Pick the right store based on environment.
+
+    ``REDIS_URL`` set → :class:`RedisJobStore`, else :class:`InMemoryJobStore`.
+    Override explicitly via ``CLOTHING_3D_JOB_STORE`` (``memory`` | ``redis``).
+    """
+    backend = os.getenv("CLOTHING_3D_JOB_STORE")
+    if backend == "memory":
+        return InMemoryJobStore()
+    if backend == "redis" or os.getenv("REDIS_URL"):
+        return RedisJobStore()
+    return InMemoryJobStore()
+
+
+__all__ = [
+    "InMemoryJobStore",
+    "JobRecord",
+    "JobStore",
+    "RedisJobStore",
+    "build_job_store",
+]

--- a/pipelines/clothing_3d/job_store.py
+++ b/pipelines/clothing_3d/job_store.py
@@ -168,7 +168,16 @@ class InMemoryJobStore:
             )[:limit]
 
     async def close(self) -> None:
-        self._jobs.clear()
+        """No-op. The dict is shared across the API and worker; clearing it
+        here would orphan in-flight jobs whose owners outlive ``close()``.
+        Use :meth:`reset` explicitly when you want to discard state (tests).
+        """
+        return
+
+    async def reset(self) -> None:
+        """Discard all jobs. Tests only — never call in production."""
+        async with self._lock:
+            self._jobs.clear()
 
 
 # =============================================================================

--- a/pipelines/clothing_3d/models.py
+++ b/pipelines/clothing_3d/models.py
@@ -1,0 +1,154 @@
+"""Pydantic models for the clothing 3D pipeline."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from services.three_d.trellis.config import TrellisBackend, TrellisQualityPreset
+
+
+# =============================================================================
+# Enums
+# =============================================================================
+
+
+class PipelineStage(StrEnum):
+    """Discrete pipeline stages — order matters."""
+
+    INGEST = "ingest"
+    PREPROCESS = "preprocess"
+    GENERATE = "generate"
+    POSTPROCESS = "postprocess"
+    QC = "qc"
+    STORE = "store"
+
+
+class PipelineStatus(StrEnum):
+    """Terminal & intermediate pipeline statuses."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    REJECTED = "rejected"  # passed generation but failed QC
+
+
+# =============================================================================
+# Request / response
+# =============================================================================
+
+
+class PipelineRequest(BaseModel):
+    """Public input contract for the clothing pipeline.
+
+    Provide one of ``image_url`` / ``image_path`` / ``prompt``. All other fields
+    are optional but improve output fidelity.
+    """
+
+    # Input — one of (image* OR prompt)
+    image_url: str | None = Field(default=None)
+    image_path: str | None = Field(default=None)
+    prompt: str | None = Field(
+        default=None,
+        description="Free-form description; required when no image is provided.",
+    )
+
+    # Garment / catalog metadata
+    product_name: str | None = Field(default=None)
+    product_sku: str | None = Field(default=None)
+    collection: str | None = Field(default=None)
+    garment_type: str | None = Field(default=None)
+
+    # Pipeline switches
+    quality: TrellisQualityPreset = TrellisQualityPreset.STANDARD
+    backend: TrellisBackend | None = Field(
+        default=None,
+        description="Force a TRELLIS backend; defaults to config.",
+    )
+    skip_qc: bool = False
+    callback_url: str | None = Field(default=None)
+
+    # Tracing
+    correlation_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _at_least_one_input(self) -> PipelineRequest:
+        if not (self.image_url or self.image_path or self.prompt):
+            raise ValueError("PipelineRequest requires image_url, image_path, or prompt")
+        return self
+
+    @property
+    def has_image(self) -> bool:
+        return bool(self.image_url or self.image_path)
+
+
+# =============================================================================
+# Reports
+# =============================================================================
+
+
+class StageReport(BaseModel):
+    """Per-stage execution report (success or failure)."""
+
+    stage: PipelineStage
+    started_at: datetime
+    finished_at: datetime
+    success: bool
+    duration_seconds: float
+    detail: dict[str, Any] = Field(default_factory=dict)
+    error: str | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class PipelineQualityReport(BaseModel):
+    """Quality-gate verdict + supporting metrics."""
+
+    accepted: bool
+    score: float
+    polycount: int | None = None
+    file_size_kb: int | None = None
+    texture_size: int | None = None
+    issues: list[str] = Field(default_factory=list)
+
+
+class PipelineResult(BaseModel):
+    """Final pipeline output returned to callers."""
+
+    status: PipelineStatus
+    artifact_id: str
+    correlation_id: str
+
+    # Primary output
+    glb_url: str | None = None
+    glb_path: str | None = None
+    usdz_url: str | None = None
+    usdz_path: str | None = None
+    thumbnail_url: str | None = None
+
+    # Diagnostics
+    garment_category: str | None = None
+    quality: PipelineQualityReport | None = None
+    stages: list[StageReport] = Field(default_factory=list)
+    total_duration_seconds: float = 0.0
+
+    # Free-form metadata for downstream tools (web viewer, AR, analytics)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def succeeded(self) -> bool:
+        return self.status == PipelineStatus.SUCCEEDED
+
+
+__all__ = [
+    "PipelineStage",
+    "PipelineStatus",
+    "PipelineRequest",
+    "StageReport",
+    "PipelineQualityReport",
+    "PipelineResult",
+]

--- a/pipelines/clothing_3d/observability.py
+++ b/pipelines/clothing_3d/observability.py
@@ -1,0 +1,286 @@
+"""Observability — structured logging + Prometheus metrics.
+
+Three concrete deliverables:
+
+1. :func:`configure_logging` — JSON-formatted stdlib logger that includes
+   correlation IDs on every record. Idempotent; safe to call repeatedly.
+2. :class:`PipelineMetrics` — Prometheus counters/histograms for the
+   pipeline. Exposed via :func:`render_metrics` which returns the
+   text/plain payload for ``/metrics`` endpoints.
+3. :func:`metrics_event_subscriber` — drop-in subscriber for
+   :class:`PipelineEventBus` that wires pipeline events into the metrics.
+
+All Prometheus imports are lazy so the module loads with a friendly fallback
+(no-op metric impls) when ``prometheus_client`` isn't installed.
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import logging.config
+import os
+import sys
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from pipelines.clothing_3d.events import PipelineEvent
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+
+class _JsonFormatter(logging.Formatter):
+    """Minimal JSON log formatter — one JSON object per line."""
+
+    _RESERVED = {
+        "name", "msg", "args", "levelname", "levelno", "pathname", "filename",
+        "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName",
+        "created", "msecs", "relativeCreated", "thread", "threadName",
+        "processName", "process", "message", "asctime",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "ts": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+
+        # Surface any custom kwargs (logger.info(msg, extra={...}))
+        for key, value in record.__dict__.items():
+            if key not in self._RESERVED and not key.startswith("_"):
+                try:
+                    json.dumps(value)
+                    payload[key] = value
+                except (TypeError, ValueError):
+                    payload[key] = repr(value)
+
+        return json.dumps(payload, separators=(",", ":"), default=str)
+
+
+def configure_logging(
+    *,
+    level: str | int = "INFO",
+    json_format: bool | None = None,
+) -> None:
+    """Install the JSON formatter on the root logger.
+
+    Args:
+        level: Stdlib log level (string or int).
+        json_format: Force JSON ``True``/``False``. ``None`` → JSON when stdout
+            isn't a TTY (i.e. running under k8s / systemd / Docker).
+    """
+    if json_format is None:
+        json_format = not sys.stdout.isatty()
+
+    root = logging.getLogger()
+    # Idempotency: clear our own handlers, leave others alone.
+    for h in list(root.handlers):
+        if getattr(h, "_clothing_3d_owned", False):
+            root.removeHandler(h)
+
+    handler = logging.StreamHandler(sys.stdout)
+    if json_format:
+        handler.setFormatter(_JsonFormatter())
+    else:
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+        )
+    handler._clothing_3d_owned = True  # type: ignore[attr-defined]
+    root.addHandler(handler)
+    root.setLevel(level)
+
+
+# =============================================================================
+# Prometheus metrics
+# =============================================================================
+
+
+class _NoopMetric:
+    """Stand-in when prometheus_client isn't installed."""
+
+    def labels(self, *_args: Any, **_kw: Any) -> _NoopMetric:
+        return self
+
+    def inc(self, *_args: Any, **_kw: Any) -> None:
+        pass
+
+    def observe(self, *_args: Any, **_kw: Any) -> None:
+        pass
+
+    def set(self, *_args: Any, **_kw: Any) -> None:
+        pass
+
+
+class PipelineMetrics:
+    """Prometheus metrics for the clothing 3D pipeline.
+
+    Each instance owns its own metric registrations, so multiple test runs in
+    one process don't trip the "duplicated timeseries" guard. In production,
+    use the singleton :func:`get_metrics`.
+    """
+
+    def __init__(self, *, namespace: str = "clothing_3d") -> None:
+        self.namespace = namespace
+        try:
+            from prometheus_client import (  # type: ignore[import-not-found]
+                CollectorRegistry,
+                Counter,
+                Gauge,
+                Histogram,
+            )
+        except ImportError:
+            self._registry = None
+            self.runs_total = _NoopMetric()
+            self.run_duration_seconds = _NoopMetric()
+            self.stage_duration_seconds = _NoopMetric()
+            self.stage_failures_total = _NoopMetric()
+            self.queue_depth = _NoopMetric()
+            self.backend_cost_usd = _NoopMetric()
+            self.cache_total = _NoopMetric()
+            return
+
+        self._registry = CollectorRegistry()
+        self.runs_total = Counter(
+            "runs_total",
+            "Pipeline runs by terminal status",
+            labelnames=("status", "backend"),
+            namespace=namespace,
+            registry=self._registry,
+        )
+        self.run_duration_seconds = Histogram(
+            "run_duration_seconds",
+            "End-to-end pipeline duration",
+            labelnames=("status", "backend"),
+            namespace=namespace,
+            buckets=(0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600),
+            registry=self._registry,
+        )
+        self.stage_duration_seconds = Histogram(
+            "stage_duration_seconds",
+            "Per-stage duration",
+            labelnames=("stage",),
+            namespace=namespace,
+            buckets=(0.05, 0.1, 0.5, 1, 5, 10, 30, 60, 300),
+            registry=self._registry,
+        )
+        self.stage_failures_total = Counter(
+            "stage_failures_total",
+            "Stage failures",
+            labelnames=("stage",),
+            namespace=namespace,
+            registry=self._registry,
+        )
+        self.queue_depth = Gauge(
+            "queue_depth",
+            "Queued jobs awaiting a worker",
+            namespace=namespace,
+            registry=self._registry,
+        )
+        self.backend_cost_usd = Counter(
+            "backend_cost_usd_total",
+            "Cumulative paid backend spend (USD)",
+            labelnames=("backend",),
+            namespace=namespace,
+            registry=self._registry,
+        )
+        self.cache_total = Counter(
+            "cache_total",
+            "Idempotency cache lookups",
+            labelnames=("outcome",),  # hit | miss
+            namespace=namespace,
+            registry=self._registry,
+        )
+
+    def render(self) -> tuple[bytes, str]:
+        """Return ``(body, content_type)`` for a Prometheus scrape endpoint."""
+        try:
+            from prometheus_client import (  # type: ignore[import-not-found]
+                CONTENT_TYPE_LATEST,
+                generate_latest,
+            )
+        except ImportError:
+            return b"", "text/plain"
+        if self._registry is None:
+            return b"", "text/plain"
+        return generate_latest(self._registry), CONTENT_TYPE_LATEST
+
+
+# =============================================================================
+# Singleton
+# =============================================================================
+
+
+_default_metrics: PipelineMetrics | None = None
+
+
+def get_metrics() -> PipelineMetrics:
+    global _default_metrics
+    if _default_metrics is None:
+        namespace = os.getenv("CLOTHING_3D_METRICS_NS", "clothing_3d")
+        _default_metrics = PipelineMetrics(namespace=namespace)
+    return _default_metrics
+
+
+def render_metrics() -> tuple[bytes, str]:
+    return get_metrics().render()
+
+
+# =============================================================================
+# Event-bus integration
+# =============================================================================
+
+
+def metrics_event_subscriber(
+    metrics: PipelineMetrics | None = None,
+) -> Callable[[PipelineEvent], Awaitable[None]]:
+    """Build a :class:`PipelineEventBus` subscriber that updates metrics."""
+    m = metrics or get_metrics()
+
+    stage_start: dict[tuple[str, str], float] = {}
+
+    async def _sub(event: PipelineEvent) -> None:
+        ts = event.timestamp.timestamp()
+
+        if event.name == "stage.started" and event.stage is not None:
+            stage_start[(event.correlation_id, event.stage.value)] = ts
+            return
+
+        if event.name == "stage.finished" and event.stage is not None:
+            start = stage_start.pop((event.correlation_id, event.stage.value), None)
+            if start is not None:
+                m.stage_duration_seconds.labels(stage=event.stage.value).observe(ts - start)
+            return
+
+        if event.name == "pipeline.succeeded":
+            duration = event.payload.get("duration", 0.0)
+            backend = event.payload.get("backend") or "unknown"
+            m.run_duration_seconds.labels(status="succeeded", backend=backend).observe(duration)
+            m.runs_total.labels(status="succeeded", backend=backend).inc()
+            return
+
+        if event.name in {"pipeline.failed", "pipeline.rejected"}:
+            status = event.name.removeprefix("pipeline.")
+            backend = event.payload.get("backend") or "unknown"
+            m.runs_total.labels(status=status, backend=backend).inc()
+            return
+
+    return _sub
+
+
+__all__ = [
+    "PipelineMetrics",
+    "configure_logging",
+    "get_metrics",
+    "metrics_event_subscriber",
+    "render_metrics",
+]

--- a/pipelines/clothing_3d/pipeline.py
+++ b/pipelines/clothing_3d/pipeline.py
@@ -1,0 +1,323 @@
+"""End-to-end clothing 3D pipeline orchestrator."""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any
+
+from pipelines.clothing_3d.events import PipelineEventBus, log_event_subscriber
+from pipelines.clothing_3d.models import (
+    PipelineQualityReport,
+    PipelineRequest,
+    PipelineResult,
+    PipelineStage,
+    PipelineStatus,
+    StageReport,
+)
+from pipelines.clothing_3d.stages import (
+    PipelineContext,
+    QCThresholds,
+    default_thresholds_for,
+    stage_generate,
+    stage_ingest,
+    stage_qc,
+    stage_store,
+)
+from pipelines.clothing_3d.storage import ArtifactStore, LocalArtifactStore
+from services.three_d.trellis.config import TrellisConfig
+from services.three_d.trellis.provider import TrellisProvider
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Pipeline
+# =============================================================================
+
+
+class ClothingPipeline:
+    """Orchestrator for the clothing 3D pipeline.
+
+    Construct with sensible defaults and call :meth:`run` per request. Inject
+    a custom ``provider`` / ``store`` / ``event_bus`` for tests or alternate
+    deployments.
+
+    Args:
+        config: TRELLIS configuration (defaults to env).
+        provider: Pre-built TRELLIS provider — useful for tests with a stub
+            backend.
+        store: Artifact store. Defaults to :class:`LocalArtifactStore`.
+        event_bus: Event bus. Defaults to a bus with the stdlib log subscriber.
+        thresholds: QC thresholds. Defaults are tuned by quality preset.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: TrellisConfig | None = None,
+        provider: TrellisProvider | None = None,
+        store: ArtifactStore | None = None,
+        event_bus: PipelineEventBus | None = None,
+        thresholds: QCThresholds | None = None,
+    ) -> None:
+        self.config = config or TrellisConfig.from_env()
+        self.config.ensure_dirs()
+        self.provider = provider or TrellisProvider(self.config)
+        self.store: ArtifactStore = store or LocalArtifactStore(base_dir=self.config.output_dir)
+        self.event_bus = event_bus or self._default_event_bus()
+        self.thresholds = thresholds or default_thresholds_for(self.config)
+
+    @staticmethod
+    def _default_event_bus() -> PipelineEventBus:
+        bus = PipelineEventBus()
+        bus.subscribe(log_event_subscriber())
+        return bus
+
+    # ---------------------------------------------------------------------
+    # Public API
+    # ---------------------------------------------------------------------
+
+    async def run(self, request: PipelineRequest) -> PipelineResult:
+        """Execute the pipeline end-to-end for a single request."""
+        ctx = PipelineContext.new(request)
+        started_perf = time.time()
+
+        logger.info(
+            "clothing_3d.pipeline.start",
+            extra={
+                "correlation_id": ctx.correlation_id,
+                "product_name": request.product_name,
+                "has_image": request.has_image,
+                "quality": request.quality.value,
+            },
+        )
+
+        await self._emit(ctx, "pipeline.started", status=PipelineStatus.RUNNING)
+
+        try:
+            return await self._run_stages(ctx, started_perf)
+        except Exception as exc:  # noqa: BLE001 — converted to failed result
+            logger.exception(
+                "clothing_3d.pipeline.unhandled",
+                extra={"correlation_id": ctx.correlation_id},
+            )
+            await self._emit(
+                ctx,
+                "pipeline.failed",
+                status=PipelineStatus.FAILED,
+                payload={"error": str(exc)},
+            )
+            return self._build_failed(
+                ctx,
+                error=f"unhandled: {exc}",
+                started_perf=started_perf,
+            )
+
+    async def close(self) -> None:
+        """Release provider resources."""
+        await self.provider.close()
+
+    # ---------------------------------------------------------------------
+    # Stage runner
+    # ---------------------------------------------------------------------
+
+    async def _run_stages(
+        self,
+        ctx: PipelineContext,
+        started_perf: float,
+    ) -> PipelineResult:
+        # ---- 1. Ingest ----
+        await self._emit(ctx, "stage.started", stage=PipelineStage.INGEST)
+        ingest_report = await stage_ingest(ctx)
+        ctx.reports.append(ingest_report)
+        await self._emit(
+            ctx,
+            "stage.finished",
+            stage=PipelineStage.INGEST,
+            payload=ingest_report.detail,
+        )
+        if not ingest_report.success:
+            return await self._fail(ctx, started_perf, ingest_report.error or "ingest failed")
+
+        # ---- 2-4. Generate (preprocess + TRELLIS + postprocess) ----
+        await self._emit(ctx, "stage.started", stage=PipelineStage.GENERATE)
+        generate_report = await stage_generate(ctx, self.provider)
+        ctx.reports.append(generate_report)
+        await self._emit(
+            ctx,
+            "stage.finished",
+            stage=PipelineStage.GENERATE,
+            payload=generate_report.detail,
+        )
+        if not generate_report.success:
+            return await self._fail(ctx, started_perf, generate_report.error or "generate failed")
+
+        # ---- 5. QC ----
+        quality_report: PipelineQualityReport | None = None
+        if not ctx.request.skip_qc:
+            await self._emit(ctx, "stage.started", stage=PipelineStage.QC)
+            qc_report, quality_report = await stage_qc(ctx, thresholds=self.thresholds)
+            ctx.reports.append(qc_report)
+            await self._emit(
+                ctx,
+                "stage.finished",
+                stage=PipelineStage.QC,
+                payload=qc_report.detail,
+            )
+            if not quality_report.accepted:
+                return await self._reject(ctx, started_perf, quality_report)
+
+        # ---- 6. Store ----
+        await self._emit(ctx, "stage.started", stage=PipelineStage.STORE)
+        store_report, stored = await stage_store(ctx, store=self.store)
+        ctx.reports.append(store_report)
+        await self._emit(
+            ctx,
+            "stage.finished",
+            stage=PipelineStage.STORE,
+            payload=store_report.detail,
+        )
+        if not store_report.success or stored is None:
+            return await self._fail(ctx, started_perf, store_report.error or "store failed")
+
+        # ---- Done ----
+        total = round(time.time() - started_perf, 4)
+        result = PipelineResult(
+            status=PipelineStatus.SUCCEEDED,
+            artifact_id=stored.artifact_id,
+            correlation_id=ctx.correlation_id,
+            glb_url=stored.glb_url,
+            glb_path=stored.glb_path,
+            usdz_url=stored.usdz_url,
+            usdz_path=stored.usdz_path,
+            thumbnail_url=stored.thumbnail_url,
+            garment_category=ctx.garment_category.value,
+            quality=quality_report,
+            stages=ctx.reports,
+            total_duration_seconds=total,
+            metadata=self._summary_metadata(ctx, stored),
+        )
+        await self._emit(
+            ctx,
+            "pipeline.succeeded",
+            status=PipelineStatus.SUCCEEDED,
+            payload={
+                "artifact_id": stored.artifact_id,
+                "glb_url": stored.glb_url,
+                "duration": total,
+            },
+        )
+        return result
+
+    # ---------------------------------------------------------------------
+    # Outcome builders
+    # ---------------------------------------------------------------------
+
+    async def _fail(
+        self,
+        ctx: PipelineContext,
+        started_perf: float,
+        error: str,
+    ) -> PipelineResult:
+        await self._emit(
+            ctx,
+            "pipeline.failed",
+            status=PipelineStatus.FAILED,
+            payload={"error": error},
+        )
+        return self._build_failed(ctx, error=error, started_perf=started_perf)
+
+    async def _reject(
+        self,
+        ctx: PipelineContext,
+        started_perf: float,
+        quality_report: PipelineQualityReport,
+    ) -> PipelineResult:
+        await self._emit(
+            ctx,
+            "pipeline.rejected",
+            status=PipelineStatus.REJECTED,
+            payload={"issues": quality_report.issues, "score": quality_report.score},
+        )
+        return PipelineResult(
+            status=PipelineStatus.REJECTED,
+            artifact_id=ctx.artifact_id,
+            correlation_id=ctx.correlation_id,
+            garment_category=ctx.garment_category.value,
+            quality=quality_report,
+            stages=ctx.reports,
+            total_duration_seconds=round(time.time() - started_perf, 4),
+        )
+
+    def _build_failed(
+        self,
+        ctx: PipelineContext,
+        *,
+        error: str,
+        started_perf: float,
+    ) -> PipelineResult:
+        return PipelineResult(
+            status=PipelineStatus.FAILED,
+            artifact_id=ctx.artifact_id,
+            correlation_id=ctx.correlation_id,
+            garment_category=ctx.garment_category.value,
+            stages=ctx.reports,
+            total_duration_seconds=round(time.time() - started_perf, 4),
+            metadata={"error": error},
+        )
+
+    def _summary_metadata(self, ctx: PipelineContext, stored) -> dict[str, Any]:
+        response = ctx.three_d_response
+        return {
+            "backend": (response.metadata.get("backend") if response else None),
+            "provider": response.provider if response else None,
+            "garment_category": ctx.garment_category.value,
+            "preprocess": response.metadata.get("preprocess") if response else None,
+            "prompt_used": response.metadata.get("prompt_used") if response else None,
+            "prompt_hint": response.metadata.get("prompt_hint") if response else None,
+            "store": stored.metadata if stored else None,
+        }
+
+    # ---------------------------------------------------------------------
+    # Event helper
+    # ---------------------------------------------------------------------
+
+    async def _emit(
+        self,
+        ctx: PipelineContext,
+        name: str,
+        *,
+        stage: PipelineStage | None = None,
+        status: PipelineStatus | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        await self.event_bus.emit(
+            correlation_id=ctx.correlation_id,
+            name=name,
+            stage=stage,
+            status=status,
+            payload=payload,
+        )
+
+
+# =============================================================================
+# Module-level convenience
+# =============================================================================
+
+
+async def run_clothing_pipeline(
+    request: PipelineRequest,
+    *,
+    config: TrellisConfig | None = None,
+) -> PipelineResult:
+    """One-shot helper for callers that don't want to manage the pipeline lifecycle."""
+    pipeline = ClothingPipeline(config=config)
+    try:
+        return await pipeline.run(request)
+    finally:
+        await pipeline.close()
+
+
+__all__ = ["ClothingPipeline", "run_clothing_pipeline"]

--- a/pipelines/clothing_3d/queue.py
+++ b/pipelines/clothing_3d/queue.py
@@ -1,0 +1,323 @@
+"""Queue abstraction for the clothing 3D worker.
+
+Two implementations:
+
+- :class:`InMemoryQueue` — single-process ``asyncio.Queue`` for dev / tests.
+- :class:`RedisStreamsQueue` — Redis Streams with consumer groups for prod.
+  Consumer groups give at-least-once delivery plus per-worker isolation, and
+  ``XACK`` only on success means a crashed worker's job is automatically
+  reclaimed by another worker after ``XCLAIM``.
+
+The :class:`QueueMessage` envelope carries the job_id; the worker resolves
+the full :class:`JobRecord` from the :class:`JobStore`. This avoids dumping
+large request bodies into Redis Streams twice.
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Message envelope
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class QueueMessage:
+    """Worker job envelope.
+
+    Attributes:
+        job_id: Lookup key into :class:`JobStore`.
+        delivery_id: Backend-specific ID needed to ACK the message.
+        enqueued_at: When the producer pushed it.
+        attempt: Delivery attempt number (>=1).
+    """
+
+    job_id: str
+    delivery_id: str
+    enqueued_at: datetime
+    attempt: int = 1
+
+
+# =============================================================================
+# Protocol
+# =============================================================================
+
+
+@runtime_checkable
+class JobQueue(Protocol):
+    """Pluggable queue contract used by the worker."""
+
+    async def enqueue(self, job_id: str) -> None: ...
+
+    async def dequeue(self, *, block_seconds: float = 5.0) -> QueueMessage | None: ...
+
+    async def ack(self, message: QueueMessage) -> None: ...
+
+    async def nack(self, message: QueueMessage, *, requeue: bool = True) -> None: ...
+
+    async def depth(self) -> int: ...
+
+    async def close(self) -> None: ...
+
+
+# =============================================================================
+# In-memory implementation
+# =============================================================================
+
+
+class InMemoryQueue:
+    """Single-process queue. Fine for dev and tests; ephemeral on restart."""
+
+    def __init__(self, *, maxsize: int = 1024) -> None:
+        self._q: asyncio.Queue[QueueMessage] = asyncio.Queue(maxsize=maxsize)
+        self._unacked: dict[str, QueueMessage] = {}
+
+    async def enqueue(self, job_id: str) -> None:
+        msg = QueueMessage(
+            job_id=job_id,
+            delivery_id=str(uuid.uuid4()),
+            enqueued_at=datetime.now(UTC),
+        )
+        await self._q.put(msg)
+
+    async def dequeue(self, *, block_seconds: float = 5.0) -> QueueMessage | None:
+        try:
+            msg = await asyncio.wait_for(self._q.get(), timeout=block_seconds)
+        except asyncio.TimeoutError:
+            return None
+        self._unacked[msg.delivery_id] = msg
+        return msg
+
+    async def ack(self, message: QueueMessage) -> None:
+        self._unacked.pop(message.delivery_id, None)
+        self._q.task_done()
+
+    async def nack(self, message: QueueMessage, *, requeue: bool = True) -> None:
+        self._unacked.pop(message.delivery_id, None)
+        self._q.task_done()
+        if requeue:
+            requeued = QueueMessage(
+                job_id=message.job_id,
+                delivery_id=str(uuid.uuid4()),
+                enqueued_at=datetime.now(UTC),
+                attempt=message.attempt + 1,
+            )
+            await self._q.put(requeued)
+
+    async def depth(self) -> int:
+        return self._q.qsize()
+
+    async def close(self) -> None:
+        pass
+
+
+# =============================================================================
+# Redis Streams implementation
+# =============================================================================
+
+
+class RedisStreamsQueue:
+    """At-least-once queue backed by Redis Streams.
+
+    Schema:
+        Stream:   ``{prefix}:queue``  (field: ``job_id``)
+        Group:    ``{prefix}:workers`` (auto-created)
+
+    Best practices:
+    - Workers ``XREADGROUP`` then explicitly ``XACK`` only on full success.
+    - Crashed worker's pending messages auto-reclaimed by another via
+      :meth:`reclaim_pending` (call periodically from a janitor task).
+    - Backpressure: cap stream length with ``MAXLEN`` to drop oldest if
+      producers outrun consumers (configurable).
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str | None = None,
+        prefix: str = "clothing3d",
+        consumer_group: str = "workers",
+        consumer_name: str | None = None,
+        maxlen: int = 10_000,
+        reclaim_idle_ms: int = 60_000,
+    ) -> None:
+        self._url = url or os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        self._prefix = prefix
+        self._group = consumer_group
+        self._consumer_name = consumer_name or f"worker-{uuid.uuid4().hex[:8]}"
+        self._maxlen = maxlen
+        self._reclaim_idle_ms = reclaim_idle_ms
+        self._client: Any = None
+        self._group_ensured = False
+        self._lock = asyncio.Lock()
+
+    @property
+    def _stream(self) -> str:
+        return f"{self._prefix}:queue"
+
+    async def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        async with self._lock:
+            if self._client is not None:
+                return self._client
+            try:
+                import redis.asyncio as redis  # type: ignore[import-not-found]
+            except ImportError as e:
+                raise RuntimeError(
+                    "RedisStreamsQueue requires `redis>=5` — pip install redis"
+                ) from e
+            self._client = redis.from_url(self._url, decode_responses=True)
+            return self._client
+
+    async def _ensure_group(self) -> None:
+        if self._group_ensured:
+            return
+        client = await self._get_client()
+        try:
+            await client.xgroup_create(self._stream, self._group, id="0", mkstream=True)
+        except Exception as exc:  # noqa: BLE001 — only BUSYGROUP is acceptable
+            msg = str(exc)
+            if "BUSYGROUP" not in msg:
+                logger.warning("xgroup_create error: %s", msg)
+        self._group_ensured = True
+
+    async def enqueue(self, job_id: str) -> None:
+        client = await self._get_client()
+        await self._ensure_group()
+        await client.xadd(
+            self._stream,
+            {"job_id": job_id, "enqueued_at": datetime.now(UTC).isoformat()},
+            maxlen=self._maxlen,
+            approximate=True,
+        )
+
+    async def dequeue(self, *, block_seconds: float = 5.0) -> QueueMessage | None:
+        client = await self._get_client()
+        await self._ensure_group()
+        block_ms = int(block_seconds * 1000)
+        result = await client.xreadgroup(
+            self._group,
+            self._consumer_name,
+            {self._stream: ">"},
+            count=1,
+            block=block_ms,
+        )
+        if not result:
+            return None
+        # result = [(stream, [(delivery_id, {fields})])]
+        _, items = result[0]
+        delivery_id, fields = items[0]
+        return QueueMessage(
+            job_id=fields["job_id"],
+            delivery_id=delivery_id,
+            enqueued_at=datetime.fromisoformat(fields["enqueued_at"]),
+            attempt=int(fields.get("attempt", 1)),
+        )
+
+    async def ack(self, message: QueueMessage) -> None:
+        client = await self._get_client()
+        await client.xack(self._stream, self._group, message.delivery_id)
+        # Trim acknowledged entries; they're not needed in the stream.
+        try:
+            await client.xdel(self._stream, message.delivery_id)
+        except Exception:  # noqa: BLE001 — best effort
+            pass
+
+    async def nack(self, message: QueueMessage, *, requeue: bool = True) -> None:
+        client = await self._get_client()
+        await client.xack(self._stream, self._group, message.delivery_id)
+        try:
+            await client.xdel(self._stream, message.delivery_id)
+        except Exception:  # noqa: BLE001
+            pass
+        if requeue:
+            await client.xadd(
+                self._stream,
+                {
+                    "job_id": message.job_id,
+                    "enqueued_at": datetime.now(UTC).isoformat(),
+                    "attempt": message.attempt + 1,
+                },
+                maxlen=self._maxlen,
+                approximate=True,
+            )
+
+    async def depth(self) -> int:
+        client = await self._get_client()
+        await self._ensure_group()
+        try:
+            return int(await client.xlen(self._stream))
+        except Exception:  # noqa: BLE001
+            return -1
+
+    async def reclaim_pending(self) -> int:
+        """Reclaim messages idle longer than ``reclaim_idle_ms``.
+
+        Returns the number of messages reclaimed. Run from a janitor task
+        every minute or so to recover from worker crashes.
+        """
+        client = await self._get_client()
+        await self._ensure_group()
+        try:
+            _, claimed, _ = await client.xautoclaim(
+                self._stream,
+                self._group,
+                self._consumer_name,
+                min_idle_time=self._reclaim_idle_ms,
+                count=100,
+            )
+            return len(claimed)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("xautoclaim failed: %s", exc)
+            return 0
+
+    async def close(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            except AttributeError:
+                await self._client.close()
+            self._client = None
+
+
+# =============================================================================
+# Factory
+# =============================================================================
+
+
+def build_queue() -> JobQueue:
+    """Pick the right queue per environment.
+
+    ``REDIS_URL`` set → :class:`RedisStreamsQueue`, else :class:`InMemoryQueue`.
+    Override with ``CLOTHING_3D_QUEUE`` (``memory`` | ``redis``).
+    """
+    backend = os.getenv("CLOTHING_3D_QUEUE")
+    if backend == "memory":
+        return InMemoryQueue()
+    if backend == "redis" or os.getenv("REDIS_URL"):
+        return RedisStreamsQueue()
+    return InMemoryQueue()
+
+
+__all__ = [
+    "InMemoryQueue",
+    "JobQueue",
+    "QueueMessage",
+    "RedisStreamsQueue",
+    "build_queue",
+]

--- a/pipelines/clothing_3d/reliability.py
+++ b/pipelines/clothing_3d/reliability.py
@@ -1,0 +1,378 @@
+"""Reliability primitives: retries, idempotency, cost quotas.
+
+Production-grade hardening for the clothing 3D pipeline:
+
+- :class:`RetryPolicy` — exponential backoff with full jitter; aware of which
+  exceptions are retryable.
+- :func:`request_fingerprint` / :class:`IdempotencyCache` — content-addressed
+  result cache so duplicate requests (same image bytes + same options) reuse
+  the existing artifact instead of burning a fresh TRELLIS call.
+- :class:`CostQuota` — per-backend spend ceiling with a token-bucket-style
+  rolling window, used by the worker to short-circuit before dispatching to
+  paid backends (replicate / modal).
+
+All three components share one design choice: **in-memory by default, swap
+in a shared store via Protocol-typed injection**. That way the unit test loop
+stays fast, dev runs need zero infra, and prod swaps in Redis without
+touching the pipeline code.
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import random
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Protocol, TypeVar, runtime_checkable
+
+from pipelines.clothing_3d.models import PipelineRequest, PipelineResult
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+# =============================================================================
+# Retry policy
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class RetryPolicy:
+    """Exponential backoff with full jitter, capped attempts.
+
+    Attributes:
+        max_attempts: Total attempts including the first try. ``1`` disables retry.
+        base_delay_seconds: Initial sleep before retry #2 (subject to jitter).
+        max_delay_seconds: Upper cap for the delay; protects from runaway sleeps.
+        backoff_multiplier: Multiplier per attempt (2.0 = double each time).
+        retry_on: Exception types that trigger a retry. Anything else propagates.
+    """
+
+    max_attempts: int = 3
+    base_delay_seconds: float = 2.0
+    max_delay_seconds: float = 60.0
+    backoff_multiplier: float = 2.0
+    retry_on: tuple[type[BaseException], ...] = (
+        TimeoutError,
+        ConnectionError,
+        asyncio.TimeoutError,
+    )
+
+    def delay_for(self, attempt: int) -> float:
+        """Compute backoff (with full jitter) before attempt #``attempt`` (1-indexed).
+
+        attempt=1 → 0 (first try, no sleep)
+        attempt=2 → uniform[0, base]
+        attempt=N → uniform[0, base * mult^(N-2)] capped at max_delay_seconds
+        """
+        if attempt <= 1:
+            return 0.0
+        target = self.base_delay_seconds * (self.backoff_multiplier ** (attempt - 2))
+        capped = min(target, self.max_delay_seconds)
+        return random.uniform(0.0, capped)
+
+    async def run(
+        self,
+        fn: Callable[[], Awaitable[T]],
+        *,
+        on_retry: Callable[[int, BaseException], None] | None = None,
+    ) -> T:
+        """Execute ``fn``, retrying on ``self.retry_on`` per the policy.
+
+        Args:
+            fn: Async callable; called fresh on each attempt.
+            on_retry: Optional callback ``(attempt_number, exception)`` invoked
+                between retries (useful for metrics).
+
+        Raises:
+            The last exception if all attempts fail.
+        """
+        last_exc: BaseException | None = None
+        for attempt in range(1, self.max_attempts + 1):
+            sleep = self.delay_for(attempt)
+            if sleep > 0:
+                await asyncio.sleep(sleep)
+            try:
+                return await fn()
+            except self.retry_on as exc:  # type: ignore[misc]
+                last_exc = exc
+                if on_retry:
+                    try:
+                        on_retry(attempt, exc)
+                    except Exception:  # noqa: BLE001
+                        logger.exception("on_retry callback failed")
+                if attempt == self.max_attempts:
+                    raise
+
+        assert last_exc is not None  # for type-checker
+        raise last_exc
+
+
+# =============================================================================
+# Idempotency
+# =============================================================================
+
+
+def request_fingerprint(request: PipelineRequest) -> str:
+    """Stable SHA-256 fingerprint of the inputs that affect generation.
+
+    Excludes ``correlation_id`` and ``metadata.artifact_id`` because they
+    change per-request without changing the output.
+    """
+    h = hashlib.sha256()
+
+    def _add(label: str, value: Any) -> None:
+        h.update(label.encode())
+        h.update(b"\x00")
+        h.update(str(value).encode())
+        h.update(b"\x00")
+
+    if request.image_path:
+        try:
+            data = Path(request.image_path).read_bytes()
+            h.update(b"img_bytes\x00")
+            h.update(hashlib.sha256(data).digest())
+        except OSError:
+            _add("image_path", request.image_path)
+    if request.image_url:
+        _add("image_url", request.image_url)
+    if request.prompt:
+        _add("prompt", request.prompt.strip())
+
+    _add("product_name", request.product_name or "")
+    _add("collection", request.collection or "")
+    _add("garment_type", request.garment_type or "")
+    _add("quality", request.quality.value)
+    if request.backend is not None:
+        _add("backend", request.backend.value)
+
+    # Allow callers to opt into stronger keys via metadata.
+    if request.metadata:
+        for key in sorted(request.metadata):
+            if not key.startswith("_"):
+                _add(f"meta:{key}", request.metadata[key])
+
+    return h.hexdigest()
+
+
+@dataclass(slots=True)
+class IdempotencyEntry:
+    """Cached pipeline result for a fingerprint."""
+
+    fingerprint: str
+    result: PipelineResult
+    cached_at: datetime
+
+
+@runtime_checkable
+class IdempotencyStore(Protocol):
+    """Pluggable backing store for :class:`IdempotencyCache`.
+
+    Implementations: :class:`InMemoryIdempotencyStore` (default),
+    ``RedisIdempotencyStore`` (see :mod:`pipelines.clothing_3d.job_store`).
+    """
+
+    async def get(self, fingerprint: str) -> IdempotencyEntry | None: ...
+
+    async def put(self, entry: IdempotencyEntry, *, ttl_seconds: int) -> None: ...
+
+
+class InMemoryIdempotencyStore:
+    """Default in-process store with TTL eviction."""
+
+    def __init__(self, *, capacity: int = 1024) -> None:
+        self._entries: dict[str, IdempotencyEntry] = {}
+        self._lock = asyncio.Lock()
+        self._capacity = capacity
+
+    async def get(self, fingerprint: str) -> IdempotencyEntry | None:
+        async with self._lock:
+            entry = self._entries.get(fingerprint)
+            if entry is None:
+                return None
+            return entry
+
+    async def put(self, entry: IdempotencyEntry, *, ttl_seconds: int) -> None:
+        async with self._lock:
+            if len(self._entries) >= self._capacity:
+                oldest = min(self._entries, key=lambda k: self._entries[k].cached_at)
+                self._entries.pop(oldest, None)
+            self._entries[entry.fingerprint] = entry
+
+
+class IdempotencyCache:
+    """Content-addressed result cache.
+
+    Wrap any function that takes a :class:`PipelineRequest` and returns a
+    :class:`PipelineResult`. Identical inputs return the cached result
+    without re-running the pipeline. Failures are NOT cached — only
+    ``status == SUCCEEDED`` runs hit the cache.
+
+    Usage:
+        cache = IdempotencyCache(ttl_seconds=86_400)
+        result = await cache.get_or_run(request, runner=pipeline.run)
+    """
+
+    def __init__(
+        self,
+        *,
+        store: IdempotencyStore | None = None,
+        ttl_seconds: int = 86_400,
+        enabled: bool = True,
+    ) -> None:
+        self._store = store or InMemoryIdempotencyStore()
+        self._ttl = ttl_seconds
+        self._enabled = enabled
+
+    async def get_or_run(
+        self,
+        request: PipelineRequest,
+        *,
+        runner: Callable[[PipelineRequest], Awaitable[PipelineResult]],
+    ) -> tuple[PipelineResult, bool]:
+        """Return ``(result, cache_hit)``. Stores successful results."""
+        if not self._enabled:
+            return await runner(request), False
+
+        fingerprint = request_fingerprint(request)
+        cached = await self._store.get(fingerprint)
+        if cached is not None:
+            age = (datetime.now(UTC) - cached.cached_at).total_seconds()
+            if age <= self._ttl:
+                logger.info(
+                    "idempotency.hit fingerprint=%s age=%.0fs", fingerprint[:12], age
+                )
+                return cached.result, True
+
+        result = await runner(request)
+
+        if result.status.value == "succeeded":
+            await self._store.put(
+                IdempotencyEntry(
+                    fingerprint=fingerprint,
+                    result=result,
+                    cached_at=datetime.now(UTC),
+                ),
+                ttl_seconds=self._ttl,
+            )
+        return result, False
+
+
+# =============================================================================
+# Cost quotas
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class BackendCost:
+    """Per-call cost approximation for a backend (USD)."""
+
+    backend: str
+    usd_per_call: float
+
+
+# Conservative estimates as of 2026; override via env in prod.
+DEFAULT_BACKEND_COSTS: dict[str, BackendCost] = {
+    "hf_space": BackendCost("hf_space", 0.0),
+    "stub": BackendCost("stub", 0.0),
+    "local": BackendCost("local", 0.0),
+    "replicate": BackendCost("replicate", 0.05),
+    "modal": BackendCost("modal", 0.10),
+}
+
+
+class QuotaExceededError(RuntimeError):
+    """Raised when a backend's spend cap is exhausted."""
+
+
+@dataclass(slots=True)
+class _QuotaWindow:
+    spent_usd: float = 0.0
+    started_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+class CostQuota:
+    """Rolling-window per-backend cost ceiling.
+
+    Wraps each TRELLIS call; rejects with :class:`QuotaExceededError` when the
+    backend's window spend would exceed the cap. The window resets when
+    ``window_seconds`` elapses since the window started.
+
+    The store is in-memory: for multi-worker deployments, run one quota per
+    backend in a sidecar (or share a Redis counter via Lua INCRBY + EXPIRE).
+
+    Usage:
+        quota = CostQuota({"replicate": 5.00, "modal": 20.00})
+        quota.charge("replicate")  # raises if cap exceeded
+    """
+
+    def __init__(
+        self,
+        caps_usd: dict[str, float] | None = None,
+        *,
+        window_seconds: int = 86_400,
+        costs: dict[str, BackendCost] | None = None,
+    ) -> None:
+        self._caps = dict(caps_usd or {})
+        self._costs = dict(costs or DEFAULT_BACKEND_COSTS)
+        self._window_seconds = window_seconds
+        self._windows: dict[str, _QuotaWindow] = {}
+
+    def charge(self, backend: str, *, calls: int = 1) -> None:
+        cap = self._caps.get(backend)
+        if cap is None:
+            return  # no cap declared → unlimited
+
+        cost = self._costs.get(backend, BackendCost(backend, 0.0)).usd_per_call * calls
+        window = self._windows.setdefault(backend, _QuotaWindow())
+
+        if (datetime.now(UTC) - window.started_at) > timedelta(seconds=self._window_seconds):
+            window.spent_usd = 0.0
+            window.started_at = datetime.now(UTC)
+
+        projected = window.spent_usd + cost
+        if projected > cap:
+            raise QuotaExceededError(
+                f"backend={backend} spend ${projected:.4f} > cap ${cap:.4f} "
+                f"(window started {window.started_at.isoformat()})"
+            )
+        window.spent_usd = projected
+
+    def spent(self, backend: str) -> float:
+        return self._windows.get(backend, _QuotaWindow()).spent_usd
+
+    def cap(self, backend: str) -> float | None:
+        return self._caps.get(backend)
+
+    def snapshot(self) -> dict[str, dict[str, float | None]]:
+        return {
+            backend: {
+                "spent_usd": w.spent_usd,
+                "cap_usd": self._caps.get(backend),
+                "window_started_at": w.started_at.timestamp(),
+            }
+            for backend, w in self._windows.items()
+        }
+
+
+__all__ = [
+    "BackendCost",
+    "CostQuota",
+    "DEFAULT_BACKEND_COSTS",
+    "IdempotencyCache",
+    "IdempotencyEntry",
+    "IdempotencyStore",
+    "InMemoryIdempotencyStore",
+    "QuotaExceededError",
+    "RetryPolicy",
+    "request_fingerprint",
+]

--- a/pipelines/clothing_3d/stages.py
+++ b/pipelines/clothing_3d/stages.py
@@ -1,0 +1,415 @@
+"""Individual pipeline stages.
+
+Each stage is an async callable producing a :class:`StageReport`. The
+:class:`~pipelines.clothing_3d.pipeline.ClothingPipeline` orchestrator
+composes them and decides whether to continue based on the report.
+
+Stages return tuples of ``(stage_report, stage_output)`` where the output is
+fed to the next stage via the :class:`PipelineContext`. The orchestrator
+owns timing, retries, and event emission; stages stay focused on one job.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pipelines.clothing_3d.models import (
+    PipelineQualityReport,
+    PipelineRequest,
+    PipelineStage,
+    StageReport,
+)
+from services.three_d.provider_interface import OutputFormat, ThreeDRequest, ThreeDResponse
+from services.three_d.trellis.config import TrellisConfig
+from services.three_d.trellis.garment_aware import GarmentCategory, classify_garment
+from services.three_d.trellis.provider import TrellisProvider
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Pipeline context — mutable state threaded through stages
+# =============================================================================
+
+
+@dataclass(slots=True)
+class PipelineContext:
+    """Mutable bag of state passed between stages."""
+
+    request: PipelineRequest
+    correlation_id: str
+    artifact_id: str
+
+    # Filled in progressively
+    local_image_path: str | None = None
+    image_size: tuple[int, int] | None = None
+    garment_category: GarmentCategory = GarmentCategory.UNKNOWN
+    three_d_response: ThreeDResponse | None = None
+    reports: list[StageReport] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def new(cls, request: PipelineRequest) -> PipelineContext:
+        corr = request.correlation_id or str(uuid.uuid4())
+        artifact_id = request.product_sku or f"art_{corr[:12]}"
+        return cls(request=request, correlation_id=corr, artifact_id=artifact_id)
+
+
+# =============================================================================
+# Stage runner helper
+# =============================================================================
+
+
+def _start_report(stage: PipelineStage) -> tuple[datetime, float]:
+    return datetime.now(UTC), time.time()
+
+
+def _finish_report(
+    stage: PipelineStage,
+    started_at: datetime,
+    started_perf: float,
+    *,
+    success: bool,
+    detail: dict[str, Any] | None = None,
+    error: str | None = None,
+    warnings: list[str] | None = None,
+) -> StageReport:
+    return StageReport(
+        stage=stage,
+        started_at=started_at,
+        finished_at=datetime.now(UTC),
+        success=success,
+        duration_seconds=round(time.time() - started_perf, 4),
+        detail=detail or {},
+        error=error,
+        warnings=warnings or [],
+    )
+
+
+# =============================================================================
+# Stage 1: ingest
+# =============================================================================
+
+
+async def stage_ingest(ctx: PipelineContext) -> StageReport:
+    """Validate inputs, resolve image path, capture image metadata."""
+    started_at, started_perf = _start_report(PipelineStage.INGEST)
+    warnings: list[str] = []
+
+    request = ctx.request
+    if not (request.image_url or request.image_path or request.prompt):
+        return _finish_report(
+            PipelineStage.INGEST,
+            started_at,
+            started_perf,
+            success=False,
+            error="No input provided",
+        )
+
+    if request.image_path:
+        path = Path(request.image_path)
+        if not path.exists():
+            return _finish_report(
+                PipelineStage.INGEST,
+                started_at,
+                started_perf,
+                success=False,
+                error=f"image_path not found: {request.image_path}",
+            )
+        ctx.local_image_path = str(path)
+
+    elif request.image_url:
+        # Provider will download as needed; just record the URL.
+        ctx.local_image_path = request.image_url
+
+    # Classify before generation so we can route + tune sampling
+    ctx.image_size = _safe_image_size(ctx.local_image_path)
+    ctx.garment_category = classify_garment(
+        image_path=request.image_path,
+        image_size=ctx.image_size,
+        declared_category=request.garment_type,
+        product_name=request.product_name,
+    )
+
+    detail = {
+        "input_kind": "image" if request.has_image else "text",
+        "garment_category": ctx.garment_category.value,
+        "image_size": ctx.image_size,
+    }
+    return _finish_report(
+        PipelineStage.INGEST,
+        started_at,
+        started_perf,
+        success=True,
+        detail=detail,
+        warnings=warnings,
+    )
+
+
+def _safe_image_size(path_or_url: str | None) -> tuple[int, int] | None:
+    if not path_or_url:
+        return None
+    if path_or_url.startswith(("http://", "https://")):
+        return None
+    if not Path(path_or_url).exists():
+        return None
+    try:
+        from PIL import Image
+
+        with Image.open(path_or_url) as im:
+            return im.size
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# =============================================================================
+# Stage 2 + 3 + 4: provider call
+#
+# Preprocessing + generation + postprocessing happen inside the TrellisProvider
+# because they need to share intermediate files. We expose them here as a
+# single stage to keep the orchestrator boundaries clean.
+# =============================================================================
+
+
+async def stage_generate(
+    ctx: PipelineContext,
+    provider: TrellisProvider,
+) -> StageReport:
+    """Run preprocess → TRELLIS → postprocess via the provider."""
+    started_at, started_perf = _start_report(PipelineStage.GENERATE)
+    request = ctx.request
+
+    three_d_request = ThreeDRequest(
+        prompt=request.prompt,
+        image_url=request.image_url,
+        image_path=request.image_path,
+        output_format=OutputFormat.GLB,
+        product_name=request.product_name,
+        collection=request.collection,
+        garment_type=(
+            request.garment_type
+            or (ctx.garment_category.value if ctx.garment_category != GarmentCategory.UNKNOWN else None)
+        ),
+        correlation_id=ctx.correlation_id,
+        metadata={
+            "artifact_id": ctx.artifact_id,
+            "quality": request.quality.value,
+            **request.metadata,
+        },
+    )
+
+    try:
+        if request.has_image:
+            response = await provider.generate_from_image(three_d_request)
+        else:
+            response = await provider.generate_from_text(three_d_request)
+    except Exception as exc:  # noqa: BLE001 — captured in report
+        return _finish_report(
+            PipelineStage.GENERATE,
+            started_at,
+            started_perf,
+            success=False,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    ctx.three_d_response = response
+    detail = {
+        "provider": response.provider,
+        "task_id": response.task_id,
+        "polycount": response.polycount,
+        "file_size_bytes": response.file_size_bytes,
+        "duration_seconds": response.duration_seconds,
+    }
+    return _finish_report(
+        PipelineStage.GENERATE,
+        started_at,
+        started_perf,
+        success=True,
+        detail=detail,
+    )
+
+
+# =============================================================================
+# Stage 5: QC
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class QCThresholds:
+    """Acceptance bounds for the QC stage."""
+
+    min_polycount: int = 8_000
+    max_polycount: int = 250_000
+    min_file_kb: int = 20
+    max_file_kb: int = 25_000
+    require_thumbnail: bool = False
+
+
+async def stage_qc(
+    ctx: PipelineContext,
+    *,
+    thresholds: QCThresholds | None = None,
+) -> tuple[StageReport, PipelineQualityReport]:
+    """Inspect the generated artifact and decide whether it's shippable."""
+    started_at, started_perf = _start_report(PipelineStage.QC)
+    thresholds = thresholds or QCThresholds()
+    response = ctx.three_d_response
+
+    if response is None or not response.model_path:
+        report = PipelineQualityReport(
+            accepted=False,
+            score=0.0,
+            issues=["No generated artifact to QC"],
+        )
+        stage_report = _finish_report(
+            PipelineStage.QC,
+            started_at,
+            started_perf,
+            success=False,
+            detail=report.model_dump(),
+            error="missing artifact",
+        )
+        return stage_report, report
+
+    issues: list[str] = []
+
+    polycount = response.polycount
+    if polycount is not None:
+        if polycount < thresholds.min_polycount:
+            issues.append(f"polycount {polycount} below floor {thresholds.min_polycount}")
+        elif polycount > thresholds.max_polycount:
+            issues.append(f"polycount {polycount} above ceiling {thresholds.max_polycount}")
+
+    file_kb: int | None = None
+    if response.file_size_bytes:
+        file_kb = response.file_size_bytes // 1024
+        if file_kb < thresholds.min_file_kb:
+            issues.append(f"file {file_kb} KB below floor {thresholds.min_file_kb} KB")
+        elif file_kb > thresholds.max_file_kb:
+            issues.append(f"file {file_kb} KB above ceiling {thresholds.max_file_kb} KB")
+
+    if thresholds.require_thumbnail and not response.thumbnail_url:
+        issues.append("missing thumbnail")
+
+    # Score: 1.0 if no issues, penalize 0.2 each.
+    score = max(0.0, 1.0 - 0.2 * len(issues))
+    accepted = not issues or ctx.request.skip_qc
+
+    report = PipelineQualityReport(
+        accepted=accepted,
+        score=round(score, 3),
+        polycount=polycount,
+        file_size_kb=file_kb,
+        texture_size=response.metadata.get("texture_size") if response.metadata else None,
+        issues=issues,
+    )
+    stage_report = _finish_report(
+        PipelineStage.QC,
+        started_at,
+        started_perf,
+        success=True,  # QC ran; acceptance is in the report
+        detail=report.model_dump(),
+        warnings=issues,
+    )
+    return stage_report, report
+
+
+# =============================================================================
+# Stage 6: store
+# =============================================================================
+
+
+async def stage_store(
+    ctx: PipelineContext,
+    *,
+    store,
+):
+    """Persist artifacts via the configured :class:`ArtifactStore`."""
+    from pipelines.clothing_3d.storage import ArtifactBundle  # local import to avoid cycle
+
+    started_at, started_perf = _start_report(PipelineStage.STORE)
+    response = ctx.three_d_response
+    if response is None or not response.model_path:
+        return _finish_report(
+            PipelineStage.STORE,
+            started_at,
+            started_perf,
+            success=False,
+            error="No artifact to store",
+        ), None
+
+    meta = response.metadata or {}
+    bundle = ArtifactBundle(
+        artifact_id=ctx.artifact_id,
+        glb_path=response.model_path,
+        usdz_path=meta.get("usdz_path"),
+        thumbnail_path=meta.get("thumbnail_path"),
+        splat_path=meta.get("splat_path"),
+        extra={
+            "category": ctx.garment_category.value,
+            "collection": ctx.request.collection or "",
+            "product_name": ctx.request.product_name or "",
+        },
+    )
+
+    try:
+        stored = await store.store(bundle)
+    except Exception as exc:  # noqa: BLE001
+        return _finish_report(
+            PipelineStage.STORE,
+            started_at,
+            started_perf,
+            success=False,
+            error=f"{type(exc).__name__}: {exc}",
+        ), None
+
+    detail = {
+        "glb_url": stored.glb_url,
+        "usdz_url": stored.usdz_url,
+        "thumbnail_url": stored.thumbnail_url,
+        "metadata": stored.metadata,
+    }
+    return _finish_report(
+        PipelineStage.STORE,
+        started_at,
+        started_perf,
+        success=True,
+        detail=detail,
+    ), stored
+
+
+# =============================================================================
+# Stage factory exports
+# =============================================================================
+
+
+def default_thresholds_for(config: TrellisConfig) -> QCThresholds:
+    """Tune QC thresholds based on the active TRELLIS quality preset."""
+    quality = config.quality.value
+    if quality == "draft":
+        return QCThresholds(min_polycount=4_000, max_polycount=120_000, min_file_kb=10)
+    if quality == "production":
+        return QCThresholds(
+            min_polycount=20_000,
+            max_polycount=300_000,
+            min_file_kb=50,
+            require_thumbnail=False,
+        )
+    return QCThresholds()
+
+
+__all__ = [
+    "PipelineContext",
+    "QCThresholds",
+    "default_thresholds_for",
+    "stage_generate",
+    "stage_ingest",
+    "stage_qc",
+    "stage_store",
+]

--- a/pipelines/clothing_3d/storage.py
+++ b/pipelines/clothing_3d/storage.py
@@ -1,0 +1,258 @@
+"""Artifact storage for the clothing 3D pipeline.
+
+A pipeline run can emit several files (GLB, USDZ, thumbnail, splat). The
+storage layer takes that bundle, persists it somewhere durable, and returns
+the URLs used by downstream consumers (web viewer, AR, analytics).
+
+Two backends ship:
+
+- :class:`LocalArtifactStore` — copies into ``./assets/3d-models-generated``
+  and serves them via the existing FastAPI static mount. Default for dev.
+- :class:`S3ArtifactStore` — uploads to S3-compatible object storage and
+  returns signed URLs. Lazy-imports :mod:`boto3` so dev doesn't need it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Bundle
+# =============================================================================
+
+
+@dataclass(slots=True)
+class ArtifactBundle:
+    """Files associated with a single pipeline run."""
+
+    artifact_id: str
+    glb_path: str
+    usdz_path: str | None = None
+    thumbnail_path: str | None = None
+    splat_path: str | None = None
+    extra: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class StoredArtifact:
+    """Result of persisting a bundle."""
+
+    artifact_id: str
+    glb_url: str
+    glb_path: str
+    usdz_url: str | None = None
+    usdz_path: str | None = None
+    thumbnail_url: str | None = None
+    thumbnail_path: str | None = None
+    stored_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# =============================================================================
+# Protocol
+# =============================================================================
+
+
+@runtime_checkable
+class ArtifactStore(Protocol):
+    """Where pipeline artifacts go to live."""
+
+    async def store(self, bundle: ArtifactBundle) -> StoredArtifact: ...
+
+
+# =============================================================================
+# Local store
+# =============================================================================
+
+
+class LocalArtifactStore:
+    """Stores artifacts on the local filesystem and exposes URL-style paths.
+
+    Files are already written to ``config.output_dir`` by the postprocessor;
+    this store just records them and synthesizes URLs that match the FastAPI
+    ``/assets/3d-models-generated`` static mount.
+
+    Args:
+        base_dir: Directory containing the artifacts. Defaults to
+            ``$THREE_D_OUTPUT_DIR`` or ``./assets/3d-models-generated``.
+        public_prefix: URL prefix where ``base_dir`` is mounted.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_dir: str | None = None,
+        public_prefix: str = "/assets/3d-models-generated",
+    ) -> None:
+        self.base_dir = Path(
+            base_dir
+            or os.getenv("THREE_D_OUTPUT_DIR", "./assets/3d-models-generated")
+        )
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.public_prefix = public_prefix.rstrip("/")
+
+    async def store(self, bundle: ArtifactBundle) -> StoredArtifact:
+        glb_dst = self._move_into_base(bundle.glb_path, suffix=".glb", artifact_id=bundle.artifact_id)
+        usdz_dst = (
+            self._move_into_base(bundle.usdz_path, suffix=".usdz", artifact_id=bundle.artifact_id)
+            if bundle.usdz_path
+            else None
+        )
+        thumb_dst = (
+            self._move_into_base(
+                bundle.thumbnail_path, suffix=".png", artifact_id=f"{bundle.artifact_id}_preview"
+            )
+            if bundle.thumbnail_path
+            else None
+        )
+
+        return StoredArtifact(
+            artifact_id=bundle.artifact_id,
+            glb_path=str(glb_dst),
+            glb_url=self._public_url(glb_dst),
+            usdz_path=str(usdz_dst) if usdz_dst else None,
+            usdz_url=self._public_url(usdz_dst) if usdz_dst else None,
+            thumbnail_path=str(thumb_dst) if thumb_dst else None,
+            thumbnail_url=self._public_url(thumb_dst) if thumb_dst else None,
+            metadata={"store": "local", "extra": bundle.extra},
+        )
+
+    def _move_into_base(self, src: str, *, suffix: str, artifact_id: str) -> Path:
+        src_path = Path(src)
+        if not src_path.exists():
+            raise FileNotFoundError(src)
+
+        # Already inside base_dir → no-op.
+        try:
+            src_path.resolve().relative_to(self.base_dir.resolve())
+            return src_path
+        except ValueError:
+            pass
+
+        dst = self.base_dir / f"{artifact_id}{suffix}"
+        shutil.copy2(src_path, dst)
+        return dst
+
+    def _public_url(self, path: Path) -> str:
+        return f"{self.public_prefix}/{path.name}"
+
+
+# =============================================================================
+# S3 store
+# =============================================================================
+
+
+class S3ArtifactStore:
+    """S3 / S3-compatible object storage backend.
+
+    Designed for CloudFlare R2, AWS S3, Cloudfront-fronted buckets, etc.
+
+    Args:
+        bucket: Bucket name.
+        prefix: Key prefix (e.g. ``"3d/garments"``).
+        public_base_url: If the bucket has a public CDN URL, signed URLs are
+            replaced with this prefix; otherwise a presigned GET URL is used.
+        signed_url_ttl_seconds: How long presigned URLs live (only when there
+            is no ``public_base_url``).
+    """
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        prefix: str = "3d/garments",
+        public_base_url: str | None = None,
+        signed_url_ttl_seconds: int = 3600,
+        region: str | None = None,
+    ) -> None:
+        self.bucket = bucket
+        self.prefix = prefix.strip("/")
+        self.public_base_url = public_base_url.rstrip("/") if public_base_url else None
+        self.signed_url_ttl_seconds = signed_url_ttl_seconds
+        self.region = region or os.getenv("AWS_REGION", "us-east-1")
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            import boto3  # type: ignore[import-not-found]
+        except ImportError as e:
+            raise RuntimeError(
+                "S3ArtifactStore requires boto3 — pip install boto3"
+            ) from e
+        self._client = boto3.client("s3", region_name=self.region)
+        return self._client
+
+    async def store(self, bundle: ArtifactBundle) -> StoredArtifact:
+        import asyncio
+
+        return await asyncio.to_thread(self._store_sync, bundle)
+
+    def _store_sync(self, bundle: ArtifactBundle) -> StoredArtifact:
+        glb_key = self._upload(bundle.glb_path, f"{bundle.artifact_id}.glb", "model/gltf-binary")
+        usdz_key = (
+            self._upload(bundle.usdz_path, f"{bundle.artifact_id}.usdz", "model/vnd.usdz+zip")
+            if bundle.usdz_path
+            else None
+        )
+        thumb_key = (
+            self._upload(
+                bundle.thumbnail_path,
+                f"{bundle.artifact_id}_preview.png",
+                "image/png",
+            )
+            if bundle.thumbnail_path
+            else None
+        )
+
+        return StoredArtifact(
+            artifact_id=bundle.artifact_id,
+            glb_path=bundle.glb_path,
+            glb_url=self._url_for(glb_key),
+            usdz_path=bundle.usdz_path,
+            usdz_url=self._url_for(usdz_key) if usdz_key else None,
+            thumbnail_path=bundle.thumbnail_path,
+            thumbnail_url=self._url_for(thumb_key) if thumb_key else None,
+            metadata={"store": "s3", "bucket": self.bucket, "prefix": self.prefix},
+        )
+
+    def _upload(self, path: str, name: str, content_type: str) -> str:
+        client = self._get_client()
+        key = f"{self.prefix}/{name}"
+        client.upload_file(
+            path,
+            self.bucket,
+            key,
+            ExtraArgs={"ContentType": content_type, "CacheControl": "public,max-age=31536000"},
+        )
+        return key
+
+    def _url_for(self, key: str) -> str:
+        if self.public_base_url:
+            return f"{self.public_base_url}/{key}"
+
+        client = self._get_client()
+        return client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self.bucket, "Key": key},
+            ExpiresIn=self.signed_url_ttl_seconds,
+        )
+
+
+__all__ = [
+    "ArtifactBundle",
+    "ArtifactStore",
+    "LocalArtifactStore",
+    "S3ArtifactStore",
+    "StoredArtifact",
+]

--- a/pipelines/clothing_3d/worker.py
+++ b/pipelines/clothing_3d/worker.py
@@ -1,0 +1,346 @@
+"""Background worker for the clothing 3D pipeline.
+
+Single-process async worker that:
+
+1. Pulls a :class:`QueueMessage` from the job queue.
+2. Loads the matching :class:`JobRecord` from the job store.
+3. Runs the pipeline via :class:`ClothingPipeline`, honoring the retry policy
+   and the per-backend cost quota.
+4. Persists the final :class:`PipelineResult` back to the store, ACKs the
+   queue.
+
+Crash-safety: a worker that dies mid-job leaves the message unacked. With
+:class:`RedisStreamsQueue`, :meth:`reclaim_pending` on a sibling worker
+re-delivers the message after ``reclaim_idle_ms``. With
+:class:`InMemoryQueue`, the message is lost (acceptable for dev).
+
+Scale-out: launch multiple worker processes (``CLOTHING_3D_WORKERS=4``); each
+sets a unique ``consumer_name`` and Redis Streams load-balances naturally.
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import socket
+import uuid
+from contextlib import suppress
+from datetime import UTC, datetime
+from typing import Any
+
+from pipelines.clothing_3d.events import PipelineEventBus, log_event_subscriber
+from pipelines.clothing_3d.job_store import JobRecord, JobStore, build_job_store
+from pipelines.clothing_3d.models import PipelineRequest, PipelineStatus
+from pipelines.clothing_3d.observability import (
+    configure_logging,
+    get_metrics,
+    metrics_event_subscriber,
+)
+from pipelines.clothing_3d.pipeline import ClothingPipeline
+from pipelines.clothing_3d.queue import JobQueue, QueueMessage, build_queue
+from pipelines.clothing_3d.reliability import (
+    CostQuota,
+    IdempotencyCache,
+    QuotaExceededError,
+    RetryPolicy,
+    request_fingerprint,
+)
+from services.three_d.trellis.config import TrellisConfig
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Worker
+# =============================================================================
+
+
+class PipelineWorker:
+    """Long-running async worker.
+
+    Args:
+        pipeline: Pre-built :class:`ClothingPipeline`. Defaults from env.
+        queue: Pre-built :class:`JobQueue`. Defaults from env.
+        store: Pre-built :class:`JobStore`. Defaults from env.
+        concurrency: Concurrent in-flight jobs.
+        retry: Per-job retry policy when the pipeline raises a retryable error.
+        quota: Per-backend cost ceiling.
+        idempotency: Skip dispatch when an identical fingerprint just succeeded.
+        worker_id: Display name; defaults to ``${HOSTNAME}-${PID}-${RAND}``.
+        reclaim_interval_seconds: How often to re-queue dropped messages.
+        poll_block_seconds: How long each ``dequeue`` blocks; affects shutdown latency.
+    """
+
+    def __init__(
+        self,
+        *,
+        pipeline: ClothingPipeline | None = None,
+        queue: JobQueue | None = None,
+        store: JobStore | None = None,
+        concurrency: int = 1,
+        retry: RetryPolicy | None = None,
+        quota: CostQuota | None = None,
+        idempotency: IdempotencyCache | None = None,
+        worker_id: str | None = None,
+        reclaim_interval_seconds: float = 30.0,
+        poll_block_seconds: float = 5.0,
+    ) -> None:
+        self.pipeline = pipeline or ClothingPipeline(config=TrellisConfig.from_env())
+        self.queue = queue or build_queue()
+        self.store = store or build_job_store()
+        self.concurrency = max(1, concurrency)
+        self.retry = retry or RetryPolicy()
+        self.quota = quota or CostQuota()
+        self.idempotency = idempotency or IdempotencyCache()
+        self.worker_id = worker_id or _build_worker_id()
+        self.reclaim_interval_seconds = reclaim_interval_seconds
+        self.poll_block_seconds = poll_block_seconds
+
+        self._metrics = get_metrics()
+        self._stop = asyncio.Event()
+        self._sem = asyncio.Semaphore(self.concurrency)
+        self._inflight: set[asyncio.Task[Any]] = set()
+
+        # Wire metrics into the pipeline's event bus.
+        if isinstance(self.pipeline.event_bus, PipelineEventBus):
+            self.pipeline.event_bus.subscribe(metrics_event_subscriber(self._metrics))
+
+    # ---------------------------------------------------------------------
+    # Lifecycle
+    # ---------------------------------------------------------------------
+
+    async def run(self) -> None:
+        """Main loop. Returns when :meth:`shutdown` is called."""
+        logger.info(
+            "worker.start id=%s concurrency=%s queue=%s store=%s",
+            self.worker_id,
+            self.concurrency,
+            type(self.queue).__name__,
+            type(self.store).__name__,
+        )
+        reclaim_task: asyncio.Task[Any] | None = None
+        if hasattr(self.queue, "reclaim_pending"):
+            reclaim_task = asyncio.create_task(self._reclaim_loop(), name="reclaim-loop")
+
+        try:
+            while not self._stop.is_set():
+                # Backpressure: gate dequeue on the semaphore.
+                await self._sem.acquire()
+                msg = await self.queue.dequeue(block_seconds=self.poll_block_seconds)
+                if msg is None:
+                    self._sem.release()
+                    continue
+
+                task = asyncio.create_task(
+                    self._process_one(msg), name=f"job-{msg.job_id}"
+                )
+                self._inflight.add(task)
+                task.add_done_callback(self._on_task_done)
+        finally:
+            if reclaim_task:
+                reclaim_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await reclaim_task
+            await self._drain()
+            await self.queue.close()
+            await self.store.close()
+            await self.pipeline.close()
+            logger.info("worker.stopped id=%s", self.worker_id)
+
+    async def shutdown(self) -> None:
+        """Request a clean shutdown. Idempotent."""
+        self._stop.set()
+
+    # ---------------------------------------------------------------------
+    # Per-job pipeline
+    # ---------------------------------------------------------------------
+
+    async def _process_one(self, msg: QueueMessage) -> None:
+        try:
+            job = await self.store.get(msg.job_id)
+            if job is None:
+                logger.warning("worker.job_missing job_id=%s", msg.job_id)
+                await self.queue.ack(msg)
+                return
+            if job.request is None:
+                logger.warning("worker.no_request job_id=%s", msg.job_id)
+                job.status = PipelineStatus.FAILED
+                job.error = "missing request body"
+                job.finished_at = datetime.now(UTC)
+                await self.store.update(job)
+                await self.queue.ack(msg)
+                return
+
+            await self._mark_running(job, msg)
+            backend = self._backend_for(job.request)
+            try:
+                self.quota.charge(backend)
+            except QuotaExceededError as exc:
+                logger.warning("worker.quota_exceeded backend=%s job=%s err=%s",
+                               backend, job.job_id, exc)
+                job.status = PipelineStatus.FAILED
+                job.error = f"quota exceeded: {exc}"
+                job.finished_at = datetime.now(UTC)
+                await self.store.update(job)
+                await self.queue.ack(msg)
+                return
+
+            await self._run_with_retry(job, msg, backend)
+        except Exception as exc:  # noqa: BLE001 — worker must never crash on a job
+            logger.exception("worker.unhandled job=%s", msg.job_id)
+            await self._fail_terminal(msg, str(exc))
+        finally:
+            self._sem.release()
+
+    async def _mark_running(self, job: JobRecord, msg: QueueMessage) -> None:
+        job.status = PipelineStatus.RUNNING
+        job.started_at = datetime.now(UTC)
+        job.attempt = msg.attempt
+        job.worker_id = self.worker_id
+        await self.store.update(job)
+
+    async def _run_with_retry(
+        self,
+        job: JobRecord,
+        msg: QueueMessage,
+        backend: str,
+    ) -> None:
+        async def _runner(req: PipelineRequest):
+            return await self.pipeline.run(req)
+
+        try:
+            result, hit = await self.idempotency.get_or_run(job.request, runner=_runner)  # type: ignore[arg-type]
+            self._metrics.cache_total.labels(outcome="hit" if hit else "miss").inc()
+            if backend in {"replicate", "modal"} and not hit:
+                cost_usd = self.quota.spent(backend) - (
+                    self.quota.spent(backend) - 0.0  # placeholder; charge already recorded
+                )
+                self._metrics.backend_cost_usd.labels(backend=backend).inc(
+                    max(cost_usd, 0.0)
+                )
+
+            job.result = result
+            job.status = result.status
+            job.error = None
+        except Exception as exc:  # noqa: BLE001
+            job.status = PipelineStatus.FAILED
+            job.error = f"{type(exc).__name__}: {exc}"
+            logger.exception("worker.pipeline_error job=%s", job.job_id)
+
+        job.finished_at = datetime.now(UTC)
+        await self.store.update(job)
+
+        terminal = job.status in {PipelineStatus.SUCCEEDED, PipelineStatus.REJECTED}
+        if terminal or job.attempt >= self.retry.max_attempts:
+            await self.queue.ack(msg)
+        else:
+            logger.info(
+                "worker.requeue job=%s attempt=%s err=%s",
+                job.job_id,
+                job.attempt,
+                job.error,
+            )
+            await self.queue.nack(msg, requeue=True)
+
+    async def _fail_terminal(self, msg: QueueMessage, error: str) -> None:
+        job = await self.store.get(msg.job_id)
+        if job is not None:
+            job.status = PipelineStatus.FAILED
+            job.error = error
+            job.finished_at = datetime.now(UTC)
+            await self.store.update(job)
+        with suppress(Exception):  # noqa: BLE001
+            await self.queue.ack(msg)
+
+    # ---------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------
+
+    def _backend_for(self, request: PipelineRequest) -> str:
+        if request.backend is not None:
+            return request.backend.value
+        return self.pipeline.provider.config.backend.value
+
+    def _on_task_done(self, task: asyncio.Task[Any]) -> None:
+        self._inflight.discard(task)
+
+    async def _drain(self) -> None:
+        if not self._inflight:
+            return
+        logger.info("worker.draining count=%s", len(self._inflight))
+        await asyncio.gather(*self._inflight, return_exceptions=True)
+
+    async def _reclaim_loop(self) -> None:
+        reclaim = getattr(self.queue, "reclaim_pending", None)
+        if reclaim is None:
+            return
+        while not self._stop.is_set():
+            try:
+                count = await reclaim()
+                if count:
+                    logger.info("worker.reclaimed count=%s", count)
+            except Exception:  # noqa: BLE001
+                logger.exception("worker.reclaim_failed")
+            try:
+                await asyncio.wait_for(
+                    self._stop.wait(),
+                    timeout=self.reclaim_interval_seconds,
+                )
+            except asyncio.TimeoutError:
+                pass
+
+
+def _build_worker_id() -> str:
+    host = socket.gethostname()
+    return f"{host}-{os.getpid()}-{uuid.uuid4().hex[:6]}"
+
+
+# =============================================================================
+# CLI entry
+# =============================================================================
+
+
+async def _run_worker(args: Any) -> int:
+    configure_logging(level=args.log_level)
+    worker = PipelineWorker(concurrency=args.concurrency)
+
+    loop = asyncio.get_running_loop()
+
+    async def _shutdown(sig: signal.Signals) -> None:
+        logger.info("worker.signal sig=%s", sig.name)
+        await worker.shutdown()
+
+    for sig_name in ("SIGINT", "SIGTERM"):
+        sig = getattr(signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            loop.add_signal_handler(sig, lambda s=sig: asyncio.create_task(_shutdown(s)))
+        except NotImplementedError:  # pragma: no cover — Windows
+            pass
+
+    await worker.run()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point: ``python -m pipelines.clothing_3d.worker``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="clothing_3d.worker")
+    parser.add_argument("--concurrency", type=int, default=int(os.getenv("CLOTHING_3D_CONCURRENCY", "1")))
+    parser.add_argument("--log-level", default=os.getenv("LOG_LEVEL", "INFO"))
+    args = parser.parse_args(argv)
+    return asyncio.run(_run_worker(args))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = ["PipelineWorker", "main"]

--- a/pipelines/clothing_3d/worker.py
+++ b/pipelines/clothing_3d/worker.py
@@ -89,7 +89,15 @@ class PipelineWorker:
         worker_id: str | None = None,
         reclaim_interval_seconds: float = 30.0,
         poll_block_seconds: float = 5.0,
+        owns_dependencies: bool | None = None,
     ) -> None:
+        # We own dependencies only when we built them ourselves — otherwise
+        # the caller (API, test harness) owns lifecycle and we'd corrupt
+        # their state by closing on shutdown.
+        owned_default = (pipeline is None) and (queue is None) and (store is None)
+        self._owns_dependencies = (
+            owned_default if owns_dependencies is None else owns_dependencies
+        )
         self.pipeline = pipeline or ClothingPipeline(config=TrellisConfig.from_env())
         self.queue = queue or build_queue()
         self.store = store or build_job_store()
@@ -147,9 +155,10 @@ class PipelineWorker:
                 with suppress(asyncio.CancelledError):
                     await reclaim_task
             await self._drain()
-            await self.queue.close()
-            await self.store.close()
-            await self.pipeline.close()
+            if self._owns_dependencies:
+                await self.queue.close()
+                await self.store.close()
+                await self.pipeline.close()
             logger.info("worker.stopped id=%s", self.worker_id)
 
     async def shutdown(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,6 +332,7 @@ include = [
     "llm*",
     "cli*",
     "services*",
+    "pipelines*",
 ]
 exclude = ["tests*", "docs*", "legacy*"]
 

--- a/requirements-trellis.txt
+++ b/requirements-trellis.txt
@@ -1,0 +1,46 @@
+# TRELLIS clothing 3D pipeline dependencies
+#
+# Install:
+#   pip install -r requirements-trellis.txt
+#
+# For LOCAL backend, also run:
+#   bash scripts/setup_trellis.sh --with-weights
+#   pip install -e vendor/trellis
+
+# --- core (always required) ---
+pillow>=10.0
+pydantic>=2.5
+httpx>=0.25
+
+# --- HF Space backend (default; cheap and CPU-only client) ---
+gradio_client>=1.0
+huggingface_hub>=0.24
+
+# --- Mesh postprocessing (recommended) ---
+trimesh>=4.0
+numpy>=1.26
+
+# --- Background removal (optional but recommended) ---
+# rembg pulls onnxruntime; pin a lighter wheel for slim images.
+rembg>=2.0.59
+onnxruntime>=1.17
+
+# --- USDZ export (optional, iOS AR) ---
+# Pick one of:
+#   - usd-core (Python, partial GLB→USDZ support)
+#   - usd_from_gltf (Google's C++ CLI, install via brew/apt)
+usd-core>=24.0; platform_system != "Windows"
+
+# --- Replicate backend (optional) ---
+replicate>=0.30
+
+# --- S3 / R2 artifact store (optional) ---
+boto3>=1.34
+
+# --- Local backend extras ---
+# Uncomment when running TRELLIS locally on a CUDA GPU.
+# torch>=2.2
+# torchvision>=0.17
+# xformers>=0.0.27
+# spconv-cu120>=2.3
+# kaolin>=0.16

--- a/requirements-trellis.txt
+++ b/requirements-trellis.txt
@@ -44,3 +44,7 @@ boto3>=1.34
 # xformers>=0.0.27
 # spconv-cu120>=2.3
 # kaolin>=0.16
+
+# --- Production hardening (queue, store, metrics) ---
+redis>=5.0           # Redis Streams queue + RedisJobStore
+prometheus_client>=0.20  # Prometheus metrics exposed at /metrics

--- a/scripts/setup_trellis.sh
+++ b/scripts/setup_trellis.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Scaffold the Microsoft TRELLIS repo under vendor/trellis/ for local inference.
+#
+# Usage:
+#   bash scripts/setup_trellis.sh                          # default: clone, no model download
+#   bash scripts/setup_trellis.sh --with-weights           # also pull image-large weights
+#   bash scripts/setup_trellis.sh --upgrade                # pull latest from origin
+#   TRELLIS_REPO=https://github.com/microsoft/TRELLIS.git bash scripts/setup_trellis.sh
+#
+# After this:
+#   pip install -r requirements-trellis.txt
+#   pip install -e vendor/trellis
+#   TRELLIS_BACKEND=local python -m pipelines.clothing_3d.cli health
+#
+# Environment:
+#   TRELLIS_REPO       — git URL (default: https://github.com/microsoft/TRELLIS.git)
+#   TRELLIS_LOCAL_PATH — where to clone (default: vendor/trellis)
+#   TRELLIS_BRANCH     — branch / tag to check out (default: main)
+
+set -euo pipefail
+
+REPO_URL="${TRELLIS_REPO:-https://github.com/microsoft/TRELLIS.git}"
+LOCAL_PATH="${TRELLIS_LOCAL_PATH:-vendor/trellis}"
+BRANCH="${TRELLIS_BRANCH:-main}"
+
+WITH_WEIGHTS=false
+UPGRADE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --with-weights) WITH_WEIGHTS=true ;;
+    --upgrade)      UPGRADE=true ;;
+    -h|--help)
+      sed -n '2,17p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown flag: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$(dirname "$0")/.."
+
+mkdir -p "$(dirname "$LOCAL_PATH")"
+
+if [ -d "$LOCAL_PATH/.git" ]; then
+  if [ "$UPGRADE" = true ]; then
+    echo ">>> Updating existing TRELLIS clone at $LOCAL_PATH"
+    git -C "$LOCAL_PATH" fetch origin
+    git -C "$LOCAL_PATH" checkout "$BRANCH"
+    git -C "$LOCAL_PATH" pull --ff-only origin "$BRANCH"
+  else
+    echo ">>> TRELLIS already present at $LOCAL_PATH (pass --upgrade to pull latest)"
+  fi
+else
+  echo ">>> Cloning $REPO_URL into $LOCAL_PATH (branch=$BRANCH)"
+  git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$LOCAL_PATH"
+fi
+
+# Mark the vendor copy as not-tracked by this repo's git.
+GITIGNORE="vendor/.gitignore"
+if [ ! -f "$GITIGNORE" ]; then
+  cat > "$GITIGNORE" <<'EOF'
+# All vendored third-party trees are excluded — see scripts/setup_trellis.sh.
+*
+!.gitignore
+EOF
+fi
+
+echo ">>> Verifying TRELLIS layout"
+required=(trellis pipelines.py setup.py)
+for f in "${required[@]}"; do
+  if [ ! -e "$LOCAL_PATH/$f" ]; then
+    echo "WARN: expected $LOCAL_PATH/$f — repo layout may have changed" >&2
+  fi
+done
+
+if [ "$WITH_WEIGHTS" = true ]; then
+  echo ">>> Pre-downloading microsoft/TRELLIS-image-large via HuggingFace"
+  if ! command -v python >/dev/null 2>&1; then
+    echo "python not found on PATH; skipping weight prefetch" >&2
+  else
+    python - <<'PY'
+import os
+from huggingface_hub import snapshot_download
+
+cache = os.environ.get("TRELLIS_CACHE_DIR", "./.cache/trellis")
+snapshot_download(
+    repo_id="microsoft/TRELLIS-image-large",
+    cache_dir=cache,
+    local_dir_use_symlinks=False,
+)
+print(f">>> Weights cached under {cache}")
+PY
+  fi
+fi
+
+cat <<EOF
+
+TRELLIS is ready at: $LOCAL_PATH
+
+Next steps:
+  pip install -r requirements-trellis.txt
+  pip install -e $LOCAL_PATH
+
+Then test the local backend:
+  TRELLIS_BACKEND=local python -m pipelines.clothing_3d.cli health
+
+Or run a dry-run against the stub backend (no GPU required):
+  python -m pipelines.clothing_3d.cli generate \\
+    --image path/to/garment.jpg \\
+    --product "Test" --garment-type tee \\
+    --quality draft --dry-run
+
+EOF

--- a/scripts/smoke_test_clothing_3d.sh
+++ b/scripts/smoke_test_clothing_3d.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Smoke test for the clothing 3D pipeline.
+#
+# Exercises the full stack against the stub TRELLIS backend so it runs in
+# under 5 seconds and needs no GPU, network, or paid API credits. Designed
+# to drop into CI:
+#
+#   bash scripts/smoke_test_clothing_3d.sh
+#
+# Exit codes:
+#   0  — all checks passed
+#   1  — at least one check failed (specific failure printed)
+#   2  — environment missing (python, etc.)
+#
+# Override the worker concurrency for the worker-roundtrip step:
+#   SMOKE_CONCURRENCY=2 bash scripts/smoke_test_clothing_3d.sh
+#
+# Use a stub backend; force in-memory queue/store so we don't touch Redis.
+set -euo pipefail
+
+# Prefer Python ≥3.12 (project requirement) — the codebase uses 3.12 type-param syntax.
+if [ -n "${PYTHON:-}" ]; then
+  PY="$PYTHON"
+elif command -v python3.12 >/dev/null 2>&1; then
+  PY="$(command -v python3.12)"
+elif command -v python3.13 >/dev/null 2>&1; then
+  PY="$(command -v python3.13)"
+elif command -v python3 >/dev/null 2>&1; then
+  PY="$(command -v python3)"
+elif command -v python >/dev/null 2>&1; then
+  PY="$(command -v python)"
+else
+  echo "✗ no python interpreter on PATH" >&2
+  exit 2
+fi
+
+# Sanity-check: the project requires Python ≥3.12.
+if ! "$PY" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 12) else 1)'; then
+  ver="$("$PY" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')"
+  echo "✗ Python $ver is too old — DevSkyy requires Python ≥3.12 (set PYTHON=/path/to/python3.12)" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Fresh tmpdir; cleaned on exit.
+TMPDIR="$(mktemp -d -t clothing3d-smoke-XXXXXX)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+export THREE_D_OUTPUT_DIR="$TMPDIR/out"
+export TRELLIS_CACHE_DIR="$TMPDIR/cache"
+export TRELLIS_BACKEND="hf_space"   # the worker won't actually call it; we use dry-run
+export CLOTHING_3D_QUEUE="memory"
+export CLOTHING_3D_JOB_STORE="memory"
+export TRELLIS_DRY_RUN="1"
+
+mkdir -p "$THREE_D_OUTPUT_DIR" "$TRELLIS_CACHE_DIR"
+
+pass() { printf "✓ %s\n" "$1"; }
+fail() { printf "✗ %s\n   %s\n" "$1" "${2:-}"; exit 1; }
+
+# ─── 1. Imports ──────────────────────────────────────────────────────────
+"$PY" - <<'PY' || fail "imports" "see traceback above"
+from pipelines.clothing_3d import (
+    ClothingPipeline, CostQuota, IdempotencyCache,
+    InMemoryJobStore, InMemoryQueue, JobRecord,
+    PipelineRequest, PipelineWorker, PipelineStatus,
+    RetryPolicy, request_fingerprint, configure_logging, get_metrics,
+)
+PY
+pass "imports"
+
+# ─── 2. Garment classifier + prompt builder ─────────────────────────────
+"$PY" - <<'PY' || fail "garment_aware" "classifier broken"
+from services.three_d.trellis.garment_aware import classify_garment, build_clothing_prompt, GarmentCategory
+assert classify_garment(declared_category="hoodie") is GarmentCategory.HOODIE
+assert classify_garment(product_name="Long Dress") is GarmentCategory.DRESS
+p = build_clothing_prompt(product_name="X", category=GarmentCategory.HOODIE, collection="black_rose")
+assert "hood" in p.lower() and "chrome" in p.lower()
+PY
+pass "garment_aware"
+
+# ─── 3. Pipeline end-to-end with stub backend ───────────────────────────
+"$PY" - <<'PY' || fail "pipeline end-to-end" "stub run failed"
+import asyncio, sys, tempfile, pathlib
+from PIL import Image
+from pipelines.clothing_3d import ClothingPipeline, PipelineRequest, PipelineStatus
+from pipelines.clothing_3d.stages import QCThresholds
+from services.three_d.trellis.config import TrellisConfig, TrellisQualityPreset
+from services.three_d.trellis.provider import TrellisProvider
+from services.three_d.trellis.client import StubClient
+
+async def main():
+    cfg = TrellisConfig(
+        cache_dir=__import__("os").environ["TRELLIS_CACHE_DIR"],
+        output_dir=__import__("os").environ["THREE_D_OUTPUT_DIR"],
+        enable_background_removal=False,
+        enable_postprocess=False,
+        export_usdz_for_ios=False,
+        quality=TrellisQualityPreset.DRAFT,
+        retry_attempts=0,
+    )
+    cfg.ensure_dirs()
+    img = pathlib.Path(cfg.cache_dir) / "smoke.png"
+    Image.new("RGB", (600, 800), (220, 220, 220)).save(img)
+    pipe = ClothingPipeline(
+        config=cfg,
+        provider=TrellisProvider(cfg, backend=StubClient(cfg)),
+        thresholds=QCThresholds(min_polycount=0, max_polycount=10**9, min_file_kb=0, max_file_kb=10**9),
+    )
+    res = await pipe.run(PipelineRequest(image_path=str(img), product_name="Smoke", garment_type="tee", skip_qc=True))
+    assert res.status is PipelineStatus.SUCCEEDED, f"expected SUCCEEDED, got {res.status}: {res.metadata}"
+    assert res.glb_url and res.glb_url.startswith("/assets/3d-models-generated/")
+    await pipe.close()
+
+asyncio.run(main())
+PY
+pass "pipeline end-to-end"
+
+# ─── 4. Idempotency cache hit ────────────────────────────────────────────
+"$PY" - <<'PY' || fail "idempotency" "cache hit not detected"
+import asyncio, os, pathlib, tempfile
+from PIL import Image
+from pipelines.clothing_3d import (
+    ClothingPipeline, IdempotencyCache, PipelineRequest,
+)
+from pipelines.clothing_3d.stages import QCThresholds
+from services.three_d.trellis.config import TrellisConfig, TrellisQualityPreset
+from services.three_d.trellis.provider import TrellisProvider
+from services.three_d.trellis.client import StubClient
+
+async def main():
+    cfg = TrellisConfig(
+        cache_dir=os.environ["TRELLIS_CACHE_DIR"],
+        output_dir=os.environ["THREE_D_OUTPUT_DIR"],
+        enable_background_removal=False, enable_postprocess=False,
+        export_usdz_for_ios=False, quality=TrellisQualityPreset.DRAFT,
+    )
+    cfg.ensure_dirs()
+    img = pathlib.Path(cfg.cache_dir) / "smoke_idem.png"
+    Image.new("RGB", (400, 500), (200, 200, 200)).save(img)
+    pipe = ClothingPipeline(config=cfg, provider=TrellisProvider(cfg, backend=StubClient(cfg)),
+                            thresholds=QCThresholds(min_polycount=0, max_polycount=10**9, min_file_kb=0, max_file_kb=10**9))
+    cache = IdempotencyCache(ttl_seconds=60)
+    req = PipelineRequest(image_path=str(img), product_name="Idem", garment_type="tee", skip_qc=True)
+    r1, hit1 = await cache.get_or_run(req, runner=pipe.run)
+    r2, hit2 = await cache.get_or_run(req, runner=pipe.run)
+    assert not hit1, "first call should be a miss"
+    assert hit2, "second call should be a hit"
+    assert r1.glb_url == r2.glb_url
+    await pipe.close()
+
+asyncio.run(main())
+PY
+pass "idempotency cache"
+
+# ─── 5. Cost quota ───────────────────────────────────────────────────────
+"$PY" - <<'PY' || fail "cost quota" "QuotaExceededError not raised"
+from pipelines.clothing_3d.reliability import CostQuota, QuotaExceededError
+q = CostQuota(caps_usd={"replicate": 0.10})
+q.charge("replicate"); q.charge("replicate")  # 2 calls @ $0.05 = $0.10
+try:
+    q.charge("replicate")  # would push over
+except QuotaExceededError:
+    pass
+else:
+    raise AssertionError("expected QuotaExceededError")
+PY
+pass "cost quota"
+
+# ─── 6. Retry policy backoff ─────────────────────────────────────────────
+"$PY" - <<'PY' || fail "retry policy" "did not retry correctly"
+import asyncio
+from pipelines.clothing_3d.reliability import RetryPolicy
+
+calls = []
+async def flaky():
+    calls.append(1)
+    if len(calls) < 3:
+        raise TimeoutError("flake")
+    return "ok"
+
+policy = RetryPolicy(max_attempts=3, base_delay_seconds=0.001, max_delay_seconds=0.01)
+result = asyncio.run(policy.run(flaky))
+assert result == "ok"
+assert len(calls) == 3
+PY
+pass "retry policy"
+
+# ─── 7. Queue + Worker round-trip ────────────────────────────────────────
+"$PY" - <<'PY' || fail "worker round-trip" "worker did not finish job"
+import asyncio, os, pathlib
+from PIL import Image
+from pipelines.clothing_3d import (
+    ClothingPipeline, InMemoryJobStore, InMemoryQueue,
+    JobRecord, PipelineRequest, PipelineStatus, PipelineWorker,
+)
+from pipelines.clothing_3d.stages import QCThresholds
+from services.three_d.trellis.config import TrellisConfig, TrellisQualityPreset
+from services.three_d.trellis.provider import TrellisProvider
+from services.three_d.trellis.client import StubClient
+
+async def main():
+    cfg = TrellisConfig(
+        cache_dir=os.environ["TRELLIS_CACHE_DIR"],
+        output_dir=os.environ["THREE_D_OUTPUT_DIR"],
+        enable_background_removal=False, enable_postprocess=False,
+        export_usdz_for_ios=False, quality=TrellisQualityPreset.DRAFT,
+        retry_attempts=0,
+    )
+    cfg.ensure_dirs()
+    img = pathlib.Path(cfg.cache_dir) / "worker_smoke.png"
+    Image.new("RGB", (500, 700), (210, 210, 210)).save(img)
+
+    pipe = ClothingPipeline(
+        config=cfg,
+        provider=TrellisProvider(cfg, backend=StubClient(cfg)),
+        thresholds=QCThresholds(min_polycount=0, max_polycount=10**9, min_file_kb=0, max_file_kb=10**9),
+    )
+    queue, store = InMemoryQueue(), InMemoryJobStore()
+    worker = PipelineWorker(
+        pipeline=pipe, queue=queue, store=store,
+        concurrency=1, poll_block_seconds=0.5, reclaim_interval_seconds=5,
+    )
+
+    record = JobRecord(
+        job_id="smoke-1",
+        request=PipelineRequest(image_path=str(img), product_name="W", garment_type="tee", skip_qc=True),
+    )
+    await store.put(record)
+    await queue.enqueue("smoke-1")
+
+    task = asyncio.create_task(worker.run())
+    for _ in range(80):  # up to 8 seconds
+        await asyncio.sleep(0.1)
+        latest = await store.get("smoke-1")
+        if latest and latest.status in {PipelineStatus.SUCCEEDED, PipelineStatus.REJECTED, PipelineStatus.FAILED}:
+            break
+    else:
+        await worker.shutdown()
+        await task
+        raise AssertionError(f"worker never finished job; final status = {(latest.status if latest else 'missing')}")
+
+    await worker.shutdown()
+    await task
+    assert latest.status is PipelineStatus.SUCCEEDED, f"expected SUCCEEDED, got {latest.status} (err={latest.error})"
+    assert latest.result is not None
+    assert latest.result.glb_url
+
+asyncio.run(main())
+PY
+pass "worker round-trip"
+
+echo
+echo "All clothing_3d smoke checks passed."

--- a/scripts/trellis_demo.py
+++ b/scripts/trellis_demo.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""End-to-end demo for the clothing 3D pipeline.
+
+Runs against the stub backend by default so you can validate orchestration
+without burning a GPU or hitting the HF Space. Pass ``--backend hf_space``
+once you've confirmed your gradio_client install is healthy.
+
+Examples:
+    # Stub run
+    python scripts/trellis_demo.py
+
+    # HuggingFace Space (no GPU required, slow cold-start)
+    python scripts/trellis_demo.py --backend hf_space --image path/to/hoodie.jpg
+
+    # Local GPU (requires scripts/setup_trellis.sh + weights)
+    python scripts/trellis_demo.py --backend local --image path/to/hoodie.jpg --quality production
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+import tempfile
+from pathlib import Path
+
+# Allow ``python scripts/trellis_demo.py`` from the repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from pipelines.clothing_3d.models import PipelineRequest  # noqa: E402
+from pipelines.clothing_3d.pipeline import ClothingPipeline  # noqa: E402
+from services.three_d.trellis.config import (  # noqa: E402
+    TrellisBackend,
+    TrellisConfig,
+    TrellisQualityPreset,
+)
+from services.three_d.trellis.provider import TrellisProvider, make_stub_provider  # noqa: E402
+
+logger = logging.getLogger("trellis_demo")
+
+
+def _make_synthetic_image() -> str:
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGB", (800, 1000), (245, 245, 245))
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([200, 200, 600, 850], fill=(20, 20, 28))
+    draw.rectangle([350, 220, 450, 280], fill=(245, 245, 245))  # hood opening
+    tmp = Path(tempfile.mkdtemp(prefix="trellis_demo_")) / "synthetic_hoodie.png"
+    img.save(tmp)
+    return str(tmp)
+
+
+async def run_demo(args: argparse.Namespace) -> int:
+    config = TrellisConfig.from_env()
+    is_stub = args.backend == "stub" or args.dry_run
+    if not is_stub:
+        config.backend = TrellisBackend(args.backend)
+    config.quality = TrellisQualityPreset(args.quality)
+    config.ensure_dirs()
+
+    if is_stub:
+        provider = make_stub_provider(config)
+    else:
+        provider = TrellisProvider(config)
+
+    pipeline = ClothingPipeline(config=config, provider=provider)
+
+    try:
+        image_path = args.image or _make_synthetic_image()
+        logger.info("input image: %s", image_path)
+
+        request = PipelineRequest(
+            image_path=image_path,
+            product_name=args.product,
+            collection=args.collection,
+            garment_type=args.garment_type,
+            quality=TrellisQualityPreset(args.quality),
+        )
+        result = await pipeline.run(request)
+    finally:
+        await pipeline.close()
+
+    print(json.dumps(result.model_dump(mode="json"), indent=2, default=str))
+    return 0 if result.succeeded else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--backend",
+        choices=[*[b.value for b in TrellisBackend], "stub"],
+        default="stub",
+    )
+    parser.add_argument(
+        "--quality",
+        choices=[q.value for q in TrellisQualityPreset],
+        default=TrellisQualityPreset.DRAFT.value,
+    )
+    parser.add_argument("--image", default=None, help="Override the synthetic input")
+    parser.add_argument("--product", default="Demo Black Rose Hoodie")
+    parser.add_argument("--collection", default="black_rose")
+    parser.add_argument("--garment-type", default="hoodie")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    return asyncio.run(run_demo(args))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/services/three_d/provider_factory.py
+++ b/services/three_d/provider_factory.py
@@ -65,8 +65,9 @@ class FactoryConfig:
     text_to_3d_order: list[str] = field(
         default_factory=lambda: ["tripo", "replicate", "huggingface"]
     )
+    # TRELLIS is the primary image-to-3D path — best mesh + texture quality for garments.
     image_to_3d_order: list[str] = field(
-        default_factory=lambda: ["tripo", "huggingface", "replicate"]
+        default_factory=lambda: ["trellis", "tripo", "huggingface", "replicate"]
     )
     # Image generation order (Gemini Nano Banana Pro is primary - no rate limits)
     image_generation_order: list[str] = field(
@@ -155,6 +156,23 @@ class ThreeDProviderFactory:
         from services.three_d.huggingface_provider import HuggingFaceProvider
         from services.three_d.replicate_provider import ReplicateProvider
         from services.three_d.tripo_provider import TripoProvider
+
+        # TRELLIS — primary for image-to-3D (best mesh quality for garments)
+        try:
+            from services.three_d.trellis.provider import TrellisProvider
+
+            self._register_provider(
+                "trellis",
+                TrellisProvider(),
+                ProviderConfig(
+                    provider_type="trellis",
+                    priority=ProviderPriority.PRIMARY,
+                    weight=110,
+                ),
+            )
+            logger.info("TRELLIS provider registered (image-to-3D primary)")
+        except Exception as e:  # noqa: BLE001 — provider must not block factory init
+            logger.warning(f"Failed to register TRELLIS provider: {e}")
 
         # Register providers
         self._register_provider(

--- a/services/three_d/trellis/__init__.py
+++ b/services/three_d/trellis/__init__.py
@@ -1,0 +1,69 @@
+"""TRELLIS — Microsoft's Structured 3D Latents pipeline for clothing.
+
+End-to-end image-to-3D + text-to-3D generation tuned for garment imagery.
+Backed by https://github.com/microsoft/TRELLIS (vendored at ``vendor/trellis``)
+with fallback to the public HuggingFace Space ``JeffreyXiang/TRELLIS``.
+
+Subpackages
+-----------
+- :mod:`config` — declarative configuration
+- :mod:`garment_aware` — clothing-category knowledge & prompt templating
+- :mod:`preprocess` — input image preparation (bg removal, crop, normalize)
+- :mod:`client` — backend transport (HF Space / local Python / Replicate)
+- :mod:`postprocess` — mesh cleanup, format conversion, AR export
+- :mod:`provider` — :class:`I3DProvider` implementation used by the factory
+
+Entry point
+-----------
+.. code-block:: python
+
+    from services.three_d.trellis import TrellisProvider, TrellisConfig
+
+    provider = TrellisProvider(TrellisConfig.from_env())
+    response = await provider.generate_from_image(request)
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+from services.three_d.trellis.config import (
+    TrellisBackend,
+    TrellisConfig,
+    TrellisQualityPreset,
+)
+from services.three_d.trellis.garment_aware import (
+    GarmentCategory,
+    GarmentKnowledge,
+    build_clothing_prompt,
+    classify_garment,
+)
+from services.three_d.trellis.postprocess import MeshPostprocessor, PostprocessResult
+from services.three_d.trellis.preprocess import (
+    PreprocessedImage,
+    PreprocessResult,
+    TrellisPreprocessor,
+)
+from services.three_d.trellis.provider import TrellisProvider
+
+__all__ = [
+    # Provider
+    "TrellisProvider",
+    # Config
+    "TrellisConfig",
+    "TrellisBackend",
+    "TrellisQualityPreset",
+    # Preprocessing
+    "TrellisPreprocessor",
+    "PreprocessedImage",
+    "PreprocessResult",
+    # Postprocessing
+    "MeshPostprocessor",
+    "PostprocessResult",
+    # Garment knowledge
+    "GarmentCategory",
+    "GarmentKnowledge",
+    "classify_garment",
+    "build_clothing_prompt",
+]

--- a/services/three_d/trellis/client.py
+++ b/services/three_d/trellis/client.py
@@ -1,0 +1,613 @@
+"""TRELLIS transport clients.
+
+Backend transports for the TRELLIS model, all conforming to
+:class:`TrellisBackendClient`. The provider picks one at runtime based on
+:class:`~services.three_d.trellis.config.TrellisBackend`.
+
+Currently implemented:
+- :class:`HFSpaceClient` — calls ``JeffreyXiang/TRELLIS`` via ``gradio_client``
+- :class:`LocalTrellisClient` — runs the vendored TRELLIS repo in-process
+  (lazy-imports the heavy deps; requires CUDA + model weights)
+- :class:`ReplicateClient` — hits the hosted Replicate endpoint
+- :class:`StubClient` — deterministic fixture for tests / dry-runs
+
+All clients return :class:`BackendResult` describing where to find the GLB
+on local disk and any side-artifacts (preview MP4, gaussian splat .ply).
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from services.three_d.trellis.config import (
+    TrellisBackend,
+    TrellisConfig,
+    TrellisSamplingParams,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Result model
+# =============================================================================
+
+
+@dataclass(slots=True)
+class BackendResult:
+    """Outcome of a TRELLIS backend call.
+
+    Attributes:
+        glb_path: Local filesystem path to the generated GLB.
+        preview_path: Optional path to a preview MP4 / image strip.
+        splat_path: Optional path to the raw Gaussian splat ``.ply``.
+        seed: Seed used (echo back for reproducibility).
+        backend: Which backend produced this result.
+        duration_seconds: Wall-clock duration of the backend call.
+        metadata: Free-form provider metadata.
+    """
+
+    glb_path: str
+    preview_path: str | None = None
+    splat_path: str | None = None
+    seed: int | None = None
+    backend: str = ""
+    duration_seconds: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# =============================================================================
+# Protocol
+# =============================================================================
+
+
+@runtime_checkable
+class TrellisBackendClient(Protocol):
+    """Common interface for all TRELLIS transports."""
+
+    backend_name: str
+
+    async def generate_from_image(
+        self,
+        image_path: str,
+        *,
+        sampling: TrellisSamplingParams,
+        prompt_hint: str | None = None,
+        seed: int | None = None,
+    ) -> BackendResult: ...
+
+    async def generate_from_text(
+        self,
+        prompt: str,
+        *,
+        sampling: TrellisSamplingParams,
+        seed: int | None = None,
+    ) -> BackendResult: ...
+
+    async def healthy(self) -> tuple[bool, str | None]: ...
+
+    async def close(self) -> None: ...
+
+
+# =============================================================================
+# Errors
+# =============================================================================
+
+
+class BackendUnavailable(RuntimeError):
+    """The configured backend cannot service the request right now."""
+
+
+# =============================================================================
+# HuggingFace Space backend
+# =============================================================================
+
+
+class HFSpaceClient:
+    """Hits the public ``JeffreyXiang/TRELLIS`` Space via Gradio.
+
+    Free, no GPU required client-side, but cold starts can be slow and the
+    space occasionally rate-limits. Production deployments should consider
+    Replicate or self-hosted Modal.
+    """
+
+    backend_name = TrellisBackend.HF_SPACE.value
+
+    def __init__(self, config: TrellisConfig) -> None:
+        self.config = config
+        self._client: Any = None
+
+    async def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            from gradio_client import Client
+        except ImportError as e:
+            raise BackendUnavailable(
+                "gradio_client not installed — pip install gradio_client"
+            ) from e
+
+        def _build() -> Any:
+            return Client(
+                self.config.hf_space_id,
+                hf_token=self.config.hf_token,
+            )
+
+        self._client = await asyncio.to_thread(_build)
+        return self._client
+
+    async def healthy(self) -> tuple[bool, str | None]:
+        try:
+            from gradio_client import Client  # noqa: F401
+        except ImportError:
+            return False, "gradio_client not installed"
+        try:
+            await self._get_client()
+            return True, None
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def generate_from_image(
+        self,
+        image_path: str,
+        *,
+        sampling: TrellisSamplingParams,
+        prompt_hint: str | None = None,
+        seed: int | None = None,
+    ) -> BackendResult:
+        client = await self._get_client()
+        seed_val = seed if seed is not None else (self.config.seed or 0)
+        start = time.time()
+
+        try:
+            from gradio_client import handle_file
+        except ImportError as e:
+            raise BackendUnavailable("gradio_client missing handle_file") from e
+
+        def _call() -> Any:
+            return client.predict(
+                image=handle_file(image_path),
+                multiimages=[],
+                seed=seed_val,
+                ss_guidance_strength=sampling.ss_guidance_strength,
+                ss_sampling_steps=sampling.ss_sampling_steps,
+                slat_guidance_strength=sampling.slat_guidance_strength,
+                slat_sampling_steps=sampling.slat_sampling_steps,
+                multiimage_algo="stochastic",
+                mesh_simplify=sampling.mesh_simplify,
+                texture_size=sampling.texture_size,
+                api_name="/generate_and_extract_glb",
+            )
+
+        try:
+            result = await asyncio.wait_for(
+                asyncio.to_thread(_call),
+                timeout=self.config.timeout_seconds,
+            )
+        except asyncio.TimeoutError as e:
+            raise TimeoutError(
+                f"TRELLIS HF Space timed out after {self.config.timeout_seconds}s"
+            ) from e
+
+        # The space returns (video_info, glb_path, download_path)
+        if not isinstance(result, (list, tuple)) or len(result) < 2:
+            raise BackendUnavailable(f"Unexpected TRELLIS response shape: {type(result)}")
+
+        video_info, glb_path = result[0], result[1]
+        if not glb_path or not os.path.exists(glb_path):
+            raise BackendUnavailable("TRELLIS HF Space returned no GLB")
+
+        return BackendResult(
+            glb_path=glb_path,
+            preview_path=_extract_preview(video_info),
+            seed=seed_val,
+            backend=self.backend_name,
+            duration_seconds=time.time() - start,
+            metadata={"hf_space": self.config.hf_space_id, "prompt_hint": prompt_hint},
+        )
+
+    async def generate_from_text(
+        self,
+        prompt: str,
+        *,
+        sampling: TrellisSamplingParams,
+        seed: int | None = None,
+    ) -> BackendResult:
+        raise BackendUnavailable(
+            "TRELLIS HF Space does not expose text-to-3D — use image-to-3D or "
+            "switch to LOCAL backend with TRELLIS-text-large weights"
+        )
+
+    async def close(self) -> None:
+        self._client = None
+
+
+def _extract_preview(video_info: Any) -> str | None:
+    """Pull a usable preview path out of the HF Space's video payload."""
+    if isinstance(video_info, str) and os.path.exists(video_info):
+        return video_info
+    if isinstance(video_info, dict) and "video" in video_info:
+        candidate = video_info["video"]
+        if isinstance(candidate, str) and os.path.exists(candidate):
+            return candidate
+    return None
+
+
+# =============================================================================
+# Local backend (vendored TRELLIS repo)
+# =============================================================================
+
+
+class LocalTrellisClient:
+    """Runs TRELLIS in-process from the vendored repo at ``vendor/trellis``.
+
+    Requires:
+    - ``vendor/trellis/`` (cloned via ``scripts/setup_trellis.sh``)
+    - CUDA-capable GPU with >=16 GB VRAM (image-large) or >=24 GB (text-large)
+    - ``pip install -r requirements-trellis.txt``
+    - Model weights cached under ``$TRELLIS_CACHE_DIR``
+
+    The class lazy-imports the pipeline so importing this module on a
+    GPU-less dev box doesn't blow up.
+    """
+
+    backend_name = TrellisBackend.LOCAL.value
+
+    def __init__(self, config: TrellisConfig) -> None:
+        self.config = config
+        self._pipeline: Any = None
+        self._pipeline_lock = asyncio.Lock()
+
+    async def _get_pipeline(self) -> Any:
+        if self._pipeline is not None:
+            return self._pipeline
+        async with self._pipeline_lock:
+            if self._pipeline is not None:
+                return self._pipeline
+            self._pipeline = await asyncio.to_thread(self._build_pipeline)
+            return self._pipeline
+
+    def _build_pipeline(self) -> Any:
+        repo_root = Path(self.config.local_repo_path).resolve()
+        if not repo_root.exists():
+            raise BackendUnavailable(
+                f"Local TRELLIS repo not found at {repo_root}. "
+                f"Run scripts/setup_trellis.sh first."
+            )
+
+        # Add the repo to sys.path so its `trellis` package is importable.
+        import sys
+
+        if str(repo_root) not in sys.path:
+            sys.path.insert(0, str(repo_root))
+
+        try:
+            from trellis.pipelines import TrellisImageTo3DPipeline  # type: ignore[import-not-found]
+        except ImportError as e:
+            raise BackendUnavailable(
+                "TRELLIS package not importable. Did you `pip install -e vendor/trellis`?"
+            ) from e
+
+        os.environ.setdefault("ATTN_BACKEND", "xformers")
+        os.environ.setdefault("SPCONV_ALGO", "native")
+
+        pipeline = TrellisImageTo3DPipeline.from_pretrained(self.config.local_model_name)
+        if hasattr(pipeline, "cuda"):
+            pipeline.cuda()
+        return pipeline
+
+    async def healthy(self) -> tuple[bool, str | None]:
+        try:
+            await self._get_pipeline()
+            return True, None
+        except BackendUnavailable as exc:
+            return False, str(exc)
+        except Exception as exc:  # noqa: BLE001
+            return False, f"local backend init failed: {exc}"
+
+    async def generate_from_image(
+        self,
+        image_path: str,
+        *,
+        sampling: TrellisSamplingParams,
+        prompt_hint: str | None = None,
+        seed: int | None = None,
+    ) -> BackendResult:
+        pipeline = await self._get_pipeline()
+        seed_val = seed if seed is not None else (self.config.seed or 0)
+        start = time.time()
+
+        def _call() -> BackendResult:
+            from PIL import Image  # local: already a dep when LOCAL backend is active
+
+            image = Image.open(image_path).convert("RGB")
+
+            outputs = pipeline.run(
+                image,
+                seed=seed_val,
+                sparse_structure_sampler_params={
+                    "steps": sampling.ss_sampling_steps,
+                    "cfg_strength": sampling.ss_guidance_strength,
+                },
+                slat_sampler_params={
+                    "steps": sampling.slat_sampling_steps,
+                    "cfg_strength": sampling.slat_guidance_strength,
+                },
+            )
+
+            return self._export_outputs(outputs, sampling, seed_val, start)
+
+        return await asyncio.to_thread(_call)
+
+    async def generate_from_text(
+        self,
+        prompt: str,
+        *,
+        sampling: TrellisSamplingParams,
+        seed: int | None = None,
+    ) -> BackendResult:
+        # Text-to-3D in TRELLIS uses a separate checkpoint
+        # (TRELLIS-text-large). We only wire up image-to-3D in v1; raise so
+        # the factory falls back to e.g. HuggingFace SHAP-E.
+        raise BackendUnavailable(
+            "Local text-to-3D not wired up in v1 — see services/three_d/trellis/TODO_TEXT.md"
+        )
+
+    def _export_outputs(
+        self,
+        outputs: Any,
+        sampling: TrellisSamplingParams,
+        seed_val: int,
+        start: float,
+    ) -> BackendResult:
+        from trellis.utils import postprocessing_utils  # type: ignore[import-not-found]
+
+        tmpdir = Path(tempfile.mkdtemp(prefix="trellis_local_"))
+        glb_path = tmpdir / "model.glb"
+        gaussian = outputs["gaussian"][0]
+        mesh = outputs["mesh"][0]
+
+        glb = postprocessing_utils.to_glb(
+            gaussian,
+            mesh,
+            simplify=sampling.mesh_simplify,
+            texture_size=sampling.texture_size,
+        )
+        glb.export(str(glb_path))
+
+        splat_path = tmpdir / "splat.ply"
+        try:
+            gaussian.save_ply(str(splat_path))
+        except Exception:  # noqa: BLE001 — optional artifact
+            splat_path = None  # type: ignore[assignment]
+
+        return BackendResult(
+            glb_path=str(glb_path),
+            splat_path=str(splat_path) if splat_path else None,
+            seed=seed_val,
+            backend=self.backend_name,
+            duration_seconds=time.time() - start,
+            metadata={"model": self.config.local_model_name},
+        )
+
+    async def close(self) -> None:
+        self._pipeline = None
+
+
+# =============================================================================
+# Replicate backend
+# =============================================================================
+
+
+class ReplicateClient:
+    """Hosted TRELLIS via Replicate's REST API.
+
+    Pros: no local GPU, ~30s warm latency, decent free credit allowance.
+    Cons: paid past free tier; mesh fidelity slightly behind self-hosted.
+    """
+
+    backend_name = TrellisBackend.REPLICATE.value
+
+    def __init__(self, config: TrellisConfig) -> None:
+        self.config = config
+        if not config.replicate_token:
+            logger.debug("REPLICATE_API_TOKEN not set; client will fail health checks")
+
+    async def healthy(self) -> tuple[bool, str | None]:
+        if not self.config.replicate_token:
+            return False, "REPLICATE_API_TOKEN not set"
+        try:
+            import replicate  # noqa: F401  # type: ignore[import-not-found]
+        except ImportError:
+            return False, "replicate SDK not installed"
+        return True, None
+
+    async def generate_from_image(
+        self,
+        image_path: str,
+        *,
+        sampling: TrellisSamplingParams,
+        prompt_hint: str | None = None,
+        seed: int | None = None,
+    ) -> BackendResult:
+        try:
+            import replicate  # type: ignore[import-not-found]
+        except ImportError as e:
+            raise BackendUnavailable("replicate SDK not installed") from e
+
+        if not self.config.replicate_token:
+            raise BackendUnavailable("REPLICATE_API_TOKEN not set")
+
+        os.environ["REPLICATE_API_TOKEN"] = self.config.replicate_token
+        seed_val = seed if seed is not None else (self.config.seed or 0)
+        start = time.time()
+
+        def _call() -> str:
+            with open(image_path, "rb") as fh:
+                output = replicate.run(
+                    self.config.replicate_model,
+                    input={
+                        "images": [fh],
+                        "seed": seed_val,
+                        "ss_guidance_strength": sampling.ss_guidance_strength,
+                        "ss_sampling_steps": sampling.ss_sampling_steps,
+                        "slat_guidance_strength": sampling.slat_guidance_strength,
+                        "slat_sampling_steps": sampling.slat_sampling_steps,
+                        "mesh_simplify": sampling.mesh_simplify,
+                        "texture_size": sampling.texture_size,
+                        "generate_model": True,
+                    },
+                )
+            if isinstance(output, list):
+                output = output[0] if output else ""
+            if not output:
+                raise BackendUnavailable("Replicate returned empty output")
+            return str(output)
+
+        try:
+            model_url = await asyncio.wait_for(
+                asyncio.to_thread(_call),
+                timeout=self.config.timeout_seconds,
+            )
+        except asyncio.TimeoutError as e:
+            raise TimeoutError("Replicate TRELLIS timed out") from e
+
+        # Download the GLB locally so the rest of the pipeline can postprocess it.
+        local_path = await asyncio.to_thread(_download_to_temp, model_url, ".glb")
+
+        return BackendResult(
+            glb_path=local_path,
+            seed=seed_val,
+            backend=self.backend_name,
+            duration_seconds=time.time() - start,
+            metadata={"model_url": model_url, "replicate_model": self.config.replicate_model},
+        )
+
+    async def generate_from_text(
+        self,
+        prompt: str,
+        *,
+        sampling: TrellisSamplingParams,
+        seed: int | None = None,
+    ) -> BackendResult:
+        raise BackendUnavailable(
+            "Replicate TRELLIS endpoint is image-to-3D only — use HF SHAP-E for text"
+        )
+
+    async def close(self) -> None:
+        pass
+
+
+def _download_to_temp(url: str, suffix: str) -> str:
+    import urllib.request
+
+    tmp = Path(tempfile.mkdtemp(prefix="trellis_replicate_")) / f"output{suffix}"
+    with urllib.request.urlopen(url) as src, open(tmp, "wb") as dst:  # noqa: S310 — trusted URL
+        shutil.copyfileobj(src, dst)
+    return str(tmp)
+
+
+# =============================================================================
+# Stub backend (tests / dry-run)
+# =============================================================================
+
+
+class StubClient:
+    """Deterministic fixture used by tests and the ``--dry-run`` CLI mode.
+
+    Writes a tiny placeholder GLB and returns immediately. Lets the rest of
+    the orchestration be exercised without burning credits or hitting a GPU.
+    """
+
+    backend_name = "stub"
+
+    def __init__(self, config: TrellisConfig) -> None:
+        self.config = config
+
+    async def healthy(self) -> tuple[bool, str | None]:
+        return True, None
+
+    async def generate_from_image(
+        self,
+        image_path: str,
+        *,
+        sampling: TrellisSamplingParams,
+        prompt_hint: str | None = None,
+        seed: int | None = None,
+    ) -> BackendResult:
+        return self._fake_result(sampling, seed, source="image")
+
+    async def generate_from_text(
+        self,
+        prompt: str,
+        *,
+        sampling: TrellisSamplingParams,
+        seed: int | None = None,
+    ) -> BackendResult:
+        return self._fake_result(sampling, seed, source="text")
+
+    async def close(self) -> None:
+        pass
+
+    def _fake_result(
+        self,
+        sampling: TrellisSamplingParams,
+        seed: int | None,
+        *,
+        source: str,
+    ) -> BackendResult:
+        tmpdir = Path(tempfile.mkdtemp(prefix="trellis_stub_"))
+        glb_path = tmpdir / "model.glb"
+        # Minimal GLB header — not a valid GLB but small and detectable.
+        glb_path.write_bytes(b"glTF\x02\x00\x00\x00" + b"\x00" * 64)
+        return BackendResult(
+            glb_path=str(glb_path),
+            seed=seed if seed is not None else (self.config.seed or 0),
+            backend=self.backend_name,
+            duration_seconds=0.01,
+            metadata={"stub": True, "source": source, "sampling": asdict(sampling)},
+        )
+
+
+# =============================================================================
+# Factory
+# =============================================================================
+
+
+def build_backend(config: TrellisConfig) -> TrellisBackendClient:
+    """Construct the backend client implied by ``config.backend``."""
+    backend = config.backend
+    if backend == TrellisBackend.HF_SPACE:
+        return HFSpaceClient(config)
+    if backend == TrellisBackend.LOCAL:
+        return LocalTrellisClient(config)
+    if backend == TrellisBackend.REPLICATE:
+        return ReplicateClient(config)
+    if backend == TrellisBackend.MODAL:
+        # Modal backend deferred — fall back to HF Space with a warning.
+        logger.warning("Modal backend not yet implemented — using HF Space")
+        return HFSpaceClient(config)
+    raise BackendUnavailable(f"Unknown TRELLIS backend: {backend}")
+
+
+__all__ = [
+    "BackendResult",
+    "BackendUnavailable",
+    "HFSpaceClient",
+    "LocalTrellisClient",
+    "ReplicateClient",
+    "StubClient",
+    "TrellisBackendClient",
+    "build_backend",
+]

--- a/services/three_d/trellis/config.py
+++ b/services/three_d/trellis/config.py
@@ -1,0 +1,248 @@
+"""TRELLIS configuration.
+
+Declarative configuration for the TRELLIS provider: backend selection,
+quality presets, output paths, and resource limits. Created from environment
+variables via :meth:`TrellisConfig.from_env`.
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+
+# =============================================================================
+# Backends
+# =============================================================================
+
+
+class TrellisBackend(StrEnum):
+    """Where the TRELLIS model runs.
+
+    - ``HF_SPACE``: hosted HuggingFace Space ``JeffreyXiang/TRELLIS``
+      (free, slower, no GPU required client-side). Default.
+    - ``LOCAL``: run TRELLIS in-process from the vendored repo at
+      ``vendor/trellis``. Requires CUDA GPU + model weights downloaded.
+    - ``REPLICATE``: hosted via Replicate's TRELLIS endpoint
+      (paid, fast, no GPU required client-side).
+    - ``MODAL``: hosted via Modal serverless GPU
+      (paid, fastest cold-start-free, requires Modal account).
+    """
+
+    HF_SPACE = "hf_space"
+    LOCAL = "local"
+    REPLICATE = "replicate"
+    MODAL = "modal"
+
+
+class TrellisQualityPreset(StrEnum):
+    """Quality presets that map onto TRELLIS sampling parameters.
+
+    DRAFT: 8 SS + 8 SLAT steps, mesh simplify 0.85 — for previews / QA
+    STANDARD: 12 SS + 12 SLAT steps, simplify 0.95 — production default
+    PRODUCTION: 20 SS + 20 SLAT steps, simplify 0.97, 2048 texture — hero shots
+    """
+
+    DRAFT = "draft"
+    STANDARD = "standard"
+    PRODUCTION = "production"
+
+
+# =============================================================================
+# Sampling parameter table
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class TrellisSamplingParams:
+    """TRELLIS sampling hyperparameters per quality preset."""
+
+    ss_sampling_steps: int
+    ss_guidance_strength: float
+    slat_sampling_steps: int
+    slat_guidance_strength: float
+    mesh_simplify: float
+    texture_size: int
+    target_polycount: int
+
+    @classmethod
+    def for_preset(cls, preset: TrellisQualityPreset) -> TrellisSamplingParams:
+        """Return canonical params for a quality preset."""
+        return _PRESET_PARAMS[preset]
+
+
+_PRESET_PARAMS: dict[TrellisQualityPreset, TrellisSamplingParams] = {
+    TrellisQualityPreset.DRAFT: TrellisSamplingParams(
+        ss_sampling_steps=8,
+        ss_guidance_strength=7.5,
+        slat_sampling_steps=8,
+        slat_guidance_strength=3.0,
+        mesh_simplify=0.85,
+        texture_size=1024,
+        target_polycount=40_000,
+    ),
+    TrellisQualityPreset.STANDARD: TrellisSamplingParams(
+        ss_sampling_steps=12,
+        ss_guidance_strength=7.5,
+        slat_sampling_steps=12,
+        slat_guidance_strength=3.0,
+        mesh_simplify=0.95,
+        texture_size=1024,
+        target_polycount=80_000,
+    ),
+    TrellisQualityPreset.PRODUCTION: TrellisSamplingParams(
+        ss_sampling_steps=20,
+        ss_guidance_strength=8.0,
+        slat_sampling_steps=20,
+        slat_guidance_strength=3.5,
+        mesh_simplify=0.97,
+        texture_size=2048,
+        target_polycount=150_000,
+    ),
+}
+
+
+# =============================================================================
+# Top-level config
+# =============================================================================
+
+
+def _default_output_dir() -> str:
+    return os.getenv("TRELLIS_OUTPUT_DIR") or os.getenv(
+        "THREE_D_OUTPUT_DIR", "./assets/3d-models-generated"
+    )
+
+
+def _default_cache_dir() -> str:
+    return os.getenv("TRELLIS_CACHE_DIR", "./.cache/trellis")
+
+
+@dataclass(slots=True)
+class TrellisConfig:
+    """Top-level TRELLIS configuration.
+
+    All fields have sensible defaults — instantiate with ``TrellisConfig()`` for
+    HF Space inference, or ``TrellisConfig(backend=TrellisBackend.LOCAL)`` for
+    local GPU inference.
+
+    Attributes:
+        backend: Which TRELLIS backend to use (HF_SPACE by default).
+        quality: Quality preset; controls sampling steps and texture size.
+        hf_space_id: HuggingFace Space ID (only used when backend=HF_SPACE).
+        hf_token: HuggingFace API token (for private spaces / rate limits).
+        local_repo_path: Path to the vendored TRELLIS repo (LOCAL backend).
+        local_model_name: TRELLIS model checkpoint (LOCAL backend).
+        replicate_model: Replicate model identifier (REPLICATE backend).
+        replicate_token: Replicate API token (REPLICATE backend).
+        modal_app: Modal app name (MODAL backend).
+        output_dir: Where to write generated GLB/USDZ artifacts.
+        cache_dir: Cache directory for preprocessing intermediates.
+        max_input_resolution: Cap on input image resolution.
+        min_input_resolution: Minimum acceptable input resolution.
+        seed: Random seed for reproducibility (None = stochastic).
+        timeout_seconds: Hard timeout for a single generation call.
+        retry_attempts: Number of retry attempts on transient failures.
+        retry_backoff_seconds: Initial backoff; doubles per attempt.
+        enable_background_removal: Run rembg/SAM on inputs before generation.
+        enable_postprocess: Run mesh cleanup + format conversion.
+        export_formats: Which output formats to emit (always includes input).
+        export_usdz_for_ios: Also emit ``.usdz`` for iOS AR Quick Look.
+    """
+
+    # Backend selection
+    backend: TrellisBackend = field(
+        default_factory=lambda: TrellisBackend(
+            os.getenv("TRELLIS_BACKEND", TrellisBackend.HF_SPACE.value)
+        )
+    )
+    quality: TrellisQualityPreset = field(
+        default_factory=lambda: TrellisQualityPreset(
+            os.getenv("TRELLIS_QUALITY", TrellisQualityPreset.STANDARD.value)
+        )
+    )
+
+    # HF Space
+    hf_space_id: str = field(
+        default_factory=lambda: os.getenv("TRELLIS_HF_SPACE", "JeffreyXiang/TRELLIS")
+    )
+    hf_token: str | None = field(
+        default_factory=lambda: os.getenv("HUGGINGFACE_TOKEN") or os.getenv("HF_TOKEN")
+    )
+
+    # Local backend
+    local_repo_path: str = field(
+        default_factory=lambda: os.getenv("TRELLIS_LOCAL_PATH", "./vendor/trellis")
+    )
+    local_model_name: str = field(
+        default_factory=lambda: os.getenv("TRELLIS_MODEL", "microsoft/TRELLIS-image-large")
+    )
+
+    # Replicate backend
+    replicate_model: str = field(
+        default_factory=lambda: os.getenv(
+            "TRELLIS_REPLICATE_MODEL",
+            "firtoz/trellis:e8f6c45206993f297372f5436b90350817bd9b4a0d52d2a76df50c1c8afa2b3c",
+        )
+    )
+    replicate_token: str | None = field(default_factory=lambda: os.getenv("REPLICATE_API_TOKEN"))
+
+    # Modal backend
+    modal_app: str = field(default_factory=lambda: os.getenv("TRELLIS_MODAL_APP", "trellis-3d"))
+
+    # I/O
+    output_dir: str = field(default_factory=_default_output_dir)
+    cache_dir: str = field(default_factory=_default_cache_dir)
+
+    # Resolution limits
+    max_input_resolution: int = 2048
+    min_input_resolution: int = 256
+
+    # Generation
+    seed: int | None = field(
+        default_factory=lambda: int(os.environ["TRELLIS_SEED"]) if os.getenv("TRELLIS_SEED") else 42
+    )
+    timeout_seconds: float = field(default_factory=lambda: float(os.getenv("TRELLIS_TIMEOUT", "420")))
+    retry_attempts: int = field(default_factory=lambda: int(os.getenv("TRELLIS_RETRIES", "2")))
+    retry_backoff_seconds: float = 4.0
+
+    # Pipeline switches
+    enable_background_removal: bool = field(
+        default_factory=lambda: os.getenv("TRELLIS_BG_REMOVE", "true").lower() == "true"
+    )
+    enable_postprocess: bool = field(
+        default_factory=lambda: os.getenv("TRELLIS_POSTPROCESS", "true").lower() == "true"
+    )
+
+    # Output format matrix
+    export_formats: tuple[str, ...] = ("glb",)
+    export_usdz_for_ios: bool = field(
+        default_factory=lambda: os.getenv("TRELLIS_EXPORT_USDZ", "true").lower() == "true"
+    )
+
+    @classmethod
+    def from_env(cls) -> TrellisConfig:
+        """Build the config from environment variables (recommended)."""
+        return cls()
+
+    @property
+    def sampling(self) -> TrellisSamplingParams:
+        """Sampling params for the selected quality preset."""
+        return TrellisSamplingParams.for_preset(self.quality)
+
+    def ensure_dirs(self) -> None:
+        """Create output / cache directories if missing."""
+        Path(self.output_dir).mkdir(parents=True, exist_ok=True)
+        Path(self.cache_dir).mkdir(parents=True, exist_ok=True)
+
+
+__all__ = [
+    "TrellisBackend",
+    "TrellisQualityPreset",
+    "TrellisSamplingParams",
+    "TrellisConfig",
+]

--- a/services/three_d/trellis/garment_aware.py
+++ b/services/three_d/trellis/garment_aware.py
@@ -1,0 +1,474 @@
+"""Garment-aware knowledge & prompt construction.
+
+TRELLIS generates better meshes when given context about the garment category
+(tops drape differently from bottoms; hoodies need shoulder-seam geometry;
+shoes need sole separation). This module encodes that knowledge.
+
+It also classifies an uploaded image into a garment category using a tiny
+visual heuristic (aspect ratio + simple color stats) — sufficient as a
+defensive default when no metadata is provided. For higher accuracy plug in
+``services/ml/visual_feature_extractor.py`` upstream.
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+
+class GarmentCategory(StrEnum):
+    """Coarse garment categories supported by the pipeline."""
+
+    TEE = "tee"
+    HOODIE = "hoodie"
+    SWEATSHIRT = "sweatshirt"
+    JACKET = "jacket"
+    DRESS = "dress"
+    PANTS = "pants"
+    SHORTS = "shorts"
+    SKIRT = "skirt"
+    SHOE = "shoe"
+    HAT = "hat"
+    BAG = "bag"
+    ACCESSORY = "accessory"
+    UNKNOWN = "unknown"
+
+
+# =============================================================================
+# Per-category geometry hints
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class GarmentKnowledge:
+    """Domain knowledge for a garment category.
+
+    These hints are spliced into the TRELLIS text prompt to bias mesh
+    generation toward category-appropriate topology.
+
+    Attributes:
+        category: The category this knowledge applies to.
+        prompt_suffix: Text appended to the TRELLIS prompt for this category.
+        polycount_hint: Recommended target polycount (mesh complexity).
+        symmetry: ``"x"`` if the garment is mirror-symmetric across X axis.
+        canonical_aspect: Expected ``height / width`` after isolation.
+    """
+
+    category: GarmentCategory
+    prompt_suffix: str
+    polycount_hint: int
+    symmetry: str | None
+    canonical_aspect: float
+
+
+_KNOWLEDGE: dict[GarmentCategory, GarmentKnowledge] = {
+    GarmentCategory.TEE: GarmentKnowledge(
+        category=GarmentCategory.TEE,
+        prompt_suffix=(
+            "soft-knit t-shirt, short sleeves, ribbed crew neckline, "
+            "natural fabric drape, clean shoulder seams, studio lighting"
+        ),
+        polycount_hint=60_000,
+        symmetry="x",
+        canonical_aspect=1.25,
+    ),
+    GarmentCategory.HOODIE: GarmentKnowledge(
+        category=GarmentCategory.HOODIE,
+        prompt_suffix=(
+            "heavyweight cotton hoodie, raised hood with drawstrings, "
+            "ribbed cuffs and hem, kangaroo pocket, soft fabric folds"
+        ),
+        polycount_hint=120_000,
+        symmetry="x",
+        canonical_aspect=1.35,
+    ),
+    GarmentCategory.SWEATSHIRT: GarmentKnowledge(
+        category=GarmentCategory.SWEATSHIRT,
+        prompt_suffix=(
+            "crewneck sweatshirt, brushed fleece interior, ribbed cuffs and hem, "
+            "soft drape, even shoulder seam"
+        ),
+        polycount_hint=90_000,
+        symmetry="x",
+        canonical_aspect=1.30,
+    ),
+    GarmentCategory.JACKET: GarmentKnowledge(
+        category=GarmentCategory.JACKET,
+        prompt_suffix=(
+            "structured jacket, defined collar and lapels, full zipper or buttons, "
+            "lining geometry, sleeve volume, hem stiffness"
+        ),
+        polycount_hint=140_000,
+        symmetry="x",
+        canonical_aspect=1.30,
+    ),
+    GarmentCategory.DRESS: GarmentKnowledge(
+        category=GarmentCategory.DRESS,
+        prompt_suffix=(
+            "flowing dress silhouette, defined waistline, hemline drape, "
+            "smooth bodice geometry, fabric folds along the skirt"
+        ),
+        polycount_hint=130_000,
+        symmetry="x",
+        canonical_aspect=1.85,
+    ),
+    GarmentCategory.PANTS: GarmentKnowledge(
+        category=GarmentCategory.PANTS,
+        prompt_suffix=(
+            "tailored pants, defined waistband, two distinct leg tubes, "
+            "inseam visible, hem cuff, no model body inside"
+        ),
+        polycount_hint=110_000,
+        symmetry="x",
+        canonical_aspect=1.70,
+    ),
+    GarmentCategory.SHORTS: GarmentKnowledge(
+        category=GarmentCategory.SHORTS,
+        prompt_suffix=(
+            "casual shorts, distinct leg openings, elastic or button waistband, "
+            "soft fabric drape"
+        ),
+        polycount_hint=70_000,
+        symmetry="x",
+        canonical_aspect=0.95,
+    ),
+    GarmentCategory.SKIRT: GarmentKnowledge(
+        category=GarmentCategory.SKIRT,
+        prompt_suffix=(
+            "skirt with defined waistband, A-line or pleated silhouette, "
+            "hemline drape, fabric movement"
+        ),
+        polycount_hint=80_000,
+        symmetry="x",
+        canonical_aspect=1.10,
+    ),
+    GarmentCategory.SHOE: GarmentKnowledge(
+        category=GarmentCategory.SHOE,
+        prompt_suffix=(
+            "athletic sneaker, distinct sole and upper, laces, tongue, heel counter, "
+            "midsole foam detail, clean rubber outsole"
+        ),
+        polycount_hint=100_000,
+        symmetry=None,
+        canonical_aspect=0.45,
+    ),
+    GarmentCategory.HAT: GarmentKnowledge(
+        category=GarmentCategory.HAT,
+        prompt_suffix=(
+            "structured hat, defined crown and brim, sweatband visible inside, "
+            "consistent radial geometry"
+        ),
+        polycount_hint=40_000,
+        symmetry="x",
+        canonical_aspect=0.55,
+    ),
+    GarmentCategory.BAG: GarmentKnowledge(
+        category=GarmentCategory.BAG,
+        prompt_suffix=(
+            "handbag, defined body and straps, clean stitching lines, "
+            "hardware detail, structural form"
+        ),
+        polycount_hint=80_000,
+        symmetry=None,
+        canonical_aspect=1.10,
+    ),
+    GarmentCategory.ACCESSORY: GarmentKnowledge(
+        category=GarmentCategory.ACCESSORY,
+        prompt_suffix="fashion accessory, clean form, no body parts visible",
+        polycount_hint=50_000,
+        symmetry=None,
+        canonical_aspect=1.0,
+    ),
+    GarmentCategory.UNKNOWN: GarmentKnowledge(
+        category=GarmentCategory.UNKNOWN,
+        prompt_suffix="fashion garment, clean silhouette, studio lighting",
+        polycount_hint=80_000,
+        symmetry=None,
+        canonical_aspect=1.0,
+    ),
+}
+
+
+def knowledge_for(category: GarmentCategory) -> GarmentKnowledge:
+    """Return :class:`GarmentKnowledge` for ``category`` (falls back to UNKNOWN)."""
+    return _KNOWLEDGE.get(category, _KNOWLEDGE[GarmentCategory.UNKNOWN])
+
+
+# =============================================================================
+# Brand prompt context
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class BrandPromptContext:
+    """Brand styling hints — currently tuned for SkyyRose collections."""
+
+    collection: str | None
+    accent: str | None
+    aesthetic: str | None
+
+
+_COLLECTION_CONTEXT: dict[str, BrandPromptContext] = {
+    "signature": BrandPromptContext(
+        collection="signature",
+        accent="rose gold trim",
+        aesthetic="elevated luxury streetwear, refined silhouette",
+    ),
+    "black_rose": BrandPromptContext(
+        collection="black_rose",
+        accent="silver chrome accents",
+        aesthetic="dark gothic streetwear, sharp angular details",
+    ),
+    "love_hurts": BrandPromptContext(
+        collection="love_hurts",
+        accent="crimson red trim",
+        aesthetic="emotional luxury streetwear, expressive lines",
+    ),
+    "kids_capsule": BrandPromptContext(
+        collection="kids_capsule",
+        accent="soft rose gold",
+        aesthetic="playful luxury kids streetwear, rounded comfortable shapes",
+    ),
+}
+
+
+def brand_context(collection: str | None) -> BrandPromptContext | None:
+    """Resolve a brand collection slug into context hints."""
+    if not collection:
+        return None
+    return _COLLECTION_CONTEXT.get(collection.lower().replace("-", "_"))
+
+
+# =============================================================================
+# Prompt construction
+# =============================================================================
+
+
+def build_clothing_prompt(
+    *,
+    product_name: str | None,
+    category: GarmentCategory,
+    collection: str | None = None,
+    user_prompt: str | None = None,
+    extra_keywords: list[str] | None = None,
+) -> str:
+    """Compose a TRELLIS-ready clothing prompt from structured inputs.
+
+    Args:
+        product_name: Display name of the SKU, e.g. "Black Rose Hoodie".
+        category: Garment category — drives geometry hints.
+        collection: SkyyRose collection slug ("signature", "black_rose", ...).
+        user_prompt: Free-form user description, treated as the highest priority.
+        extra_keywords: Additional descriptors merged into the prompt.
+
+    Returns:
+        A single newline-joined prompt string optimized for TRELLIS text-to-3D.
+        Order: product → user description → category geometry → brand aesthetic
+        → technical render hints.
+    """
+    parts: list[str] = []
+
+    if product_name:
+        parts.append(product_name.strip())
+
+    if user_prompt:
+        parts.append(user_prompt.strip())
+
+    knowledge = knowledge_for(category)
+    parts.append(knowledge.prompt_suffix)
+
+    brand = brand_context(collection)
+    if brand:
+        if brand.accent:
+            parts.append(brand.accent)
+        if brand.aesthetic:
+            parts.append(brand.aesthetic)
+
+    if extra_keywords:
+        parts.extend(k.strip() for k in extra_keywords if k.strip())
+
+    # Universal render hints
+    parts.append("photorealistic, evenly lit studio render, neutral background")
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    uniq: list[str] = []
+    for p in parts:
+        key = p.lower()
+        if key and key not in seen:
+            uniq.append(p)
+            seen.add(key)
+
+    return ", ".join(uniq)
+
+
+# =============================================================================
+# Classification (lightweight default)
+# =============================================================================
+
+
+def classify_garment(
+    *,
+    image_path: str | None = None,
+    image_size: tuple[int, int] | None = None,
+    declared_category: str | None = None,
+    product_name: str | None = None,
+) -> GarmentCategory:
+    """Best-effort garment classification.
+
+    Prefers explicit signals in order:
+
+    1. ``declared_category`` argument (highest trust).
+    2. Substring match in ``product_name``.
+    3. Aspect-ratio heuristic over ``image_size``.
+
+    Returns :attr:`GarmentCategory.UNKNOWN` when no signal is available — the
+    pipeline will still run with neutral geometry hints.
+
+    Args:
+        image_path: Optional path; only used for size detection if ``image_size``
+            is not provided and PIL is available.
+        image_size: ``(width, height)`` of the input — preferred over reading
+            the file (cheaper).
+        declared_category: Explicit category string from the caller / catalog.
+        product_name: Display name; scanned for category keywords.
+    """
+    if declared_category:
+        try:
+            return GarmentCategory(declared_category.lower().strip())
+        except ValueError:
+            pass
+
+    name_hit = _classify_by_name(product_name)
+    if name_hit is not GarmentCategory.UNKNOWN:
+        return name_hit
+
+    size = image_size or _safe_image_size(image_path)
+    if size:
+        return _classify_by_aspect(size)
+
+    return GarmentCategory.UNKNOWN
+
+
+_NAME_KEYWORDS: dict[GarmentCategory, tuple[str, ...]] = {
+    GarmentCategory.TEE: ("tee", "t-shirt", "tshirt"),
+    GarmentCategory.HOODIE: ("hoodie", "hood"),
+    GarmentCategory.SWEATSHIRT: ("sweatshirt", "crewneck"),
+    GarmentCategory.JACKET: ("jacket", "blazer", "coat", "outerwear"),
+    GarmentCategory.DRESS: ("dress", "gown"),
+    GarmentCategory.PANTS: ("pants", "trouser", "jeans", "denim"),
+    GarmentCategory.SHORTS: ("short",),
+    GarmentCategory.SKIRT: ("skirt",),
+    GarmentCategory.SHOE: ("shoe", "sneaker", "boot", "heel"),
+    GarmentCategory.HAT: ("hat", "cap", "beanie"),
+    GarmentCategory.BAG: ("bag", "tote", "purse", "backpack"),
+    GarmentCategory.ACCESSORY: ("scarf", "belt", "glove"),
+}
+
+
+def _classify_by_name(product_name: str | None) -> GarmentCategory:
+    if not product_name:
+        return GarmentCategory.UNKNOWN
+    lowered = product_name.lower()
+    for category, keywords in _NAME_KEYWORDS.items():
+        if any(k in lowered for k in keywords):
+            return category
+    return GarmentCategory.UNKNOWN
+
+
+def _classify_by_aspect(size: tuple[int, int]) -> GarmentCategory:
+    width, height = size
+    if width <= 0 or height <= 0:
+        return GarmentCategory.UNKNOWN
+
+    aspect = height / width
+    if aspect >= 1.65:
+        return GarmentCategory.DRESS
+    if aspect >= 1.40:
+        return GarmentCategory.PANTS
+    if aspect >= 1.15:
+        return GarmentCategory.TEE
+    if aspect >= 0.85:
+        return GarmentCategory.SHORTS
+    if aspect >= 0.50:
+        return GarmentCategory.HAT
+    return GarmentCategory.SHOE
+
+
+def _safe_image_size(image_path: str | None) -> tuple[int, int] | None:
+    if not image_path or not Path(image_path).exists():
+        return None
+    try:
+        from PIL import Image
+
+        with Image.open(image_path) as im:
+            return im.size
+    except Exception:  # noqa: BLE001 — defensive default
+        return None
+
+
+# =============================================================================
+# Convenience aggregate
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class GarmentPrompt:
+    """Bundle of (category, prompt, knowledge) used downstream."""
+
+    category: GarmentCategory
+    prompt: str
+    knowledge: GarmentKnowledge
+    extra: dict[str, str] = field(default_factory=dict)
+
+
+def build_garment_prompt_bundle(
+    *,
+    image_path: str | None = None,
+    image_size: tuple[int, int] | None = None,
+    product_name: str | None = None,
+    declared_category: str | None = None,
+    collection: str | None = None,
+    user_prompt: str | None = None,
+    extra_keywords: list[str] | None = None,
+) -> GarmentPrompt:
+    """Classify + build prompt + attach knowledge in one call."""
+    category = classify_garment(
+        image_path=image_path,
+        image_size=image_size,
+        declared_category=declared_category,
+        product_name=product_name,
+    )
+    prompt = build_clothing_prompt(
+        product_name=product_name,
+        category=category,
+        collection=collection,
+        user_prompt=user_prompt,
+        extra_keywords=extra_keywords,
+    )
+    return GarmentPrompt(
+        category=category,
+        prompt=prompt,
+        knowledge=knowledge_for(category),
+        extra={
+            "collection": collection or "",
+            "product_name": product_name or "",
+        },
+    )
+
+
+__all__ = [
+    "GarmentCategory",
+    "GarmentKnowledge",
+    "BrandPromptContext",
+    "GarmentPrompt",
+    "knowledge_for",
+    "brand_context",
+    "build_clothing_prompt",
+    "build_garment_prompt_bundle",
+    "classify_garment",
+]

--- a/services/three_d/trellis/postprocess.py
+++ b/services/three_d/trellis/postprocess.py
@@ -1,0 +1,341 @@
+"""Mesh post-processing: cleanup, decimation, AR export.
+
+TRELLIS outputs a high-quality GLB, but production e-commerce delivery wants:
+
+- Reasonable polycount for the target device (mobile / desktop / AR)
+- Texture compression (KTX2 / WebP) to keep page weight in check
+- Normalized bounding box (unit cube centered on origin) so it drops into a
+  Three.js scene without extra transforms
+- USDZ export for iOS Quick Look AR
+- Optional PLY export for research / archival
+
+This module wraps :mod:`trimesh` (and falls back to pure-Python copy ops when
+``trimesh`` isn't installed, so the pipeline still runs end-to-end with
+slightly larger files).
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess  # noqa: S404 — invoked with no untrusted input
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from services.three_d.trellis.config import TrellisConfig, TrellisSamplingParams
+from services.three_d.trellis.garment_aware import GarmentCategory, knowledge_for
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Results
+# =============================================================================
+
+
+@dataclass(slots=True)
+class PostprocessResult:
+    """Output bundle from postprocessing."""
+
+    glb_path: str
+    usdz_path: str | None = None
+    ply_path: str | None = None
+    thumbnail_path: str | None = None
+    polycount: int | None = None
+    file_size_bytes: int | None = None
+    warnings: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# =============================================================================
+# Postprocessor
+# =============================================================================
+
+
+class MeshPostprocessor:
+    """Garment-aware mesh postprocessing.
+
+    Usage:
+        post = MeshPostprocessor(TrellisConfig())
+        result = post.process(
+            raw_glb="/tmp/trellis_out.glb",
+            category=GarmentCategory.HOODIE,
+            sampling=config.sampling,
+        )
+    """
+
+    def __init__(self, config: TrellisConfig | None = None) -> None:
+        self.config = config or TrellisConfig.from_env()
+        self.config.ensure_dirs()
+
+    def process(
+        self,
+        *,
+        raw_glb: str | Path,
+        category: GarmentCategory,
+        sampling: TrellisSamplingParams,
+        artifact_id: str,
+    ) -> PostprocessResult:
+        """Run the full postprocessing chain on ``raw_glb``."""
+        src = Path(raw_glb)
+        if not src.exists():
+            raise FileNotFoundError(f"Raw GLB not found: {src}")
+
+        warnings: list[str] = []
+        out_dir = Path(self.config.output_dir)
+        timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+        stem = f"{artifact_id}_{timestamp}"
+
+        glb_out = out_dir / f"{stem}.glb"
+
+        if not self.config.enable_postprocess:
+            shutil.copy2(src, glb_out)
+            warnings.append("postprocessing disabled — raw GLB copied through")
+            return PostprocessResult(
+                glb_path=str(glb_out),
+                file_size_bytes=glb_out.stat().st_size,
+                warnings=warnings,
+            )
+
+        polycount, glb_bytes = self._clean_and_decimate(
+            src=src,
+            dst=glb_out,
+            category=category,
+            sampling=sampling,
+            warnings=warnings,
+        )
+
+        usdz_path = None
+        if self.config.export_usdz_for_ios:
+            usdz_path = self._maybe_export_usdz(glb_out, stem, warnings)
+
+        thumbnail_path = self._render_thumbnail(glb_out, stem, warnings)
+
+        return PostprocessResult(
+            glb_path=str(glb_out),
+            usdz_path=str(usdz_path) if usdz_path else None,
+            thumbnail_path=str(thumbnail_path) if thumbnail_path else None,
+            polycount=polycount,
+            file_size_bytes=glb_bytes,
+            warnings=warnings,
+            metadata={
+                "category": category.value,
+                "target_polycount": sampling.target_polycount,
+                "texture_size": sampling.texture_size,
+            },
+        )
+
+    # ---------------------------------------------------------------------
+    # Pipeline stages
+    # ---------------------------------------------------------------------
+
+    def _clean_and_decimate(
+        self,
+        *,
+        src: Path,
+        dst: Path,
+        category: GarmentCategory,
+        sampling: TrellisSamplingParams,
+        warnings: list[str],
+    ) -> tuple[int | None, int]:
+        """Load → fix normals → decimate → normalize bbox → write.
+
+        Returns ``(polycount, file_size_bytes)``. Polycount may be ``None`` if
+        trimesh isn't installed (we just copy the file through).
+        """
+        try:
+            import numpy as np
+            import trimesh
+        except ImportError:
+            warnings.append("trimesh / numpy not installed — copying GLB unchanged")
+            shutil.copy2(src, dst)
+            return None, dst.stat().st_size
+
+        try:
+            scene_or_mesh = trimesh.load(str(src), force="scene")
+        except Exception as exc:  # noqa: BLE001 — trimesh raises broadly
+            warnings.append(f"trimesh load failed: {exc} — copying through")
+            shutil.copy2(src, dst)
+            return None, dst.stat().st_size
+
+        meshes: list[trimesh.Trimesh] = self._gather_meshes(scene_or_mesh)
+        if not meshes:
+            warnings.append("no geometry found in GLB — copying through")
+            shutil.copy2(src, dst)
+            return None, dst.stat().st_size
+
+        target = self._target_polycount(category, sampling)
+        for i, mesh in enumerate(meshes):
+            mesh.fix_normals()
+            mesh.remove_degenerate_faces()
+            mesh.remove_unreferenced_vertices()
+            if mesh.faces.shape[0] > target:
+                try:
+                    decimated = mesh.simplify_quadric_decimation(target)
+                    if decimated is not None and decimated.faces.shape[0] > 0:
+                        meshes[i] = decimated
+                except Exception as exc:  # noqa: BLE001
+                    warnings.append(f"decimation failed for mesh #{i}: {exc}")
+
+        normalized = self._merge_and_normalize(meshes, np, trimesh)
+
+        try:
+            normalized.export(str(dst), file_type="glb")
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(f"GLB export failed: {exc} — copying source")
+            shutil.copy2(src, dst)
+            return None, dst.stat().st_size
+
+        return int(normalized.faces.shape[0]), dst.stat().st_size
+
+    def _gather_meshes(self, loaded: Any) -> list[Any]:
+        try:
+            import trimesh
+        except ImportError:
+            return []
+
+        if isinstance(loaded, trimesh.Scene):
+            return [g for g in loaded.geometry.values() if isinstance(g, trimesh.Trimesh)]
+        if isinstance(loaded, trimesh.Trimesh):
+            return [loaded]
+        return []
+
+    def _merge_and_normalize(
+        self,
+        meshes: list[Any],
+        np: Any,
+        trimesh: Any,
+    ) -> Any:
+        """Concatenate, then translate + scale into a unit cube at origin."""
+        merged = trimesh.util.concatenate(meshes) if len(meshes) > 1 else meshes[0]
+
+        bounds = merged.bounds  # (2, 3)
+        center = bounds.mean(axis=0)
+        merged.apply_translation(-center)
+
+        extent = float((merged.bounds[1] - merged.bounds[0]).max())
+        if extent > 0:
+            merged.apply_scale(1.0 / extent)
+        return merged
+
+    def _target_polycount(
+        self,
+        category: GarmentCategory,
+        sampling: TrellisSamplingParams,
+    ) -> int:
+        """Pick a decimation target combining category prior + quality preset."""
+        kn = knowledge_for(category)
+        # Quality preset wins, but never go below 60% of the category hint.
+        floor = int(kn.polycount_hint * 0.6)
+        return max(floor, sampling.target_polycount)
+
+    # ---------------------------------------------------------------------
+    # USDZ
+    # ---------------------------------------------------------------------
+
+    def _maybe_export_usdz(
+        self,
+        glb_path: Path,
+        stem: str,
+        warnings: list[str],
+    ) -> Path | None:
+        """Try usd-core, then fall back to ``usd_from_gltf`` CLI if available."""
+        usdz_out = Path(self.config.output_dir) / f"{stem}.usdz"
+
+        if self._export_usdz_via_python(glb_path, usdz_out, warnings):
+            return usdz_out
+        if self._export_usdz_via_cli(glb_path, usdz_out, warnings):
+            return usdz_out
+
+        warnings.append(
+            "USDZ export skipped — install `usd-core` or `usd_from_gltf` to enable"
+        )
+        return None
+
+    def _export_usdz_via_python(
+        self,
+        glb_path: Path,
+        usdz_out: Path,
+        warnings: list[str],
+    ) -> bool:
+        try:
+            from pxr import Usd  # type: ignore[import-not-found]  # noqa: F401
+        except ImportError:
+            return False
+        # Real USD conversion requires shader translation; out of scope for v1.
+        # We surface a warning so callers know the path is unimplemented but
+        # the dependency is present.
+        warnings.append(
+            "pxr.Usd available but GLB→USDZ shader translation not wired up — "
+            "falling through to CLI"
+        )
+        return False
+
+    def _export_usdz_via_cli(
+        self,
+        glb_path: Path,
+        usdz_out: Path,
+        warnings: list[str],
+    ) -> bool:
+        binary = shutil.which("usd_from_gltf")
+        if not binary:
+            return False
+        try:
+            subprocess.run(
+                [binary, str(glb_path), str(usdz_out)],
+                check=True,
+                capture_output=True,
+                timeout=60,
+            )
+        except subprocess.CalledProcessError as exc:
+            warnings.append(f"usd_from_gltf failed: {exc.stderr.decode(errors='ignore')[:200]}")
+            return False
+        except subprocess.TimeoutExpired:
+            warnings.append("usd_from_gltf timed out")
+            return False
+        return usdz_out.exists()
+
+    # ---------------------------------------------------------------------
+    # Thumbnail
+    # ---------------------------------------------------------------------
+
+    def _render_thumbnail(
+        self,
+        glb_path: Path,
+        stem: str,
+        warnings: list[str],
+    ) -> Path | None:
+        """Headless thumbnail via trimesh's offscreen renderer.
+
+        Falls through silently if pyglet/pyrender aren't installed; the web
+        viewer can synthesize its own preview from the GLB anyway.
+        """
+        try:
+            import trimesh
+        except ImportError:
+            return None
+
+        try:
+            scene = trimesh.load(str(glb_path), force="scene")
+            png_bytes = scene.save_image(resolution=(512, 512), visible=True)
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(f"thumbnail render skipped: {exc}")
+            return None
+
+        if not png_bytes:
+            return None
+
+        thumb_path = Path(self.config.output_dir) / f"{stem}_preview.png"
+        thumb_path.write_bytes(png_bytes)
+        return thumb_path
+
+
+__all__ = [
+    "MeshPostprocessor",
+    "PostprocessResult",
+]

--- a/services/three_d/trellis/preprocess.py
+++ b/services/three_d/trellis/preprocess.py
@@ -1,0 +1,341 @@
+"""Input image preparation for TRELLIS.
+
+TRELLIS expects square-ish, background-free, well-lit garment imagery. This
+module turns whatever the caller gave us (raw product photo, model on white,
+lifestyle shot, marketplace screenshot) into a clean input that maximizes
+generation quality.
+
+Stages
+------
+1. **Validate**: dimensions, format, file size, accessibility
+2. **Background removal** (optional): rembg (default), SAM fallback, or
+   "leave alone" for already-isolated assets
+3. **Center crop** to garment bounding box with smart padding
+4. **Resize** to TRELLIS target (518×518 typical) preserving aspect with
+   transparent letterbox
+5. **Color normalize**: white-balance + gamma correction
+6. **Quality score**: sharpness (Laplacian), contrast, exposure — used to
+   short-circuit obviously bad inputs
+
+All heavy deps (``rembg``, ``opencv-python``, ``PIL``) are imported lazily so
+the module loads even when they're missing — affected stages emit warnings
+and degrade gracefully.
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from services.three_d.trellis.config import TrellisConfig
+
+if TYPE_CHECKING:  # pragma: no cover
+    from PIL.Image import Image
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Results
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class PreprocessedImage:
+    """Path-based handle to a preprocessed image plus metadata."""
+
+    path: str
+    width: int
+    height: int
+    has_alpha: bool
+    background_removed: bool
+
+
+@dataclass(slots=True)
+class PreprocessResult:
+    """Outcome of running the preprocessor on a single input."""
+
+    image: PreprocessedImage
+    quality_score: float
+    sharpness: float
+    contrast: float
+    exposure: float
+    warnings: list[str] = field(default_factory=list)
+    bypassed: bool = False
+
+    @property
+    def acceptable(self) -> bool:
+        """Heuristic: quality_score >= 0.45 is good enough to ship."""
+        return self.quality_score >= 0.45
+
+
+# =============================================================================
+# Errors
+# =============================================================================
+
+
+class PreprocessError(RuntimeError):
+    """Raised when the preprocessor cannot produce a usable image."""
+
+
+# =============================================================================
+# Preprocessor
+# =============================================================================
+
+
+class TrellisPreprocessor:
+    """Image preparation pipeline tuned for TRELLIS clothing generation.
+
+    Usage:
+        prep = TrellisPreprocessor(TrellisConfig())
+        result = prep.prepare("./uploads/hoodie.jpg")
+        ready_path = result.image.path
+    """
+
+    # TRELLIS image-large is trained on 518×518 inputs.
+    TARGET_RESOLUTION = 518
+
+    def __init__(self, config: TrellisConfig | None = None) -> None:
+        self.config = config or TrellisConfig.from_env()
+        self.config.ensure_dirs()
+        self._cache_dir = Path(self.config.cache_dir) / "preprocess"
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # ---------------------------------------------------------------------
+    # Public API
+    # ---------------------------------------------------------------------
+
+    def prepare(self, image_path: str | Path) -> PreprocessResult:
+        """Run the full preprocessing pipeline on ``image_path``.
+
+        Returns a :class:`PreprocessResult`. Raises :class:`PreprocessError`
+        only for genuinely fatal issues (file missing, unreadable, no PIL).
+        """
+        src = Path(image_path)
+        if not src.exists():
+            raise PreprocessError(f"Input image not found: {src}")
+
+        warnings: list[str] = []
+        pil_image = self._open_image(src, warnings)
+        self._validate_dimensions(pil_image, warnings)
+
+        if self.config.enable_background_removal:
+            pil_image, bg_removed = self._remove_background(pil_image, warnings)
+        else:
+            bg_removed = False
+
+        pil_image = self._crop_to_garment(pil_image, warnings)
+        pil_image = self._resize_letterbox(pil_image, self.TARGET_RESOLUTION)
+        pil_image = self._normalize_color(pil_image, warnings)
+
+        out_path = self._write_output(pil_image, src.stem)
+        sharpness, contrast, exposure = self._quality_metrics(pil_image)
+        score = self._aggregate_score(sharpness, contrast, exposure)
+
+        return PreprocessResult(
+            image=PreprocessedImage(
+                path=str(out_path),
+                width=pil_image.width,
+                height=pil_image.height,
+                has_alpha=pil_image.mode == "RGBA",
+                background_removed=bg_removed,
+            ),
+            quality_score=score,
+            sharpness=sharpness,
+            contrast=contrast,
+            exposure=exposure,
+            warnings=warnings,
+        )
+
+    def passthrough(self, image_path: str | Path) -> PreprocessResult:
+        """Skip preprocessing — used when caller asserts the input is ready.
+
+        Still copies into the cache directory so downstream paths are stable.
+        """
+        src = Path(image_path)
+        if not src.exists():
+            raise PreprocessError(f"Input image not found: {src}")
+
+        dst = self._cache_dir / f"{src.stem}_passthrough{src.suffix}"
+        shutil.copy2(src, dst)
+        width, height = self._image_size(src)
+
+        return PreprocessResult(
+            image=PreprocessedImage(
+                path=str(dst),
+                width=width,
+                height=height,
+                has_alpha=src.suffix.lower() == ".png",
+                background_removed=False,
+            ),
+            quality_score=1.0,
+            sharpness=1.0,
+            contrast=1.0,
+            exposure=1.0,
+            warnings=["passthrough: preprocessing skipped"],
+            bypassed=True,
+        )
+
+    # ---------------------------------------------------------------------
+    # Stage implementations
+    # ---------------------------------------------------------------------
+
+    def _open_image(self, src: Path, warnings: list[str]) -> Image:
+        try:
+            from PIL import Image as PILImage
+        except ImportError as e:
+            raise PreprocessError("Pillow is required: pip install pillow") from e
+
+        img = PILImage.open(src)
+        img.load()
+        if img.mode not in ("RGB", "RGBA"):
+            warnings.append(f"Converting mode {img.mode} → RGBA")
+            img = img.convert("RGBA")
+        return img
+
+    def _validate_dimensions(self, img: Image, warnings: list[str]) -> None:
+        if img.width < self.config.min_input_resolution or img.height < self.config.min_input_resolution:
+            warnings.append(
+                f"Input resolution {img.size} below recommended minimum "
+                f"{self.config.min_input_resolution}px — quality may suffer"
+            )
+        if max(img.size) > self.config.max_input_resolution:
+            warnings.append(
+                f"Input resolution {img.size} above max {self.config.max_input_resolution}px"
+                f" — will be downscaled before generation"
+            )
+
+    def _remove_background(
+        self,
+        img: Image,
+        warnings: list[str],
+    ) -> tuple[Image, bool]:
+        """Try rembg; if unavailable, leave the image alone but note it."""
+        try:
+            from rembg import remove  # type: ignore[import-not-found]
+        except ImportError:
+            warnings.append("rembg not installed — skipping background removal")
+            return img, False
+
+        try:
+            return remove(img), True
+        except Exception as exc:  # noqa: BLE001 — vendor lib raises broadly
+            warnings.append(f"Background removal failed: {exc}")
+            return img, False
+
+    def _crop_to_garment(self, img: Image, warnings: list[str]) -> Image:
+        """Tight bbox crop with 10% padding; assumes alpha = subject when present."""
+        try:
+            from PIL import Image as PILImage  # noqa: F401
+        except ImportError:
+            return img
+
+        if img.mode == "RGBA":
+            alpha = img.split()[-1]
+            bbox = alpha.getbbox()
+        else:
+            grayscale = img.convert("L")
+            bbox = grayscale.point(lambda v: 0 if v >= 240 else 255).getbbox()
+
+        if not bbox:
+            warnings.append("Could not find subject bbox — using whole image")
+            return img
+
+        left, top, right, bottom = bbox
+        width = right - left
+        height = bottom - top
+        pad_w = int(width * 0.10)
+        pad_h = int(height * 0.10)
+
+        left = max(0, left - pad_w)
+        top = max(0, top - pad_h)
+        right = min(img.width, right + pad_w)
+        bottom = min(img.height, bottom + pad_h)
+
+        return img.crop((left, top, right, bottom))
+
+    def _resize_letterbox(self, img: Image, target: int) -> Image:
+        """Resize preserving aspect into a square ``target × target`` canvas."""
+        from PIL import Image as PILImage
+
+        ratio = min(target / img.width, target / img.height)
+        new_size = (max(1, int(img.width * ratio)), max(1, int(img.height * ratio)))
+        resized = img.resize(new_size, PILImage.Resampling.LANCZOS)
+
+        canvas = PILImage.new("RGBA", (target, target), (255, 255, 255, 0))
+        off_x = (target - new_size[0]) // 2
+        off_y = (target - new_size[1]) // 2
+        if resized.mode != "RGBA":
+            resized = resized.convert("RGBA")
+        canvas.paste(resized, (off_x, off_y), resized)
+        return canvas
+
+    def _normalize_color(self, img: Image, warnings: list[str]) -> Image:
+        """Light contrast + brightness equalization. Falls back to no-op."""
+        try:
+            from PIL import ImageOps
+        except ImportError:
+            return img
+        try:
+            if img.mode == "RGBA":
+                rgb = img.convert("RGB")
+                eq = ImageOps.autocontrast(rgb, cutoff=1)
+                eq.putalpha(img.split()[-1])
+                return eq
+            return ImageOps.autocontrast(img, cutoff=1)
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(f"Color normalization skipped: {exc}")
+            return img
+
+    def _write_output(self, img: Image, stem: str) -> Path:
+        out = self._cache_dir / f"{stem}_trellis_input.png"
+        img.save(out, format="PNG")
+        return out
+
+    # ---------------------------------------------------------------------
+    # Quality metrics
+    # ---------------------------------------------------------------------
+
+    def _quality_metrics(self, img: Image) -> tuple[float, float, float]:
+        """Return (sharpness, contrast, exposure) — all normalized to [0, 1]."""
+        try:
+            from PIL import ImageFilter, ImageStat
+        except ImportError:
+            return 0.5, 0.5, 0.5
+
+        gray = img.convert("L")
+        edges = gray.filter(ImageFilter.FIND_EDGES)
+        stat = ImageStat.Stat(edges)
+        sharpness = min(1.0, stat.stddev[0] / 64.0) if stat.stddev else 0.5
+
+        contrast_stat = ImageStat.Stat(gray)
+        contrast = min(1.0, contrast_stat.stddev[0] / 80.0)
+
+        mean = contrast_stat.mean[0]
+        exposure = 1.0 - abs((mean - 128) / 128)
+
+        return sharpness, contrast, max(0.0, exposure)
+
+    def _aggregate_score(self, sharpness: float, contrast: float, exposure: float) -> float:
+        # Sharpness dominates because blurry input ruins TRELLIS output.
+        return round(0.5 * sharpness + 0.3 * contrast + 0.2 * exposure, 4)
+
+    def _image_size(self, src: Path) -> tuple[int, int]:
+        from PIL import Image as PILImage
+
+        with PILImage.open(src) as im:
+            return im.size
+
+
+__all__ = [
+    "TrellisPreprocessor",
+    "PreprocessedImage",
+    "PreprocessResult",
+    "PreprocessError",
+]

--- a/services/three_d/trellis/provider.py
+++ b/services/three_d/trellis/provider.py
@@ -1,0 +1,522 @@
+"""TRELLIS provider — :class:`I3DProvider` implementation.
+
+Wires together:
+
+- :class:`~services.three_d.trellis.preprocess.TrellisPreprocessor`
+- :class:`~services.three_d.trellis.client.TrellisBackendClient`
+- :class:`~services.three_d.trellis.postprocess.MeshPostprocessor`
+- :func:`~services.three_d.trellis.garment_aware.build_clothing_prompt`
+
+into a single async surface that the
+:class:`~services.three_d.provider_factory.ThreeDProviderFactory` can register
+alongside the existing Tripo / Replicate / HuggingFace adapters.
+
+Author: DevSkyy Platform Team
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+from services.three_d.provider_interface import (
+    OutputFormat,
+    ProviderHealth,
+    ProviderStatus,
+    ThreeDCapability,
+    ThreeDGenerationError,
+    ThreeDProviderError,
+    ThreeDRequest,
+    ThreeDResponse,
+    ThreeDTimeoutError,
+)
+from services.three_d.trellis.client import (
+    BackendResult,
+    BackendUnavailable,
+    StubClient,
+    TrellisBackendClient,
+    build_backend,
+)
+from services.three_d.trellis.config import (
+    TrellisBackend,
+    TrellisConfig,
+    TrellisQualityPreset,
+)
+from services.three_d.trellis.garment_aware import (
+    GarmentCategory,
+    build_garment_prompt_bundle,
+)
+from services.three_d.trellis.postprocess import MeshPostprocessor, PostprocessResult
+from services.three_d.trellis.preprocess import PreprocessResult, TrellisPreprocessor
+
+logger = logging.getLogger(__name__)
+
+
+class TrellisProvider:
+    """TRELLIS-backed 3D provider, conforming to :class:`I3DProvider`.
+
+    The provider is opinionated for clothing imagery — it auto-classifies the
+    garment category, builds a clothing-aware prompt, runs background removal,
+    and decimates the mesh into a category-appropriate polycount.
+
+    Lifecycle:
+        provider = TrellisProvider(TrellisConfig.from_env())
+        try:
+            resp = await provider.generate_from_image(request)
+        finally:
+            await provider.close()
+    """
+
+    def __init__(
+        self,
+        config: TrellisConfig | None = None,
+        *,
+        backend: TrellisBackendClient | None = None,
+        preprocessor: TrellisPreprocessor | None = None,
+        postprocessor: MeshPostprocessor | None = None,
+    ) -> None:
+        self.config = config or TrellisConfig.from_env()
+        self.config.ensure_dirs()
+        self._backend = backend or build_backend(self.config)
+        self._preprocessor = preprocessor or TrellisPreprocessor(self.config)
+        self._postprocessor = postprocessor or MeshPostprocessor(self.config)
+
+    # ---------------------------------------------------------------------
+    # Identity
+    # ---------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "trellis"
+
+    @property
+    def capabilities(self) -> list[ThreeDCapability]:
+        caps = [ThreeDCapability.IMAGE_TO_3D, ThreeDCapability.TEXTURE_GENERATION]
+        if self.config.backend == TrellisBackend.LOCAL:
+            # text-to-3D requires the TRELLIS-text-large checkpoint;
+            # advertise it conditionally so the factory routes correctly.
+            caps.append(ThreeDCapability.TEXT_TO_3D)
+        return caps
+
+    # ---------------------------------------------------------------------
+    # I3DProvider — text
+    # ---------------------------------------------------------------------
+
+    async def generate_from_text(self, request: ThreeDRequest) -> ThreeDResponse:
+        correlation_id = request.correlation_id or str(uuid.uuid4())
+        start = time.time()
+
+        if not request.prompt:
+            raise ThreeDProviderError(
+                "TRELLIS text-to-3D requires a non-empty prompt",
+                provider=self.name,
+                correlation_id=correlation_id,
+            )
+
+        bundle = build_garment_prompt_bundle(
+            product_name=request.product_name,
+            declared_category=request.garment_type,
+            collection=request.collection,
+            user_prompt=request.prompt,
+        )
+
+        sampling = self._resolve_sampling(request)
+        task_id = f"trellis_txt_{uuid.uuid4().hex[:12]}"
+        logger.info(
+            "TRELLIS text-to-3D",
+            extra={
+                "correlation_id": correlation_id,
+                "category": bundle.category.value,
+                "backend": self._backend.backend_name,
+            },
+        )
+
+        try:
+            backend_result = await self._call_backend_text(
+                bundle.prompt,
+                sampling_steps=sampling,
+                seed=request.metadata.get("seed") or self.config.seed,
+                correlation_id=correlation_id,
+            )
+        except BackendUnavailable as exc:
+            raise ThreeDProviderError(
+                str(exc),
+                provider=self.name,
+                correlation_id=correlation_id,
+                retryable=False,
+            ) from exc
+
+        post = await self._postprocess(
+            backend_result,
+            category=bundle.category,
+            request=request,
+            correlation_id=correlation_id,
+        )
+
+        return self._build_response(
+            task_id=task_id,
+            request=request,
+            backend_result=backend_result,
+            post=post,
+            extra_metadata={
+                "garment_category": bundle.category.value,
+                "prompt_used": bundle.prompt,
+                "preprocess": None,
+            },
+            duration=time.time() - start,
+            correlation_id=correlation_id,
+        )
+
+    # ---------------------------------------------------------------------
+    # I3DProvider — image
+    # ---------------------------------------------------------------------
+
+    async def generate_from_image(self, request: ThreeDRequest) -> ThreeDResponse:
+        correlation_id = request.correlation_id or str(uuid.uuid4())
+        start = time.time()
+
+        image_source = request.get_image_source()
+        if not image_source:
+            raise ThreeDProviderError(
+                "TRELLIS image-to-3D requires image_url or image_path",
+                provider=self.name,
+                correlation_id=correlation_id,
+            )
+
+        local_image = await self._ensure_local_image(image_source, correlation_id)
+        preprocess = await self._preprocess(local_image, correlation_id)
+
+        bundle = build_garment_prompt_bundle(
+            image_path=preprocess.image.path,
+            image_size=(preprocess.image.width, preprocess.image.height),
+            product_name=request.product_name,
+            declared_category=request.garment_type,
+            collection=request.collection,
+            user_prompt=request.prompt,
+        )
+
+        sampling = self._resolve_sampling(request)
+        task_id = f"trellis_img_{uuid.uuid4().hex[:12]}"
+
+        logger.info(
+            "TRELLIS image-to-3D",
+            extra={
+                "correlation_id": correlation_id,
+                "category": bundle.category.value,
+                "preprocess_quality": preprocess.quality_score,
+                "backend": self._backend.backend_name,
+            },
+        )
+
+        try:
+            backend_result = await self._call_backend_image(
+                preprocess.image.path,
+                sampling=sampling,
+                prompt_hint=bundle.prompt,
+                seed=request.metadata.get("seed") or self.config.seed,
+                correlation_id=correlation_id,
+            )
+        except BackendUnavailable as exc:
+            raise ThreeDProviderError(
+                str(exc),
+                provider=self.name,
+                correlation_id=correlation_id,
+                retryable=False,
+            ) from exc
+
+        post = await self._postprocess(
+            backend_result,
+            category=bundle.category,
+            request=request,
+            correlation_id=correlation_id,
+        )
+
+        return self._build_response(
+            task_id=task_id,
+            request=request,
+            backend_result=backend_result,
+            post=post,
+            extra_metadata={
+                "garment_category": bundle.category.value,
+                "prompt_hint": bundle.prompt,
+                "preprocess": {
+                    "quality_score": preprocess.quality_score,
+                    "sharpness": preprocess.sharpness,
+                    "background_removed": preprocess.image.background_removed,
+                    "warnings": preprocess.warnings,
+                },
+                "post_warnings": post.warnings,
+            },
+            duration=time.time() - start,
+            correlation_id=correlation_id,
+        )
+
+    # ---------------------------------------------------------------------
+    # I3DProvider — health
+    # ---------------------------------------------------------------------
+
+    async def health_check(self) -> ProviderHealth:
+        start = time.time()
+        try:
+            healthy, error = await self._backend.healthy()
+        except Exception as exc:  # noqa: BLE001 — broad to satisfy contract
+            healthy, error = False, str(exc)
+
+        latency = (time.time() - start) * 1000
+        return ProviderHealth(
+            provider=self.name,
+            status=ProviderStatus.AVAILABLE if healthy else ProviderStatus.UNAVAILABLE,
+            capabilities=self.capabilities,
+            latency_ms=latency,
+            last_check=datetime.now(UTC),
+            error_message=error,
+        )
+
+    async def close(self) -> None:
+        await self._backend.close()
+
+    # ---------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------
+
+    def _resolve_sampling(self, request: ThreeDRequest):
+        # Allow per-request override; default to config preset.
+        preset = request.metadata.get("quality")
+        if preset:
+            try:
+                return TrellisConfig(
+                    backend=self.config.backend,
+                    quality=TrellisQualityPreset(preset),
+                ).sampling
+            except ValueError:
+                logger.warning("Unknown quality preset %s — using config default", preset)
+        return self.config.sampling
+
+    async def _preprocess(
+        self,
+        image_path: str,
+        correlation_id: str,
+    ) -> PreprocessResult:
+        try:
+            return await asyncio.to_thread(self._preprocessor.prepare, image_path)
+        except Exception as exc:  # noqa: BLE001
+            raise ThreeDProviderError(
+                f"Preprocessing failed: {exc}",
+                provider=self.name,
+                correlation_id=correlation_id,
+                retryable=False,
+                cause=exc,
+            ) from exc
+
+    async def _postprocess(
+        self,
+        backend_result: BackendResult,
+        *,
+        category: GarmentCategory,
+        request: ThreeDRequest,
+        correlation_id: str,
+    ) -> PostprocessResult:
+        artifact_id = (
+            request.metadata.get("artifact_id")
+            or request.correlation_id
+            or correlation_id[:12]
+        )
+        sampling = self._resolve_sampling(request)
+        try:
+            return await asyncio.to_thread(
+                self._postprocessor.process,
+                raw_glb=backend_result.glb_path,
+                category=category,
+                sampling=sampling,
+                artifact_id=str(artifact_id),
+            )
+        except FileNotFoundError as exc:
+            raise ThreeDGenerationError(
+                f"Postprocess missing raw GLB: {exc}",
+                provider=self.name,
+                correlation_id=correlation_id,
+            ) from exc
+
+    async def _call_backend_image(
+        self,
+        image_path: str,
+        *,
+        sampling,
+        prompt_hint: str,
+        seed: int | None,
+        correlation_id: str,
+    ) -> BackendResult:
+        attempts = self.config.retry_attempts
+        delay = self.config.retry_backoff_seconds
+        last_exc: Exception | None = None
+        for attempt in range(attempts + 1):
+            try:
+                return await self._backend.generate_from_image(
+                    image_path,
+                    sampling=sampling,
+                    prompt_hint=prompt_hint,
+                    seed=seed,
+                )
+            except asyncio.TimeoutError as exc:
+                raise ThreeDTimeoutError(
+                    f"TRELLIS timed out after {self.config.timeout_seconds}s",
+                    provider=self.name,
+                    timeout_seconds=self.config.timeout_seconds,
+                    correlation_id=correlation_id,
+                ) from exc
+            except BackendUnavailable:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                if attempt < attempts:
+                    logger.warning(
+                        "TRELLIS attempt %s failed: %s — retrying in %.1fs",
+                        attempt + 1,
+                        exc,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    delay *= 2
+
+        raise ThreeDGenerationError(
+            f"TRELLIS image-to-3D failed after {attempts + 1} attempts: {last_exc}",
+            provider=self.name,
+            correlation_id=correlation_id,
+        ) from last_exc
+
+    async def _call_backend_text(
+        self,
+        prompt: str,
+        *,
+        sampling_steps,
+        seed: int | None,
+        correlation_id: str,
+    ) -> BackendResult:
+        try:
+            return await self._backend.generate_from_text(
+                prompt,
+                sampling=sampling_steps,
+                seed=seed,
+            )
+        except asyncio.TimeoutError as exc:
+            raise ThreeDTimeoutError(
+                f"TRELLIS text-to-3D timed out",
+                provider=self.name,
+                timeout_seconds=self.config.timeout_seconds,
+                correlation_id=correlation_id,
+            ) from exc
+
+    async def _ensure_local_image(
+        self,
+        image_source: str,
+        correlation_id: str,
+    ) -> str:
+        """If the caller gave us a URL, download it; otherwise return the path."""
+        if image_source.startswith(("http://", "https://")):
+            return await asyncio.to_thread(
+                _download_image,
+                image_source,
+                self.config.cache_dir,
+            )
+        if not Path(image_source).exists():
+            raise ThreeDProviderError(
+                f"Image not found: {image_source}",
+                provider=self.name,
+                correlation_id=correlation_id,
+            )
+        return image_source
+
+    def _build_response(
+        self,
+        *,
+        task_id: str,
+        request: ThreeDRequest,
+        backend_result: BackendResult,
+        post: PostprocessResult,
+        extra_metadata: dict,
+        duration: float,
+        correlation_id: str,
+    ) -> ThreeDResponse:
+        glb_path = Path(post.glb_path)
+        relative_url = (
+            f"/assets/3d-models-generated/{glb_path.name}"
+            if "3d-models-generated" in str(glb_path)
+            else None
+        )
+
+        metadata = {
+            "backend": backend_result.backend,
+            "backend_duration": backend_result.duration_seconds,
+            "seed": backend_result.seed,
+            "usdz_path": post.usdz_path,
+            "thumbnail_path": post.thumbnail_path,
+            "splat_path": backend_result.splat_path,
+            "preview_path": backend_result.preview_path,
+        }
+        metadata.update(extra_metadata)
+        metadata.update(backend_result.metadata)
+
+        return ThreeDResponse(
+            success=True,
+            task_id=task_id,
+            status="completed",
+            model_url=relative_url,
+            model_path=str(glb_path),
+            thumbnail_url=(
+                f"/assets/3d-models-generated/{Path(post.thumbnail_path).name}"
+                if post.thumbnail_path
+                else None
+            ),
+            output_format=OutputFormat.GLB,
+            provider=self.name,
+            duration_seconds=duration,
+            polycount=post.polycount,
+            file_size_bytes=post.file_size_bytes,
+            created_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            correlation_id=correlation_id,
+            metadata=metadata,
+        )
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _download_image(url: str, cache_dir: str) -> str:
+    import hashlib
+    import urllib.request
+
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+    suffix = Path(url.split("?")[0]).suffix or ".jpg"
+    dst = Path(cache_dir) / f"download_{digest}{suffix}"
+    if dst.exists():
+        return str(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    with urllib.request.urlopen(url, timeout=30) as src, open(dst, "wb") as out:  # noqa: S310
+        out.write(src.read())
+    return str(dst)
+
+
+# =============================================================================
+# Test helper
+# =============================================================================
+
+
+def make_stub_provider(config: TrellisConfig | None = None) -> TrellisProvider:
+    """Build a TrellisProvider wired to the deterministic stub backend."""
+    cfg = config or TrellisConfig()
+    cfg.ensure_dirs()
+    return TrellisProvider(cfg, backend=StubClient(cfg))
+
+
+__all__ = [
+    "TrellisProvider",
+    "make_stub_provider",
+]

--- a/tests/pipelines/clothing_3d/test_pipeline.py
+++ b/tests/pipelines/clothing_3d/test_pipeline.py
@@ -1,0 +1,197 @@
+"""End-to-end tests for :class:`ClothingPipeline` with the stub backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pipelines.clothing_3d import (
+    ClothingPipeline,
+    PipelineEventBus,
+    PipelineRequest,
+    PipelineStatus,
+)
+from pipelines.clothing_3d.events import log_event_subscriber
+from pipelines.clothing_3d.stages import QCThresholds
+from pipelines.clothing_3d.storage import LocalArtifactStore
+from services.three_d.trellis import (
+    TrellisConfig,
+    TrellisProvider,
+    TrellisQualityPreset,
+)
+from services.three_d.trellis.client import StubClient
+
+pytest.importorskip("PIL.Image")
+
+
+def _config(tmp_path: Path) -> TrellisConfig:
+    cfg = TrellisConfig(
+        cache_dir=str(tmp_path / "cache"),
+        output_dir=str(tmp_path / "out"),
+        enable_background_removal=False,
+        enable_postprocess=False,
+        export_usdz_for_ios=False,
+        quality=TrellisQualityPreset.DRAFT,
+    )
+    cfg.ensure_dirs()
+    return cfg
+
+
+def _image(tmp_path: Path, name: str = "tee.png") -> Path:
+    from PIL import Image
+
+    p = tmp_path / name
+    Image.new("RGB", (700, 900), (240, 240, 240)).save(p)
+    return p
+
+
+def _pipeline(tmp_path: Path, *, skip_qc: bool = True) -> ClothingPipeline:
+    cfg = _config(tmp_path)
+    provider = TrellisProvider(cfg, backend=StubClient(cfg))
+    store = LocalArtifactStore(base_dir=cfg.output_dir)
+    return ClothingPipeline(
+        config=cfg,
+        provider=provider,
+        store=store,
+        # Relaxed thresholds so the stub's tiny GLB passes if QC runs at all.
+        thresholds=QCThresholds(
+            min_polycount=0,
+            max_polycount=10**9,
+            min_file_kb=0,
+            max_file_kb=10**9,
+        ),
+    )
+
+
+# =============================================================================
+# Happy path
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_pipeline_image_to_3d_succeeds(tmp_path: Path) -> None:
+    pipeline = _pipeline(tmp_path)
+    request = PipelineRequest(
+        image_path=str(_image(tmp_path)),
+        product_name="Signature Tee",
+        collection="signature",
+        garment_type="tee",
+        quality=TrellisQualityPreset.DRAFT,
+    )
+
+    result = await pipeline.run(request)
+
+    assert result.status is PipelineStatus.SUCCEEDED
+    assert result.glb_url is not None
+    assert result.glb_path is not None
+    assert Path(result.glb_path).exists()
+    assert result.garment_category == "tee"
+
+    # All stages reported
+    stages = [r.stage.value for r in result.stages]
+    assert "ingest" in stages
+    assert "generate" in stages
+    assert "store" in stages
+
+    await pipeline.close()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_text_to_3d_succeeds(tmp_path: Path) -> None:
+    pipeline = _pipeline(tmp_path)
+    request = PipelineRequest(
+        prompt="oversized crimson love-hurts hoodie",
+        product_name="LH Hoodie",
+        collection="love_hurts",
+        garment_type="hoodie",
+        quality=TrellisQualityPreset.DRAFT,
+    )
+
+    result = await pipeline.run(request)
+
+    assert result.status is PipelineStatus.SUCCEEDED
+    assert result.garment_category == "hoodie"
+    assert result.metadata.get("provider") == "trellis"
+
+    await pipeline.close()
+
+
+# =============================================================================
+# Failure paths
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_pipeline_with_missing_image_fails_in_ingest(tmp_path: Path) -> None:
+    pipeline = _pipeline(tmp_path)
+    request = PipelineRequest(
+        image_path=str(tmp_path / "does-not-exist.png"),
+        product_name="Ghost",
+    )
+
+    result = await pipeline.run(request)
+
+    assert result.status is PipelineStatus.FAILED
+    assert result.stages[0].stage.value == "ingest"
+    assert "not found" in (result.stages[0].error or "").lower()
+
+    await pipeline.close()
+
+
+# =============================================================================
+# Events
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_pipeline_emits_lifecycle_events(tmp_path: Path) -> None:
+    bus = PipelineEventBus()
+    bus.subscribe(log_event_subscriber())
+
+    received: list[str] = []
+
+    async def collector(event) -> None:
+        received.append(event.name)
+
+    bus.subscribe(collector)
+
+    cfg = _config(tmp_path)
+    provider = TrellisProvider(cfg, backend=StubClient(cfg))
+    pipeline = ClothingPipeline(
+        config=cfg,
+        provider=provider,
+        store=LocalArtifactStore(base_dir=cfg.output_dir),
+        event_bus=bus,
+    )
+
+    request = PipelineRequest(
+        image_path=str(_image(tmp_path)),
+        product_name="Test",
+        skip_qc=True,
+    )
+    await pipeline.run(request)
+    await pipeline.close()
+
+    assert "pipeline.started" in received
+    assert "pipeline.succeeded" in received
+    assert "stage.started" in received
+    assert "stage.finished" in received
+
+
+# =============================================================================
+# Storage
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_local_store_emits_public_urls(tmp_path: Path) -> None:
+    pipeline = _pipeline(tmp_path)
+    request = PipelineRequest(
+        image_path=str(_image(tmp_path)),
+        product_name="P",
+        skip_qc=True,
+    )
+    result = await pipeline.run(request)
+    assert result.glb_url and result.glb_url.startswith("/assets/3d-models-generated/")
+    await pipeline.close()

--- a/tests/pipelines/clothing_3d/test_queue_and_store.py
+++ b/tests/pipelines/clothing_3d/test_queue_and_store.py
@@ -1,0 +1,143 @@
+"""Unit tests for InMemoryQueue + InMemoryJobStore."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pipelines.clothing_3d.job_store import InMemoryJobStore, JobRecord
+from pipelines.clothing_3d.models import PipelineRequest, PipelineStatus
+from pipelines.clothing_3d.queue import InMemoryQueue
+
+
+# =============================================================================
+# InMemoryQueue
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_enqueue_dequeue_ack_roundtrip() -> None:
+    q = InMemoryQueue()
+    await q.enqueue("job-1")
+    msg = await q.dequeue(block_seconds=1.0)
+    assert msg is not None
+    assert msg.job_id == "job-1"
+    assert msg.attempt == 1
+    await q.ack(msg)
+    # After ack the queue is empty
+    assert await q.depth() == 0
+    assert await q.dequeue(block_seconds=0.05) is None
+
+
+@pytest.mark.asyncio
+async def test_nack_requeues_with_incremented_attempt() -> None:
+    q = InMemoryQueue()
+    await q.enqueue("job-1")
+    msg = await q.dequeue(block_seconds=1.0)
+    assert msg is not None
+    await q.nack(msg, requeue=True)
+
+    msg2 = await q.dequeue(block_seconds=1.0)
+    assert msg2 is not None
+    assert msg2.job_id == "job-1"
+    assert msg2.attempt == msg.attempt + 1
+
+
+@pytest.mark.asyncio
+async def test_nack_no_requeue_drops_message() -> None:
+    q = InMemoryQueue()
+    await q.enqueue("drop-me")
+    msg = await q.dequeue(block_seconds=1.0)
+    assert msg is not None
+    await q.nack(msg, requeue=False)
+    assert await q.dequeue(block_seconds=0.05) is None
+
+
+@pytest.mark.asyncio
+async def test_depth_reports_pending_messages() -> None:
+    q = InMemoryQueue()
+    for i in range(3):
+        await q.enqueue(f"j{i}")
+    assert await q.depth() == 3
+
+
+# =============================================================================
+# InMemoryJobStore
+# =============================================================================
+
+
+def _make_record(job_id: str) -> JobRecord:
+    return JobRecord(
+        job_id=job_id,
+        status=PipelineStatus.PENDING,
+        request=PipelineRequest(prompt="x", product_name="x"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_put_and_get() -> None:
+    store = InMemoryJobStore()
+    rec = _make_record("a")
+    await store.put(rec)
+    fetched = await store.get("a")
+    assert fetched is not None
+    assert fetched.job_id == "a"
+    assert fetched.status == PipelineStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_store_update_replaces_record() -> None:
+    store = InMemoryJobStore()
+    rec = _make_record("a")
+    await store.put(rec)
+
+    rec.status = PipelineStatus.SUCCEEDED
+    await store.update(rec)
+
+    fetched = await store.get("a")
+    assert fetched is not None
+    assert fetched.status == PipelineStatus.SUCCEEDED
+
+
+@pytest.mark.asyncio
+async def test_store_list_returns_newest_first() -> None:
+    store = InMemoryJobStore()
+    await store.put(_make_record("a"))
+    await asyncio.sleep(0.01)
+    await store.put(_make_record("b"))
+
+    jobs = await store.list(limit=10)
+    assert [j.job_id for j in jobs] == ["b", "a"]
+
+
+@pytest.mark.asyncio
+async def test_store_evicts_oldest_at_capacity() -> None:
+    store = InMemoryJobStore(capacity=2)
+    await store.put(_make_record("a"))
+    await asyncio.sleep(0.01)
+    await store.put(_make_record("b"))
+    await asyncio.sleep(0.01)
+    await store.put(_make_record("c"))
+
+    assert await store.get("a") is None
+    assert await store.get("b") is not None
+    assert await store.get("c") is not None
+
+
+@pytest.mark.asyncio
+async def test_record_to_from_dict_roundtrip() -> None:
+    rec = _make_record("rt-1")
+    rec.attempt = 2
+    rec.worker_id = "worker-7"
+    rec.idempotency_key = "sha256:abc"
+
+    payload = rec.to_dict()
+    restored = JobRecord.from_dict(payload)
+    assert restored.job_id == "rt-1"
+    assert restored.status == PipelineStatus.PENDING
+    assert restored.attempt == 2
+    assert restored.worker_id == "worker-7"
+    assert restored.idempotency_key == "sha256:abc"
+    assert restored.request is not None
+    assert restored.request.prompt == "x"

--- a/tests/pipelines/clothing_3d/test_reliability.py
+++ b/tests/pipelines/clothing_3d/test_reliability.py
@@ -1,0 +1,224 @@
+"""Unit tests for reliability primitives."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from pipelines.clothing_3d.models import PipelineRequest, PipelineResult, PipelineStatus
+from pipelines.clothing_3d.reliability import (
+    CostQuota,
+    IdempotencyCache,
+    InMemoryIdempotencyStore,
+    QuotaExceededError,
+    RetryPolicy,
+    request_fingerprint,
+)
+from services.three_d.trellis.config import TrellisQualityPreset
+
+
+# =============================================================================
+# RetryPolicy
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_after_transient_failures() -> None:
+    attempts = []
+
+    async def flaky():
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise TimeoutError("flake")
+        return "ok"
+
+    policy = RetryPolicy(max_attempts=4, base_delay_seconds=0.001, max_delay_seconds=0.01)
+    assert await policy.run(flaky) == "ok"
+    assert len(attempts) == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_gives_up_after_max_attempts() -> None:
+    async def always_fails():
+        raise TimeoutError("nope")
+
+    policy = RetryPolicy(max_attempts=2, base_delay_seconds=0.001, max_delay_seconds=0.01)
+    with pytest.raises(TimeoutError):
+        await policy.run(always_fails)
+
+
+@pytest.mark.asyncio
+async def test_retry_only_retries_listed_exceptions() -> None:
+    async def value_err():
+        raise ValueError("not retryable")
+
+    policy = RetryPolicy(max_attempts=3, base_delay_seconds=0.001)
+    with pytest.raises(ValueError):
+        await policy.run(value_err)
+
+
+def test_retry_delay_grows_with_attempt() -> None:
+    policy = RetryPolicy(
+        max_attempts=5,
+        base_delay_seconds=1.0,
+        max_delay_seconds=64.0,
+        backoff_multiplier=2.0,
+    )
+    # delay_for(1) = 0 (first try, no sleep)
+    assert policy.delay_for(1) == 0.0
+    # delay_for(2) ∈ [0, 1]
+    # delay_for(3) ∈ [0, 2]
+    # delay_for(N) capped at max_delay_seconds
+    for n in range(2, 10):
+        d = policy.delay_for(n)
+        assert d >= 0.0
+        assert d <= policy.max_delay_seconds
+
+
+# =============================================================================
+# Idempotency
+# =============================================================================
+
+
+def test_fingerprint_stable_across_identical_requests() -> None:
+    a = PipelineRequest(prompt="hoodie", product_name="X", garment_type="hoodie",
+                        quality=TrellisQualityPreset.STANDARD)
+    b = PipelineRequest(prompt="hoodie", product_name="X", garment_type="hoodie",
+                        quality=TrellisQualityPreset.STANDARD,
+                        correlation_id="differs")
+    assert request_fingerprint(a) == request_fingerprint(b)
+
+
+def test_fingerprint_changes_with_quality() -> None:
+    a = PipelineRequest(prompt="hoodie", product_name="X",
+                        quality=TrellisQualityPreset.DRAFT)
+    b = PipelineRequest(prompt="hoodie", product_name="X",
+                        quality=TrellisQualityPreset.PRODUCTION)
+    assert request_fingerprint(a) != request_fingerprint(b)
+
+
+@pytest.mark.asyncio
+async def test_idempotency_cache_returns_cached_on_second_call() -> None:
+    runs = 0
+    sentinel = PipelineResult(
+        status=PipelineStatus.SUCCEEDED,
+        artifact_id="a1",
+        correlation_id="c1",
+        glb_url="/foo.glb",
+    )
+
+    async def runner(_req):
+        nonlocal runs
+        runs += 1
+        return sentinel
+
+    cache = IdempotencyCache(ttl_seconds=60)
+    req = PipelineRequest(prompt="x", product_name="x")
+
+    r1, hit1 = await cache.get_or_run(req, runner=runner)
+    r2, hit2 = await cache.get_or_run(req, runner=runner)
+
+    assert runs == 1
+    assert r1 == r2
+    assert hit1 is False and hit2 is True
+
+
+@pytest.mark.asyncio
+async def test_idempotency_does_not_cache_failures() -> None:
+    runs = 0
+
+    async def runner(_req):
+        nonlocal runs
+        runs += 1
+        return PipelineResult(
+            status=PipelineStatus.FAILED,
+            artifact_id="x",
+            correlation_id="c",
+        )
+
+    cache = IdempotencyCache(ttl_seconds=60)
+    req = PipelineRequest(prompt="x", product_name="x")
+    await cache.get_or_run(req, runner=runner)
+    await cache.get_or_run(req, runner=runner)
+    assert runs == 2  # not cached
+
+
+@pytest.mark.asyncio
+async def test_idempotency_disabled_passthrough() -> None:
+    runs = 0
+
+    async def runner(_req):
+        nonlocal runs
+        runs += 1
+        return PipelineResult(
+            status=PipelineStatus.SUCCEEDED, artifact_id="x", correlation_id="c"
+        )
+
+    cache = IdempotencyCache(enabled=False)
+    req = PipelineRequest(prompt="x", product_name="x")
+    await cache.get_or_run(req, runner=runner)
+    await cache.get_or_run(req, runner=runner)
+    assert runs == 2
+
+
+# =============================================================================
+# CostQuota
+# =============================================================================
+
+
+def test_cost_quota_charges_until_cap() -> None:
+    q = CostQuota(caps_usd={"replicate": 0.10})  # default replicate cost = $0.05/call
+    q.charge("replicate")  # spent $0.05
+    q.charge("replicate")  # spent $0.10
+    with pytest.raises(QuotaExceededError):
+        q.charge("replicate")
+    assert q.spent("replicate") == pytest.approx(0.10)
+
+
+def test_cost_quota_no_cap_means_unlimited() -> None:
+    q = CostQuota()
+    for _ in range(100):
+        q.charge("replicate")
+    # No cap declared, so no exception. spent stays 0 (not tracked w/o cap).
+
+
+def test_cost_quota_snapshot_shape() -> None:
+    q = CostQuota(caps_usd={"modal": 0.50})
+    q.charge("modal")
+    snap = q.snapshot()
+    assert "modal" in snap
+    assert snap["modal"]["cap_usd"] == 0.50
+    assert snap["modal"]["spent_usd"] > 0
+
+
+# =============================================================================
+# InMemoryIdempotencyStore
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_evicts_when_full() -> None:
+    store = InMemoryIdempotencyStore(capacity=2)
+    from datetime import UTC, datetime
+    from pipelines.clothing_3d.reliability import IdempotencyEntry
+
+    def make(fp: str) -> IdempotencyEntry:
+        return IdempotencyEntry(
+            fingerprint=fp,
+            result=PipelineResult(
+                status=PipelineStatus.SUCCEEDED, artifact_id=fp, correlation_id=fp
+            ),
+            cached_at=datetime.now(UTC),
+        )
+
+    await store.put(make("a"), ttl_seconds=60)
+    await asyncio.sleep(0.001)
+    await store.put(make("b"), ttl_seconds=60)
+    await asyncio.sleep(0.001)
+    await store.put(make("c"), ttl_seconds=60)  # evicts 'a'
+
+    assert await store.get("a") is None
+    assert (await store.get("b")) is not None
+    assert (await store.get("c")) is not None

--- a/tests/three_d/trellis/test_config.py
+++ b/tests/three_d/trellis/test_config.py
@@ -1,0 +1,74 @@
+"""Unit tests for TRELLIS configuration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from services.three_d.trellis.config import (
+    TrellisBackend,
+    TrellisConfig,
+    TrellisQualityPreset,
+    TrellisSamplingParams,
+)
+
+
+class TestSamplingParams:
+    def test_each_preset_has_params(self) -> None:
+        for preset in TrellisQualityPreset:
+            params = TrellisSamplingParams.for_preset(preset)
+            assert params.ss_sampling_steps > 0
+            assert params.slat_sampling_steps > 0
+            assert 0 < params.mesh_simplify <= 1
+
+    def test_quality_monotonic(self) -> None:
+        draft = TrellisSamplingParams.for_preset(TrellisQualityPreset.DRAFT)
+        standard = TrellisSamplingParams.for_preset(TrellisQualityPreset.STANDARD)
+        production = TrellisSamplingParams.for_preset(TrellisQualityPreset.PRODUCTION)
+
+        # Steps grow with quality
+        assert draft.ss_sampling_steps < standard.ss_sampling_steps < production.ss_sampling_steps
+        assert draft.target_polycount < standard.target_polycount < production.target_polycount
+
+
+class TestTrellisConfig:
+    def test_defaults(self) -> None:
+        cfg = TrellisConfig()
+        assert cfg.backend == TrellisBackend.HF_SPACE
+        assert cfg.quality == TrellisQualityPreset.STANDARD
+        assert cfg.hf_space_id == "JeffreyXiang/TRELLIS"
+        assert cfg.timeout_seconds > 0
+        assert cfg.retry_attempts >= 0
+
+    def test_sampling_property(self) -> None:
+        cfg = TrellisConfig(quality=TrellisQualityPreset.PRODUCTION)
+        assert cfg.sampling.ss_sampling_steps == 20
+
+    def test_from_env_with_overrides(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("TRELLIS_BACKEND", "local")
+        monkeypatch.setenv("TRELLIS_QUALITY", "production")
+        monkeypatch.setenv("TRELLIS_OUTPUT_DIR", str(tmp_path / "out"))
+        monkeypatch.setenv("TRELLIS_CACHE_DIR", str(tmp_path / "cache"))
+        monkeypatch.setenv("TRELLIS_SEED", "1234")
+        monkeypatch.setenv("TRELLIS_TIMEOUT", "999")
+        monkeypatch.setenv("TRELLIS_RETRIES", "5")
+
+        cfg = TrellisConfig.from_env()
+        assert cfg.backend == TrellisBackend.LOCAL
+        assert cfg.quality == TrellisQualityPreset.PRODUCTION
+        assert cfg.output_dir == str(tmp_path / "out")
+        assert cfg.cache_dir == str(tmp_path / "cache")
+        assert cfg.seed == 1234
+        assert cfg.timeout_seconds == 999
+        assert cfg.retry_attempts == 5
+
+    def test_ensure_dirs(self, tmp_path: Path) -> None:
+        cfg = TrellisConfig(
+            output_dir=str(tmp_path / "out"),
+            cache_dir=str(tmp_path / "cache"),
+        )
+        cfg.ensure_dirs()
+        assert (tmp_path / "out").is_dir()
+        assert (tmp_path / "cache").is_dir()

--- a/tests/three_d/trellis/test_garment_aware.py
+++ b/tests/three_d/trellis/test_garment_aware.py
@@ -1,0 +1,143 @@
+"""Unit tests for garment knowledge & prompt building."""
+
+from __future__ import annotations
+
+from services.three_d.trellis.garment_aware import (
+    GarmentCategory,
+    brand_context,
+    build_clothing_prompt,
+    build_garment_prompt_bundle,
+    classify_garment,
+    knowledge_for,
+)
+
+
+# =============================================================================
+# Classification
+# =============================================================================
+
+
+class TestClassify:
+    def test_declared_category_wins(self) -> None:
+        result = classify_garment(declared_category="hoodie", product_name="Random Name")
+        assert result is GarmentCategory.HOODIE
+
+    def test_invalid_declared_falls_through_to_name(self) -> None:
+        result = classify_garment(declared_category="not-a-category", product_name="Black Hoodie")
+        assert result is GarmentCategory.HOODIE
+
+    def test_product_name_keyword(self) -> None:
+        assert classify_garment(product_name="Silver Sneaker") is GarmentCategory.SHOE
+        assert classify_garment(product_name="Long Dress") is GarmentCategory.DRESS
+        assert classify_garment(product_name="Denim Jeans") is GarmentCategory.PANTS
+
+    def test_aspect_ratio_fallback(self) -> None:
+        # Tall image → dress
+        assert classify_garment(image_size=(600, 1200)) is GarmentCategory.DRESS
+        # Moderately tall → tee
+        assert classify_garment(image_size=(600, 800)) is GarmentCategory.TEE
+        # Wide-ish → hat
+        assert classify_garment(image_size=(1000, 600)) is GarmentCategory.HAT
+
+    def test_unknown_when_no_signal(self) -> None:
+        assert classify_garment() is GarmentCategory.UNKNOWN
+
+
+# =============================================================================
+# Knowledge lookup
+# =============================================================================
+
+
+class TestKnowledge:
+    def test_known_category_has_prompt(self) -> None:
+        kn = knowledge_for(GarmentCategory.HOODIE)
+        assert "hood" in kn.prompt_suffix.lower()
+        assert kn.polycount_hint > 50_000
+        assert kn.symmetry == "x"
+
+    def test_unknown_returns_neutral(self) -> None:
+        kn = knowledge_for(GarmentCategory.UNKNOWN)
+        assert kn.category is GarmentCategory.UNKNOWN
+        assert kn.polycount_hint > 0
+
+
+# =============================================================================
+# Brand context
+# =============================================================================
+
+
+class TestBrandContext:
+    def test_known_collection(self) -> None:
+        ctx = brand_context("black_rose")
+        assert ctx is not None
+        assert "chrome" in (ctx.accent or "").lower()
+
+    def test_hyphen_aliases(self) -> None:
+        assert brand_context("black-rose") == brand_context("black_rose")
+
+    def test_none_for_missing(self) -> None:
+        assert brand_context(None) is None
+        assert brand_context("nonexistent") is None
+
+
+# =============================================================================
+# Prompt construction
+# =============================================================================
+
+
+class TestBuildPrompt:
+    def test_includes_product_name_and_user_prompt(self) -> None:
+        prompt = build_clothing_prompt(
+            product_name="Black Rose Hoodie",
+            category=GarmentCategory.HOODIE,
+            user_prompt="oversized fit, vintage wash",
+        )
+        assert "Black Rose Hoodie" in prompt
+        assert "vintage wash" in prompt
+        assert "hood" in prompt.lower()
+
+    def test_brand_context_applied(self) -> None:
+        prompt = build_clothing_prompt(
+            product_name="Tee",
+            category=GarmentCategory.TEE,
+            collection="black_rose",
+        )
+        assert "chrome" in prompt.lower()
+        assert "gothic" in prompt.lower() or "dark" in prompt.lower()
+
+    def test_deduplicates(self) -> None:
+        prompt = build_clothing_prompt(
+            product_name="Sweatshirt",
+            category=GarmentCategory.TEE,
+            user_prompt="Sweatshirt",  # duplicate phrase
+            extra_keywords=["sweatshirt"],  # duplicate again (case-insensitive)
+        )
+        # Case-insensitive phrase dedup: the exact phrase appears once.
+        parts = [p.strip() for p in prompt.split(",")]
+        lowered = [p.lower() for p in parts]
+        assert lowered.count("sweatshirt") == 1
+
+    def test_always_appends_render_hint(self) -> None:
+        prompt = build_clothing_prompt(
+            product_name=None,
+            category=GarmentCategory.UNKNOWN,
+        )
+        assert "studio" in prompt.lower()
+
+
+# =============================================================================
+# Bundle
+# =============================================================================
+
+
+class TestBundle:
+    def test_bundle_classifies_and_builds(self) -> None:
+        bundle = build_garment_prompt_bundle(
+            product_name="Black Rose Hoodie",
+            collection="black_rose",
+            declared_category="hoodie",
+        )
+        assert bundle.category is GarmentCategory.HOODIE
+        assert "Black Rose Hoodie" in bundle.prompt
+        assert bundle.knowledge.polycount_hint > 0
+        assert bundle.extra["collection"] == "black_rose"

--- a/tests/three_d/trellis/test_preprocess.py
+++ b/tests/three_d/trellis/test_preprocess.py
@@ -1,0 +1,85 @@
+"""Unit tests for the TRELLIS image preprocessor.
+
+These tests only exercise the file-handling + dimensions path. The optional
+``rembg`` / advanced color-correction stages skip themselves gracefully when
+deps are missing, which is checked here too.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pil = pytest.importorskip("PIL.Image", reason="Pillow not installed")
+
+from services.three_d.trellis.config import TrellisConfig  # noqa: E402
+from services.three_d.trellis.preprocess import (  # noqa: E402
+    PreprocessError,
+    TrellisPreprocessor,
+)
+
+
+def _make_test_image(path: Path, *, size: tuple[int, int] = (600, 800)) -> Path:
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGBA", size, (255, 255, 255, 255))
+    draw = ImageDraw.Draw(img)
+    # Black rectangle in the middle = "the garment"
+    cx, cy = size[0] // 2, size[1] // 2
+    draw.rectangle(
+        [cx - 100, cy - 200, cx + 100, cy + 200],
+        fill=(20, 20, 20, 255),
+    )
+    img.save(path)
+    return path
+
+
+class TestTrellisPreprocessor:
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        cfg = TrellisConfig(cache_dir=str(tmp_path / "cache"), output_dir=str(tmp_path / "out"))
+        prep = TrellisPreprocessor(cfg)
+        with pytest.raises(PreprocessError):
+            prep.prepare(tmp_path / "missing.png")
+
+    def test_prepare_produces_square_target(self, tmp_path: Path) -> None:
+        cfg = TrellisConfig(
+            cache_dir=str(tmp_path / "cache"),
+            output_dir=str(tmp_path / "out"),
+            enable_background_removal=False,
+        )
+        prep = TrellisPreprocessor(cfg)
+
+        src = _make_test_image(tmp_path / "tee.png", size=(800, 1200))
+        result = prep.prepare(src)
+
+        assert result.image.width == TrellisPreprocessor.TARGET_RESOLUTION
+        assert result.image.height == TrellisPreprocessor.TARGET_RESOLUTION
+        assert Path(result.image.path).exists()
+        assert 0.0 <= result.quality_score <= 1.0
+
+    def test_passthrough_copies_unchanged(self, tmp_path: Path) -> None:
+        cfg = TrellisConfig(cache_dir=str(tmp_path / "cache"), output_dir=str(tmp_path / "out"))
+        prep = TrellisPreprocessor(cfg)
+
+        src = _make_test_image(tmp_path / "src.png", size=(400, 500))
+        result = prep.passthrough(src)
+
+        assert result.bypassed
+        assert Path(result.image.path).exists()
+        assert result.image.width == 400
+        assert result.image.height == 500
+
+    def test_small_input_emits_warning(self, tmp_path: Path) -> None:
+        cfg = TrellisConfig(
+            cache_dir=str(tmp_path / "cache"),
+            output_dir=str(tmp_path / "out"),
+            enable_background_removal=False,
+            min_input_resolution=512,
+        )
+        prep = TrellisPreprocessor(cfg)
+
+        src = _make_test_image(tmp_path / "tiny.png", size=(128, 128))
+        result = prep.prepare(src)
+
+        assert any("below" in w for w in result.warnings)

--- a/tests/three_d/trellis/test_provider.py
+++ b/tests/three_d/trellis/test_provider.py
@@ -1,0 +1,122 @@
+"""Unit tests for :class:`TrellisProvider` using the stub backend.
+
+These tests don't touch the network, GPU, or any optional deps beyond Pillow.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from services.three_d.provider_interface import (
+    ThreeDProviderError,
+    ThreeDRequest,
+)
+from services.three_d.trellis import (
+    TrellisConfig,
+    TrellisProvider,
+    TrellisQualityPreset,
+)
+from services.three_d.trellis.client import StubClient
+
+pil = pytest.importorskip("PIL.Image")
+
+
+def _make_image(path: Path) -> Path:
+    from PIL import Image
+
+    Image.new("RGB", (640, 800), (200, 200, 200)).save(path)
+    return path
+
+
+def _make_provider(tmp_path: Path) -> TrellisProvider:
+    cfg = TrellisConfig(
+        cache_dir=str(tmp_path / "cache"),
+        output_dir=str(tmp_path / "out"),
+        enable_background_removal=False,
+        enable_postprocess=False,
+        export_usdz_for_ios=False,
+        quality=TrellisQualityPreset.DRAFT,
+    )
+    cfg.ensure_dirs()
+    return TrellisProvider(cfg, backend=StubClient(cfg))
+
+
+# =============================================================================
+# generate_from_image
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_generate_from_image_returns_glb(tmp_path: Path) -> None:
+    provider = _make_provider(tmp_path)
+    img = _make_image(tmp_path / "hoodie.png")
+
+    response = await provider.generate_from_image(
+        ThreeDRequest(
+            image_path=str(img),
+            product_name="Black Rose Hoodie",
+            collection="black_rose",
+            garment_type="hoodie",
+        )
+    )
+
+    assert response.success
+    assert response.model_path is not None
+    assert Path(response.model_path).exists()
+    assert response.provider == "trellis"
+    assert response.metadata["garment_category"] == "hoodie"
+    assert response.metadata["backend"] == "stub"
+
+
+@pytest.mark.asyncio
+async def test_generate_from_image_missing_input_raises(tmp_path: Path) -> None:
+    provider = _make_provider(tmp_path)
+    with pytest.raises(ThreeDProviderError):
+        await provider.generate_from_image(ThreeDRequest(prompt="hoodie"))
+
+
+# =============================================================================
+# generate_from_text
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_generate_from_text_uses_clothing_prompt(tmp_path: Path) -> None:
+    provider = _make_provider(tmp_path)
+
+    response = await provider.generate_from_text(
+        ThreeDRequest(
+            prompt="silver chrome bomber jacket",
+            product_name="BR Bomber",
+            collection="black_rose",
+            garment_type="jacket",
+        )
+    )
+
+    assert response.success
+    assert response.metadata["garment_category"] == "jacket"
+    # Brand + category hints should be in the composed prompt
+    prompt = response.metadata["prompt_used"]
+    assert "jacket" in prompt.lower()
+
+
+@pytest.mark.asyncio
+async def test_text_requires_prompt(tmp_path: Path) -> None:
+    provider = _make_provider(tmp_path)
+    with pytest.raises(ThreeDProviderError):
+        await provider.generate_from_text(ThreeDRequest())
+
+
+# =============================================================================
+# Health
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_health_check_with_stub(tmp_path: Path) -> None:
+    provider = _make_provider(tmp_path)
+    health = await provider.health_check()
+    assert health.is_available
+    assert health.provider == "trellis"

--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,0 +1,6 @@
+# Vendored third-party repositories — managed by scripts/setup_*.sh.
+# Kept out of version control because they're large, fetched on demand,
+# and shouldn't be vendored into this repo's git history.
+*
+!.gitignore
+!README.md

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,0 +1,21 @@
+# Vendored repositories
+
+This directory holds third-party repositories scaffolded by setup scripts.
+Contents are intentionally git-ignored — fetch them on demand.
+
+| Subdir         | Setup script                  | Purpose                              |
+|----------------|-------------------------------|--------------------------------------|
+| `trellis/`     | `scripts/setup_trellis.sh`    | Microsoft TRELLIS 3D generation repo |
+
+To bootstrap TRELLIS:
+
+```bash
+bash scripts/setup_trellis.sh                # clone only
+bash scripts/setup_trellis.sh --with-weights # also pre-download image-large
+pip install -r requirements-trellis.txt
+pip install -e vendor/trellis
+```
+
+The clothing 3D pipeline (`services/three_d/trellis/`) reads from
+`vendor/trellis/` only when `TRELLIS_BACKEND=local`. Default is `hf_space`,
+which calls the public HuggingFace Space and needs no local TRELLIS install.


### PR DESCRIPTION
## Summary

Scaffolds [microsoft/TRELLIS](https://github.com/microsoft/TRELLIS) into `vendor/` and builds a production-grade pipeline around it tuned for SkyyRose garment imagery. Image / text → preprocessed → TRELLIS → post-processed GLB + USDZ + thumbnail → QC-gated → stored → delivered, with event emission at every stage boundary.

```
PipelineRequest
  ▶ ingest (validate, classify garment)
  ▶ generate  (preprocess → TRELLIS → postprocess)
  ▶ qc        (polycount / size / thumbnail thresholds)
  ▶ store     (Local FS or S3-compatible)
  ▶ PipelineResult  (status, stage reports, URLs, metadata)
```

TRELLIS is wired in as the **primary** image-to-3D provider in the existing `services/three_d/provider_factory.py`. Tripo, Replicate, and HuggingFace remain as fallbacks behind the circuit breaker.

## What ships

### `services/three_d/trellis/`
| File | Purpose |
|---|---|
| `config.py` | `TrellisConfig`, `TrellisBackend` (hf_space / local / replicate / modal), `TrellisQualityPreset` (draft / standard / production), `TrellisSamplingParams` table |
| `garment_aware.py` | Garment category classifier (name → keyword → aspect-ratio fallback), per-category geometry knowledge, SkyyRose brand prompt context, deduplicated prompt builder |
| `preprocess.py` | `TrellisPreprocessor`: bg removal (rembg), garment-bbox crop with 10% padding, 518² letterbox, color normalize, sharpness/contrast/exposure score |
| `client.py` | Four backends behind one `TrellisBackendClient` Protocol: `HFSpaceClient` (gradio_client), `LocalTrellisClient` (vendored repo + CUDA), `ReplicateClient`, `StubClient` (deterministic, for tests) |
| `postprocess.py` | trimesh load → fix normals → quadric decimation to category-aware target → unit-cube normalize → GLB export → optional USDZ via `usd_from_gltf` CLI → headless thumbnail |
| `provider.py` | `TrellisProvider` (`I3DProvider` impl) — composes the above, exponential-backoff retries, capability advertisement, factory registration |

### `pipelines/clothing_3d/`
End-to-end orchestrator with stage timing, event bus, QC gate, pluggable storage:

| File | Purpose |
|---|---|
| `models.py` | `PipelineRequest` / `PipelineResult` / `StageReport` / `PipelineQualityReport` |
| `events.py` | Async pub/sub bus; `log_event_subscriber` + `webhook_subscriber` built-ins |
| `storage.py` | `LocalArtifactStore` (default) + `S3ArtifactStore` (R2 / S3 / Cloudfront) |
| `stages.py` | `stage_ingest` / `stage_generate` / `stage_qc` / `stage_store` + threshold tuning per quality preset |
| `pipeline.py` | `ClothingPipeline` orchestrator with `run()`, full failure / rejection paths |
| `cli.py` | `python -m pipelines.clothing_3d.cli generate|batch|health` |

### `api/v1/clothing_3d/`
FastAPI surface — five endpoints:

```
POST /generate            synchronous run
POST /generate/async      enqueue, returns job_id + status_url
GET  /jobs/{job_id}       poll an async job
GET  /health              provider/backend health
GET  /info                active config + capabilities
```

Mount with `app.include_router(clothing_3d_router, prefix="/v1/clothing-3d")` in `main_enterprise.py`.

### Infrastructure
- `scripts/setup_trellis.sh` — one-shot bootstrap of `microsoft/TRELLIS` into `vendor/trellis/` with optional `--with-weights`
- `scripts/trellis_demo.py` — end-to-end smoke demo (works against stub by default, switch with `--backend hf_space|local|replicate`)
- `requirements-trellis.txt` — optional ML/3D deps; pipeline degrades gracefully when they're missing
- `vendor/.gitignore` + `vendor/README.md` — scaffolding tracked, vendored repos themselves git-ignored
- `docs/CLOTHING_3D_PIPELINE.md` — architecture diagram, layout, backend comparison, quality preset table, usage examples

## Backends at a glance

| Backend | GPU? | Cost | Latency | Best for |
|---|---|---|---|---|
| `hf_space` (default) | no | free | 60–180 s | dev, low-volume prod |
| `local` | yes | hardware | 15–30 s | high-volume self-hosted |
| `replicate` | no | ~$0.05/model | 30–60 s | bursty workloads |
| `modal` | no | per GPU sec | 10–20 s | strict-SLA prod (placeholder; falls back to hf_space) |
| `stub` | no | free | <0.1 s | tests, CI, dry-runs |

## Verified locally against the Stub backend

```
GLB: /tmp/.../art_*.glb
category: hoodie
backend: stub
text→3d OK; prompt: BR Bomber, silver bomber jacket, structured jacket, defined collar and lapels…
health OK
IMG pipeline OK, TEXT pipeline OK, FAIL pipeline OK (missing file)
Events emitted: pipeline.failed, pipeline.started, pipeline.succeeded, stage.finished, stage.started
```

All 5 API routes register cleanly; CLI `generate` / `batch` / `health` all run; `bash -n scripts/setup_trellis.sh` passes.

## Test plan

- [ ] `pip install -r requirements-trellis.txt` then `pytest tests/three_d/trellis tests/pipelines/clothing_3d -v` — unit + integration against the Stub backend
- [ ] `python -m pipelines.clothing_3d.cli health` — confirms backend selection logic
- [ ] `python scripts/trellis_demo.py --dry-run` — verifies pipeline orchestration end-to-end
- [ ] `bash scripts/setup_trellis.sh --upgrade` on a CUDA box — verifies the local backend wiring
- [ ] `curl -X POST $API/v1/clothing-3d/generate -d '…'` once mounted — verifies HTTP surface
- [ ] Visual diff on a real SKU (br-001, sig-tee, lh-001) through `--backend hf_space --quality production` — confirms QC thresholds aren't over-strict

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuWYuoh7JY5y4K77YJa9gP)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end clothing 3D pipeline on `microsoft/TRELLIS`, makes TRELLIS the primary image-to-3D provider, and productionizes it with an async worker, durable queue/job store, idempotency, metrics, and deploy manifests. Verifies all `/v1/clothing-3d` routes and fixes endpoint reliability issues; outputs GLB/USDZ/thumbnail and runs on `hf_space`, local GPU, or Replicate.

- **New Features**
  - TRELLIS set first in `services/three_d/provider_factory.py`; Tripo/Replicate/HF are fallbacks.
  - Orchestrated pipeline (ingest → generate → QC → store) with stage timing and async events.
  - FastAPI: `POST /generate`, `POST /generate/async`, `GET /jobs/{id}`, `GET /jobs`, `/health`, `/ready`, `/info`, `/metrics` (Prometheus text).
  - Reliability: exponential backoff retries, content-addressed idempotency cache, per-backend cost quota.
  - Async infra: Redis Streams queue with consumer groups (or in-memory), Redis-backed job store (or in-memory), background worker (`python -m pipelines.clothing_3d.worker`) with crash-safe reclaim.
  - Observability: JSON logs and Prometheus metrics (runs, latency, queue depth, cost) via a metrics event subscriber.
  - Storage: `LocalArtifactStore` and `S3ArtifactStore`; optional USDZ export and thumbnails.
  - Deploy: Dockerfile, `docker-compose.yml`, and `k8s.yaml` (HPA on CPU + queue depth); smoke test script; docs for pipeline and production.

- **Bug Fixes**
  - Worker no longer closes shared `queue`/`store`/`pipeline`; added `owns_dependencies` flag.
  - `InMemoryJobStore.close()` is now a no-op; destructive `reset()` kept for tests.
  - `/health` reports the live backend name; configured backend moved to `detail.configured_backend`.
  - Full-stack verification passes for all `/v1/clothing-3d` endpoints (sync/async generate, jobs, health/readiness/info/metrics).

<sup>Written for commit 09aa0d0732a017419eb04874b83d1bd3fc85f0ef. Summary will update on new commits. <a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/508?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added clothing 3D pipeline with HTTP API endpoints for generating 3D garment models from images or text
  - Added asynchronous job support with polling and status tracking
  - Added health checks and pipeline readiness endpoints
  - Added Prometheus metrics for observability
  - Added CLI tools for pipeline operations and batch processing

* **Documentation**
  - Added comprehensive pipeline documentation
  - Added production deployment guides for Docker and Kubernetes

* **Tests**
  - Added test coverage for pipeline operations, configuration, and reliability features

* **Chores**
  - Updated gitignore and project configuration for third-party dependencies
  - Added Docker and Kubernetes deployment templates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->