### PR TITLE
feat(orchestration): orchestration mode — standing-consent fan-out loop

### DIFF
--- a/docs/superpowers/specs/2026-06-01-orchestration-mode-design.html
+++ b/docs/superpowers/specs/2026-06-01-orchestration-mode-design.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orchestration Mode — Design Spec (2026-06-01)</title>
+<style>
+  :root { --rose:#B76E79; --dark:#0A0A0A; --ink:#1a1a1a; --mut:#666; --bg:#fafafa; --code:#f4f0f1; --line:#e2dcde; }
+  body { font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; color:var(--ink); background:var(--bg); max-width:980px; margin:0 auto; padding:2rem 1.5rem 6rem; }
+  h1 { font-size:2rem; border-bottom:3px solid var(--rose); padding-bottom:.4rem; }
+  h2 { font-size:1.35rem; margin-top:2.4rem; color:var(--dark); border-left:4px solid var(--rose); padding-left:.6rem; }
+  h3 { font-size:1.08rem; margin-top:1.4rem; color:var(--rose); }
+  code { background:var(--code); padding:.1em .35em; border-radius:4px; font:13.5px/1.4 "SF Mono",Menlo,monospace; }
+  pre { background:var(--dark); color:#eee; padding:1rem 1.2rem; border-radius:8px; overflow-x:auto; font:13px/1.5 "SF Mono",Menlo,monospace; }
+  pre code { background:none; color:inherit; padding:0; }
+  table { border-collapse:collapse; width:100%; margin:1rem 0; font-size:14.5px; }
+  th,td { border:1px solid var(--line); padding:.5rem .65rem; text-align:left; vertical-align:top; }
+  th { background:var(--rose); color:#fff; }
+  tr:nth-child(even) td { background:#f3eef0; }
+  .nav { background:#fff; border:1px solid var(--line); border-radius:8px; padding:1rem 1.3rem; columns:2; font-size:14px; }
+  .nav a { color:var(--rose); text-decoration:none; }
+  .badge { display:inline-block; background:var(--rose); color:#fff; font-size:11px; padding:.15em .5em; border-radius:3px; vertical-align:middle; }
+  .note { background:#fff8f0; border-left:4px solid #d4a017; padding:.7rem 1rem; border-radius:0 6px 6px 0; margin:1rem 0; }
+  .kill { background:#fdf0f0; border-left:4px solid #c0392b; padding:.7rem 1rem; border-radius:0 6px 6px 0; margin:1rem 0; }
+  .meta { color:var(--mut); font-size:14px; }
+  ul li { margin:.25rem 0; }
+</style>
+</head>
+<body>
+
+<h1>Orchestration Mode — Design Spec</h1>
+<p class="meta"><strong>Date:</strong> 2026-06-01 &middot; <strong>Status:</strong> Design — awaiting founder approval &middot; <strong>Author:</strong> DevSkyy engineering agent &middot; <strong>Source:</strong> Anthropic "Build an orchestration mode" reference, refactored into DevSkyy house idiom.</p>
+
+<nav class="nav">
+  <a href="#goal">1. Goal &amp; scope</a><br>
+  <a href="#decisions">2. Decision record</a><br>
+  <a href="#findings">3. Codebase findings</a><br>
+  <a href="#arch">4. Architecture</a><br>
+  <a href="#mechanisms">5. Three mechanisms → runs-today</a><br>
+  <a href="#loop">6. The loop (semantics)</a><br>
+  <a href="#concurrency">7. Concurrency model</a><br>
+  <a href="#house">8. House-idiom conformance</a><br>
+  <a href="#api">9. Public API surface</a><br>
+  <a href="#tools">10. Tool schemas</a><br>
+  <a href="#tests">11. Test plan</a><br>
+  <a href="#wiring">12. Module-wiring checklist</a><br>
+  <a href="#sequence">13. Build sequence</a><br>
+  <a href="#scope">14. Out of scope (YAGNI)</a><br>
+  <a href="#risks">15. Risks &amp; next-opus seams</a>
+</nav>
+
+<h2 id="goal">1. Goal &amp; scope</h2>
+<p>Refactor the Anthropic "orchestration mode" loop theory into DevSkyy as a real, tested module. An <strong>orchestration mode</strong> is a session-level switch: when on, the agent runs every substantive request at maximum effort and fans work out to parallel subagents by default; when off, the same fan-out tool reverts to per-request opt-in. The mode is built from three documented pieces — an <strong>effort level</strong>, a <strong>mid-conversation mode reminder</strong>, and <strong>standing consent</strong> written into the fan-out tool's description — never an API flag.</p>
+<p>The founder's steer: <em>"I like the loop theory so refactor it to our codebase."</em> Keep the raw-API <code>ModeAgent</code> loop mechanics intact; make it idiomatic DevSkyy; runs today on <code>anthropic 0.83.0</code>.</p>
+
+<h2 id="decisions">2. Decision record</h2>
+<table>
+  <tr><th>Decision</th><th>Choice</th><th>Why</th></tr>
+  <tr><td>Placement</td><td><code>orchestration/</code> (two flat files)</td><td>Raw-API streaming, tool-use, and effort precedents all live here/adjacent. Matches <code>llm_orchestrator.py</code> neighbors.</td></tr>
+  <tr><td>Paradigm</td><td>Raw <code>AsyncAnthropic.messages.stream</code> agentic loop</td><td>The loop theory. <span class="badge">founder-chosen</span> Set aside agent-1's <code>ClaudeSDKClient</code> rec — it abandons the loop theory and mixes the CLI-spawning paradigm.</td></tr>
+  <tr><td>Effort default</td><td><code>"xhigh"</code></td><td><span class="badge">founder-chosen</span> Matches shipping house precedent <code>scripts/nano_banana/tournament.py:522</code>; reaches the API as a raw dict.</td></tr>
+  <tr><td>Subagent backend</td><td>Self-contained async raw-API nested loop</td><td><span class="badge">founder-chosen</span> Preserves the loop theory; one paradigm; no coupling.</td></tr>
+  <tr><td>Sync vs async</td><td>Async (<code>AsyncAnthropic</code>)</td><td><code>orchestration/</code> is async-only by convention; fan-out uses <code>asyncio.gather</code>.</td></tr>
+  <tr><td>Reminder transport</td><td><code>&lt;system-reminder&gt;</code> folded into the user turn's content (default); standalone <code>role:"system"</code> behind a config seam</td><td>Messages train on alternating user/assistant turns — a separate user message would create consecutive user turns. Folding into the user turn's content keeps alternation valid and the cached prefix intact. <code>SYSTEM_ROLE</code> emits standalone system messages (outside alternation) for the newer SDK that types them.</td></tr>
+  <tr><td>Spec format</td><td>HTML</td><td>Project always-on rule: structured docs with 3+ sections are HTML.</td></tr>
+</table>
+
+<h2 id="findings">3. Codebase findings</h2>
+<p>Four parallel read-only agents mapped the relevant surface (2026-06-01).</p>
+<h3>The orchestration landscape</h3>
+<table>
+  <tr><th>System</th><th>Paradigm</th><th>Fan-out primitive</th><th>Role here</th></tr>
+  <tr><td><code>skyyrose/multi_agent/orchestrator.py</code></td><td>claude-agent-sdk (<code>ClaudeSDKClient</code>, spawns <code>claude</code> CLI)</td><td>LLM-decided <code>Agent</code> tool</td><td>Different paradigm — not the loop theory</td></tr>
+  <tr><td><code>llm/round_table.py:1323</code></td><td>raw provider SDKs</td><td><code>asyncio.gather(return_exceptions=True)</code></td><td>Canonical parallel fan-out idiom</td></tr>
+  <tr><td><code>agents/elite_web_builder/director.py:603</code></td><td>raw SDK + ModelRouter</td><td><code>gather</code> + <code>Semaphore(4)</code></td><td>Bounded-concurrency template</td></tr>
+  <tr><td><code>orchestration/catalog_retriever.py:408</code></td><td><code>AsyncAnthropic.messages.stream</code></td><td>—</td><td>Streaming skeleton to copy</td></tr>
+  <tr><td><code>agents/render_pipeline/tools/articulate_layer0.py:188</code></td><td>sync <code>Anthropic</code> + <code>tools=</code>/<code>tool_choice=</code></td><td>—</td><td>Tool-use skeleton to copy</td></tr>
+  <tr><td><code>scripts/nano_banana/tournament.py:522</code></td><td>sync <code>Anthropic</code> + <code>output_config</code>+<code>thinking</code></td><td>—</td><td>effort/<code>xhigh</code> precedent</td></tr>
+</table>
+<div class="note"><strong>No streaming tool-use feedback loop exists anywhere in the repo.</strong> The three skeletons above are scattered across three files; none compose them. <code>ModeAgent</code> is the first real agentic loop here — that is its novel value, not a re-implementation.</div>
+<h3>SDK reality (<code>anthropic 0.83.0</code>, Python 3.14)</h3>
+<ul>
+  <li><code>output_config={"effort": ...}</code> — stable <code>OutputConfigParam.effort = Literal["low","medium","high","max"]</code>. <code>"xhigh"</code> is not typed but is passed as a raw dict (bypasses the type check) and is already shipped in <code>tournament.py</code>.</li>
+  <li><code>thinking={"type":"adaptive"}</code> — supported in stable 0.83.0 (<code>thinking_config_adaptive_param.py</code>).</li>
+  <li>Mid-conversation <code>role:"system"</code> — not in pinned <strong>0.83.0</strong> (<code>MessageParam.role = Literal["user","assistant"]</code>). <strong>But the latest anthropic-sdk-python (main) DOES type it</strong>: <code>role = Literal["user","assistant","system"]</code> plus a <code>MidConversationSystemBlockParam</code> content block (verified via Context7, 2026-06-01). So mid-conversation system messages are a real shipped feature, just newer than our pin — the <code>SYSTEM_ROLE</code> seam is forward-compatible, not hypothetical.</li>
+  <li>Message roles are trained to alternate user/assistant. A reminder as a separate <em>user</em> message would create consecutive user turns; the runs-today transport therefore <strong>folds the reminder into the user turn's content</strong> as a second text block.</li>
+  <li>Client + key: <code>try: from config import ANTHROPIC_API_KEY / except ImportError: os.getenv("ANTHROPIC_API_KEY","")</code>. (<code>config</code> is a package; there is no root <code>config.py</code>.)</li>
+</ul>
+
+<h2 id="arch">4. Architecture</h2>
+<p>Two focused files (&lt;800 lines each; functions &lt;50 lines).</p>
+<h3><code>orchestration/orchestration_mode.py</code></h3>
+<ul>
+  <li><code>SYSTEM_PROMPT</code> — static top-level <code>system</code> string, never mutated (cache-prefix integrity).</li>
+  <li><code>MODE_ENTER</code>, <code>MODE_REFRESH</code>, <code>MODE_EXIT</code> — the three reminder strings.</li>
+  <li><code>ReminderTransport</code> — <code>StrEnum</code>: <code>USER_REMINDER</code> (default) | <code>SYSTEM_ROLE</code>.</li>
+  <li><code>@dataclass(frozen=True) ModeConfig</code> — models (from <code>model_ids</code>), <code>effort="xhigh"</code>, <code>reminder_transport</code>, <code>max_tokens</code>, turn caps, <code>turns_between_refreshers</code>.</li>
+  <li><code>ModeAgent</code> — the async loop: <code>set_mode</code>, <code>_due_system_messages</code>, <code>turn</code>. Injectable <code>AsyncAnthropic</code> (test seam).</li>
+</ul>
+<h3><code>orchestration/orchestration_mode_tools.py</code></h3>
+<ul>
+  <li><code>WORKFLOW_TOOL</code>, <code>BASH_TOOL</code>, <code>REPORT_TOOL</code> — tool schemas (§10).</li>
+  <li><code>normalize_subtasks(raw)</code> — accepts array | JSON-string | newline list.</li>
+  <li><code>handle_bash_block(block)</code> + <code>run_bash(cmd)</code> — local <code>bash_20250124</code>, timeout + truncation. <strong>No sandbox.</strong></li>
+  <li><code>run_subagent(client, prompt, config)</code> — nested async loop, <code>SUBAGENT_MODEL</code>, bash + <code>report_findings</code>.</li>
+  <li><code>run_workflow(client, raw_subtasks, config)</code> — <code>gather</code>+<code>Semaphore</code> fan-out, per-subagent failure isolation, dropped-overflow note.</li>
+</ul>
+<div class="note"><strong>Why two files, not one:</strong> the loop and the tool/fan-out layer have distinct responsibilities and distinct test surfaces. Splitting keeps each &lt;400 lines, lets the tools layer be tested without instantiating <code>ModeAgent</code>, and matches the project's "many small files" rule.</div>
+
+<h2 id="mechanisms">5. Three mechanisms → runs-today mapping</h2>
+<table>
+  <tr><th>Mechanism</th><th>Doc (next-opus)</th><th>Runs-today (0.83.0)</th><th>Forward seam</th></tr>
+  <tr><td>Effort level</td><td><code>effort:"xhigh"</code></td><td><code>output_config={"effort":"xhigh"}</code> — raw dict, per tournament.py precedent</td><td><code>ModeConfig.effort</code> constant</td></tr>
+  <tr><td>Mode reminder</td><td>mid-convo <code>role:"system"</code></td><td><code>&lt;system-reminder&gt;…&lt;/system-reminder&gt;</code> folded into the user turn's content (alternation-safe)</td><td><code>ModeConfig.reminder_transport</code> → flip to <code>SYSTEM_ROLE</code> (typed in newer SDK)</td></tr>
+  <tr><td>Standing consent</td><td>tool description text</td><td>identical — verbatim in <code>WORKFLOW_TOOL["description"]</code></td><td>none</td></tr>
+  <tr><td>Thinking</td><td><code>{"type":"adaptive"}</code></td><td>identical — valid in 0.83.0</td><td>none</td></tr>
+</table>
+<p>The top-level <code>system</code> field never changes across turns, so the cached prefix stays intact — the entire point of the design. Reminders ride in the <code>messages</code> array, placed <em>after</em> the user turn they apply to.</p>
+
+<h2 id="loop">6. The loop (semantics)</h2>
+<p>Faithful to the reference, adapted to async. Pseudocode for <code>ModeAgent.turn</code>:</p>
+<pre><code>async def turn(self, user_input: str) -> str:
+    # reminder rides WITH the user turn (folded into its content under
+    # USER_REMINDER) → alternation preserved, cached prefix untouched
+    reminder_texts = self._due_reminder_texts()
+    self.messages.extend(self._build_user_messages(user_input, reminder_texts))
+    self._turns_since_reminder += 1
+
+    for _ in range(self.config.max_main_turns):
+        async with self._client.messages.stream(
+            model=self._model,
+            max_tokens=self.config.max_tokens,
+            system=SYSTEM_PROMPT,                       # static for the whole session
+            thinking={"type": "adaptive"},
+            output_config={"effort": self.config.effort},
+            tools=[WORKFLOW_TOOL, BASH_TOOL],
+            messages=self.messages,
+        ) as stream:
+            response = await stream.get_final_message()
+        self.messages.append({"role": "assistant", "content": response.content})
+
+        if response.stop_reason == "pause_turn":
+            continue
+        if response.stop_reason != "tool_use":
+            text = "".join(b.text for b in response.content if b.type == "text")
+            if response.stop_reason == "max_tokens":
+                self.messages.pop()                     # drop truncated turn
+                text += "\n\n(warning: response truncated at max_tokens)"
+            return text
+
+        tool_results = []
+        for block in response.content:
+            if block.type != "tool_use":
+                continue
+            if block.name == "Workflow":
+                out, is_err = await run_workflow(self._client, block.input.get("subtasks", []), self.config)
+            elif block.name == "bash":
+                out, is_err = await handle_bash_block(block)
+            else:
+                out, is_err = f"unknown tool: {block.name}", True
+            tool_results.append({"type": "tool_result", "tool_use_id": block.id,
+                                 "content": out, "is_error": is_err})
+        self.messages.append({"role": "user", "content": tool_results})
+    return "(hit the main loop turn limit before finishing)"</code></pre>
+<h3>State machine + transport (two methods)</h3>
+<p><code>_due_reminder_texts() -&gt; list[str]</code> — pure state machine, no transport:</p>
+<ul>
+  <li>EXIT pending → emit <code>MODE_EXIT</code> once, clear <code>_mode_announced</code>.</li>
+  <li>Mode on &amp; not announced → emit <code>MODE_ENTER</code> once, reset refresh counter.</li>
+  <li>Mode on &amp; <code>_turns_since_reminder &gt;= turns_between_refreshers</code> → emit <code>MODE_REFRESH</code>, reset counter.</li>
+</ul>
+<p><code>_build_user_messages(user_input, reminder_texts) -&gt; list[dict]</code> — attaches reminders per transport:</p>
+<ul>
+  <li>No reminders → <code>[{"role":"user","content":user_input}]</code>.</li>
+  <li><code>USER_REMINDER</code> → ONE user turn whose content is a list of text blocks: the input first, then one <code>&lt;system-reminder&gt;</code>-wrapped block per reminder. No consecutive same-role turns.</li>
+  <li><code>SYSTEM_ROLE</code> → the user turn followed by standalone <code>{"role":"system","content":text}</code> messages (outside user/assistant alternation).</li>
+</ul>
+
+<h2 id="concurrency">7. Concurrency model</h2>
+<p>Fan-out follows the repo idiom (<code>director.py:603</code>, <code>round_table.py:1323</code>), not the doc's <code>ThreadPoolExecutor</code>:</p>
+<pre><code>sem = asyncio.Semaphore(config.max_parallel_agents)
+async def _bounded(prompt):
+    async with sem:
+        return await run_subagent(client, prompt, config)
+results = await asyncio.gather(*(_bounded(p) for p in subtasks), return_exceptions=True)
+# isolation: any Exception → "(subagent failed: <type>: <msg>)" string, never raises</code></pre>
+<p>Overflow beyond <code>max_parallel_agents</code> is logged via <code>structlog</code> and noted in the joined output ("N subtasks not run; rerun in a follow-up Workflow call") — no silent truncation.</p>
+
+<h2 id="house">8. House-idiom conformance</h2>
+<pre><code>from __future__ import annotations
+import asyncio, json, os
+from dataclasses import dataclass
+
+import structlog                                   # NOT stdlib logging
+
+try:
+    from config import ANTHROPIC_API_KEY
+except ImportError:
+    ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
+
+from anthropic import AsyncAnthropic
+from llm.model_ids import ORCHESTRATOR_MODEL, SUBAGENT_MODEL   # never hardcode strings
+
+logger = structlog.get_logger(__name__)</code></pre>
+<ul>
+  <li><strong>Frozen config</strong> — <code>@dataclass(frozen=True)</code>, tuples not lists for sequences (per <code>elite_studio/models.py:13</code>).</li>
+  <li><strong>Client seam</strong> — constructor injection with a default (Protocol not needed; mirror <code>elite_studio/coordinator.py</code> <code>logger or PrintLogger()</code>). Tests inject an <code>AsyncMock</code>.</li>
+  <li><strong>Errors</strong> — explicit handling at every external call; generic strings to the model, detailed context to <code>structlog</code>.</li>
+</ul>
+
+<h2 id="api">9. Public API surface</h2>
+<pre><code>class ModeAgent:
+    def __init__(self, model: str = ORCHESTRATOR_MODEL,
+                 config: ModeConfig = ModeConfig(),
+                 client: AsyncAnthropic | None = None,
+                 mode_on: bool = True) -> None: ...
+    def set_mode(self, mode_on: bool) -> None: ...
+    async def turn(self, user_input: str) -> str: ...
+
+@dataclass(frozen=True)
+class ModeConfig:
+    orchestrator_model: str = ORCHESTRATOR_MODEL
+    subagent_model: str = SUBAGENT_MODEL
+    effort: str = "xhigh"
+    reminder_transport: ReminderTransport = ReminderTransport.USER_REMINDER
+    max_tokens: int = 64000
+    max_main_turns: int = 30
+    max_subagent_turns: int = 15
+    max_parallel_agents: int = 10
+    turns_between_refreshers: int = 10
+    bash_timeout_seconds: int = 60
+    tool_result_max_chars: int = 8000</code></pre>
+
+<h2 id="tools">10. Tool schemas</h2>
+<ul>
+  <li><code>WORKFLOW_TOOL</code> — <code>{name, description, input_schema}</code>; description carries the verbatim <strong>Opt-in</strong>, <strong>Quality patterns</strong>, and <strong>Standing consent</strong> paragraphs from the reference. <code>input_schema</code>: <code>{subtasks: array&lt;string&gt;}</code> required.</li>
+  <li><code>BASH_TOOL</code> — <code>{"type": "bash_20250124", "name": "bash"}</code> (Anthropic-defined, executed locally).</li>
+  <li><code>REPORT_TOOL</code> — <code>report_findings</code>: <code>{summary: string, findings: array&lt;{claim, evidence, severity∈[high,medium,low,info]}&gt;}</code> required; ends a subagent's task.</li>
+</ul>
+
+<h2 id="tests">11. Test plan</h2>
+<p><code>tests/orchestration/test_orchestration_mode.py</code> — <code>@pytest.mark.unit</code> + <code>@pytest.mark.asyncio</code>. Inject an <code>AsyncMock</code> client (mirror <code>tests/llm/test_verification.py:59</code> multi-turn <code>side_effect</code>). <strong>No live API calls, no spend.</strong></p>
+<table>
+  <tr><th>Test</th><th>Asserts</th></tr>
+  <tr><td>mode toggle</td><td>ENTER once on first turn; REFRESH every <code>turns_between_refreshers</code>; EXIT once after <code>set_mode(False)</code>; nothing while off</td></tr>
+  <tr><td>reminder placement</td><td>reminder message appears <em>after</em> the user turn in <code>messages</code></td></tr>
+  <tr><td>cache-prefix integrity</td><td>the <code>system=</code> argument is byte-identical across every <code>stream</code> call</td></tr>
+  <tr><td>transport</td><td><code>USER_REMINDER</code> → role <code>user</code> + <code>&lt;system-reminder&gt;</code> wrap; <code>SYSTEM_ROLE</code> → role <code>system</code></td></tr>
+  <tr><td>standing consent</td><td><code>WORKFLOW_TOOL["description"]</code> contains the standing-consent sentence</td></tr>
+  <tr><td><code>normalize_subtasks</code></td><td>array / JSON-string / newline list all normalize; junk → <code>[]</code></td></tr>
+  <tr><td>fan-out cap + isolation</td><td>caps at <code>max_parallel_agents</code> (overflow noted); one raising subagent → error string, others succeed</td></tr>
+  <tr><td>tool dispatch</td><td>Workflow → <code>run_workflow</code>; bash → <code>handle_bash_block</code>; unknown → <code>is_error</code></td></tr>
+  <tr><td>bash handler</td><td>timeout, truncation at <code>tool_result_max_chars</code>, <code>restart</code>, missing-command error</td></tr>
+  <tr><td>max_tokens</td><td>truncated assistant turn dropped from history + warning appended</td></tr>
+</table>
+<p>One <code>@pytest.mark.integration</code> live smoke test (single real <code>turn</code> at low effort) — excluded by default <code>addopts</code>, runs only under <code>-m integration</code> with a key present. Gated by STOP-AND-SHOW (costs money) — not run during the build.</p>
+
+<h2 id="wiring">12. Module-wiring checklist</h2>
+<ul>
+  <li><code>orchestration/__init__.py</code> — add <code>ModeAgent</code>, <code>ModeConfig</code>, <code>ReminderTransport</code> to <code>_LAZY_IMPORTS</code> + <code>__all__</code>.</li>
+  <li><code>orchestration/CLAUDE.md</code> — add architecture-table rows for both new files.</li>
+  <li>No <code>tests/orchestration/__init__.py</code> (dir convention is no init); no sub-conftest (root conftest provides <code>mock_api_keys</code>).</li>
+  <li>No <code>__main__.py</code>/<code>cli.py</code> in <code>orchestration/</code> (CLI lives in <code>cli/</code>); a CLI entry is out of scope for v1.</li>
+</ul>
+
+<h2 id="sequence">13. Build sequence</h2>
+<ol>
+  <li>Commit this spec (on a feature branch — working tree is dirty on <code>main</code>).</li>
+  <li>RED: write <code>tests/orchestration/test_orchestration_mode.py</code> against the API in §9–§10; confirm failures.</li>
+  <li>GREEN: <code>orchestration/orchestration_mode_tools.py</code> (tools, bash, subagent, fan-out).</li>
+  <li>GREEN: <code>orchestration/orchestration_mode.py</code> (config, reminders, <code>ModeAgent</code>).</li>
+  <li>Wire <code>__init__.py</code> + <code>orchestration/CLAUDE.md</code>.</li>
+  <li>Verify the exact footprint: <code>ruff check --fix</code> + <code>black</code> + <code>isort</code> + <code>mypy</code> + <code>pytest tests/orchestration/test_orchestration_mode.py -v</code>. Independently re-verify (per <code>feedback_independent_reverify</code>): re-run, lint the precise files, check <code>git diff --name-only</code> scope.</li>
+  <li>Memory + cerebrum: record the loop pattern, the xhigh precedent link, the spec path.</li>
+</ol>
+
+<h2 id="scope">14. Out of scope (YAGNI)</h2>
+<ul>
+  <li>No wiring into <code>skyyrose/multi_agent</code> (CLI paradigm) or any existing orchestrator.</li>
+  <li>No hexagonal AI-port abstraction — constructor injection of the client is the entire seam. This is a focused capability module, not a vendor-swappable subsystem.</li>
+  <li>No real MCP / external subagent backend; subagents are self-contained raw-API loops.</li>
+  <li>No persistent shell session for bash (each call is a fresh subshell — documented limitation).</li>
+  <li>No <code>role:"system"</code> transport until next-opus + a newer SDK; the seam is present, the path is dormant.</li>
+</ul>
+
+<h2 id="risks">15. Risks &amp; next-opus seams</h2>
+<table>
+  <tr><th>Risk</th><th>Mitigation</th></tr>
+  <tr><td><code>effort="xhigh"</code> may be rejected at runtime</td><td><strong>RESOLVED — live smoke PASSED 2026-06-01.</strong> A real <code>claude-opus-4-7</code> call on <code>messages.stream</code> with <code>output_config={"effort":"xhigh"}</code> + adaptive thinking + the folded <code>&lt;system-reminder&gt;</code> transport returned successfully — no <code>roles must alternate</code> 400, no effort rejection. Config seam → <code>effort="max"</code> remains the guaranteed-safe fallback.</td></tr>
+  <tr><td>Key resolution — module gets an empty key from <code>config</code></td><td>Root <code>.env</code> is 0 bytes and <code>config</code> does not surface <code>ANTHROPIC_API_KEY</code> (the key lives in purpose env files like <code>.env.judge-opus-thinking</code> / <code>.env.production</code>). The module relies on the SDK's env fallback, so the <strong>runtime entrypoint must export <code>ANTHROPIC_API_KEY</code></strong> into the environment — <code>from config import ANTHROPIC_API_KEY</code> alone yields empty in this repo state.</td></tr>
+  <tr><td>Local bash tool runs model-written commands with no sandbox</td><td>Documented loud warning; timeout + output truncation; intended for trusted local experimentation only. Sandboxing is a follow-up before any non-local use.</td></tr>
+  <tr><td>Fan-out multiplies token spend</td><td><code>max_parallel_agents</code> + <code>max_subagent_turns</code> caps; <code>structlog</code> logs every fan-out width; overflow surfaced, never silent.</td></tr>
+  <tr><td>SDK ships typed <code>role:"system"</code> / <code>xhigh</code> later</td><td>Flip <code>reminder_transport</code> to <code>SYSTEM_ROLE</code>; effort already <code>xhigh</code>. No structural change.</td></tr>
+</table>
+
+<p class="meta">End of spec. Approve to proceed to TDD build (steps 2–7).</p>
+
+</body>
+</html>

--- a/orchestration/CLAUDE.md
+++ b/orchestration/CLAUDE.md
@@ -45,6 +45,7 @@ from orchestration import ProductAssetPipeline   # only imports asset_pipeline s
 | `PromptEngineer`, `PromptChain`, `PromptTemplate`, `PromptTechnique` | `prompt_engineering.py` | Advanced prompting (CoT, ToT, ReAct templates) |
 | `WorkflowState`, `WorkflowStatus`, `WorkflowEdge`, `StateGraph`, `END`, `START`, `add_messages` | `langgraph_integration.py` | LangGraph re-exports + workflow state base |
 | `ToolRegistry`, `ToolDefinition`, `ToolCategory`, `ToolParameter` | (re-export from `core.runtime.tool_registry`) | Tool registration surface |
+| `ModeAgent`, `ModeConfig`, `ReminderTransport` | `orchestration_mode.py` (+ `orchestration_mode_tools.py`) | Standing-consent fan-out loop: mid-conversation mode reminders toggle "fan out to parallel subagents by default" + `effort="xhigh"`. First streaming tool-use feedback loop in the repo. Raw `AsyncAnthropic`; `asyncio.gather`+`Semaphore` fan-out; **local bash, no sandbox**. Spec: `docs/superpowers/specs/2026-06-01-orchestration-mode-design.html` |
 
 ## `ProductAssetPipeline` (canonical entry point)
 

--- a/orchestration/__init__.py
+++ b/orchestration/__init__.py
@@ -135,6 +135,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "InsightCategory": ("orchestration.brand_learning", "InsightCategory"),
     "InsightConfidence": ("orchestration.brand_learning", "InsightConfidence"),
     "SignalType": ("orchestration.brand_learning", "SignalType"),
+    # Orchestration Mode (standing-consent fan-out loop)
+    "ModeAgent": ("orchestration.orchestration_mode", "ModeAgent"),
+    "ModeConfig": ("orchestration.orchestration_mode", "ModeConfig"),
+    "ReminderTransport": ("orchestration.orchestration_mode", "ReminderTransport"),
 }
 
 __all__ = list(_LAZY_IMPORTS.keys())

--- a/orchestration/orchestration_mode.py
+++ b/orchestration/orchestration_mode.py
@@ -1,0 +1,235 @@
+"""Orchestration mode — a session-level standing-consent fan-out loop.
+
+Refactored from Anthropic's "Build an orchestration mode" reference into the
+DevSkyy house idiom: async ``AsyncAnthropic`` streaming, ``structlog``,
+``llm.model_ids`` constants, and an ``asyncio`` fan-out (in
+``orchestration_mode_tools``) rather than the reference's sync
+``ThreadPoolExecutor``.
+
+An orchestration mode is a session-level switch. When it is **on**, the agent
+runs every substantive request at maximum effort and fans work out to parallel
+subagents by default. When it is **off**, the same Workflow tool reverts to
+per-request opt-in. The mode is built from three documented pieces, never an API
+flag:
+
+1. **Effort** — ``output_config={"effort": ...}``, defaulting to ``"xhigh"`` to
+   match the house precedent in ``scripts/nano_banana/tournament.py``.
+2. **Mode reminder** — a mid-conversation message placed *after* the user turn
+   it applies to, so the static top-level ``system`` prefix never changes and
+   the cached prefix stays intact. Transported today as a ``<system-reminder>``
+   user turn (``role:"system"`` is next-opus only); the ``SYSTEM_ROLE`` seam is
+   ready for when that lands.
+3. **Standing consent** — written into ``WORKFLOW_TOOL``'s description.
+
+Spec: docs/superpowers/specs/2026-06-01-orchestration-mode-design.html
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+import structlog
+
+try:
+    from config import ANTHROPIC_API_KEY
+except ImportError:  # pragma: no cover - standalone usage fallback
+    ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
+
+from anthropic import AsyncAnthropic
+
+from llm.model_ids import ORCHESTRATOR_MODEL, SUBAGENT_MODEL
+from orchestration.orchestration_mode_tools import (
+    BASH_TOOL,
+    WORKFLOW_TOOL,
+    handle_bash_block,
+    run_workflow,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+# The top-level system field is static for the whole session — never mutate it,
+# or the cached prefix breaks. Mode state rides in the messages array instead.
+SYSTEM_PROMPT = "You are a helpful general-purpose agent. Answer the user's request directly."
+
+MODE_ENTER = (
+    "Orchestration mode is on: optimize for the most exhaustive, correct answer rather "
+    "than the fastest or cheapest one. Use the Workflow tool on every substantive task; "
+    "token cost is not a constraint. See the Workflow tool's standing consent section and "
+    "quality patterns. Work solo only on conversational or trivial turns."
+)
+MODE_REFRESH = (
+    "Orchestration mode is still on. Use the Workflow tool; see its standing consent section."
+)
+MODE_EXIT = "Orchestration mode is off. The Workflow tool's standard opt-in rule applies again."
+
+
+class ReminderTransport(StrEnum):
+    """How a mid-conversation mode reminder is delivered."""
+
+    USER_REMINDER = "user_reminder"  # runs today: a <system-reminder> user turn
+    SYSTEM_ROLE = "system_role"  # next-opus: a true role:"system" message
+
+
+@dataclass(frozen=True)
+class ModeConfig:
+    """Immutable knobs for the orchestration-mode loop.
+
+    Models resolve from ``llm.model_ids`` so a roll-forward updates every caller.
+    ``effort`` defaults to ``"xhigh"`` to match the shipping house precedent; the
+    config seam lets it drop to ``"max"`` if an org loses next-opus access.
+    """
+
+    orchestrator_model: str = ORCHESTRATOR_MODEL
+    subagent_model: str = SUBAGENT_MODEL
+    effort: str = "xhigh"
+    reminder_transport: ReminderTransport = ReminderTransport.USER_REMINDER
+    max_tokens: int = 64000
+    max_main_turns: int = 30
+    max_subagent_turns: int = 15
+    max_parallel_agents: int = 10
+    turns_between_refreshers: int = 10
+    bash_timeout_seconds: int = 60
+    tool_result_max_chars: int = 8000
+
+
+class ModeAgent:
+    """An agent loop whose orchestration mode toggles via mid-conversation reminders.
+
+    The Anthropic client is injectable so tests fake the boundary; in production
+    it defaults to an ``AsyncAnthropic`` built from the configured key.
+    """
+
+    def __init__(
+        self,
+        model: str | None = None,
+        config: ModeConfig | None = None,
+        client: AsyncAnthropic | None = None,
+        mode_on: bool = True,
+    ) -> None:
+        self.config = config or ModeConfig()
+        self._model = model or self.config.orchestrator_model
+        self._client = client or AsyncAnthropic(api_key=ANTHROPIC_API_KEY or None)
+        self.mode_on = mode_on
+        self.messages: list[dict[str, Any]] = []
+        self._mode_announced = False
+        self._exit_pending = False
+        self._turns_since_reminder = 0
+
+    def set_mode(self, mode_on: bool) -> None:
+        """Turn the mode on or off. The notice is delivered with the next turn."""
+        if mode_on == self.mode_on:
+            return
+        if mode_on:
+            self._exit_pending = False
+        elif self._mode_announced:
+            self._exit_pending = True
+        self.mode_on = mode_on
+
+    def _due_reminder_texts(self) -> list[str]:
+        """Reminder strings owed this turn (pure state machine).
+
+        Emits the exit notice once on turn-off, the full mode text once on
+        entry, or a one-line refresher every ``turns_between_refreshers`` turns.
+        """
+        due: list[str] = []
+        if self._exit_pending:
+            self._exit_pending = False
+            self._mode_announced = False
+            due.append(MODE_EXIT)
+        if self.mode_on:
+            if not self._mode_announced:
+                self._mode_announced = True
+                self._turns_since_reminder = 0
+                due.append(MODE_ENTER)
+            elif self._turns_since_reminder >= self.config.turns_between_refreshers:
+                self._turns_since_reminder = 0
+                due.append(MODE_REFRESH)
+        return due
+
+    def _build_user_messages(
+        self, user_input: str, reminder_texts: list[str]
+    ) -> list[dict[str, Any]]:
+        """Attach due reminders to the user turn per the configured transport.
+
+        The top-level ``system`` prefix never changes — reminders ride here. The
+        Messages API is trained on alternating user/assistant turns, so
+        ``USER_REMINDER`` folds reminders into the user turn's content as extra
+        text blocks (not separate user messages, which would create consecutive
+        user turns). ``SYSTEM_ROLE`` (newer SDK / next-opus) emits standalone
+        ``role:"system"`` messages, which sit outside that alternation. Either
+        way the cached prefix ahead of the reminder is left untouched.
+        """
+        if not reminder_texts:
+            return [{"role": "user", "content": user_input}]
+        if self.config.reminder_transport is ReminderTransport.SYSTEM_ROLE:
+            messages: list[dict[str, Any]] = [{"role": "user", "content": user_input}]
+            messages.extend({"role": "system", "content": text} for text in reminder_texts)
+            return messages
+        content: list[dict[str, Any]] = [{"type": "text", "text": user_input}]
+        content.extend(
+            {"type": "text", "text": f"<system-reminder>\n{text}\n</system-reminder>"}
+            for text in reminder_texts
+        )
+        return [{"role": "user", "content": content}]
+
+    async def turn(self, user_input: str) -> str:
+        """Run one user turn, executing tool calls until the model stops."""
+        # The reminder rides with the user turn it applies to (folded into its
+        # content under USER_REMINDER, or as a trailing system message under
+        # SYSTEM_ROLE), keeping the cached prefix ahead of it untouched.
+        reminder_texts = self._due_reminder_texts()
+        self.messages.extend(self._build_user_messages(user_input, reminder_texts))
+        self._turns_since_reminder += 1
+
+        for _ in range(self.config.max_main_turns):
+            async with self._client.messages.stream(
+                model=self._model,
+                max_tokens=self.config.max_tokens,
+                system=SYSTEM_PROMPT,
+                thinking={"type": "adaptive"},
+                output_config={"effort": self.config.effort},
+                tools=[WORKFLOW_TOOL, BASH_TOOL],
+                messages=self.messages,
+            ) as stream:
+                response = await stream.get_final_message()
+            self.messages.append({"role": "assistant", "content": response.content})
+
+            if response.stop_reason == "pause_turn":
+                continue
+            if response.stop_reason != "tool_use":
+                text = "".join(
+                    b.text for b in response.content if getattr(b, "type", None) == "text"
+                )
+                if response.stop_reason == "max_tokens":
+                    # Drop the truncated assistant turn so later turns don't build on it.
+                    self.messages.pop()
+                    text += "\n\n(warning: response was truncated at max_tokens)"
+                return text
+
+            tool_results: list[dict[str, Any]] = []
+            for block in response.content:
+                if getattr(block, "type", None) != "tool_use":
+                    continue
+                if block.name == "Workflow":
+                    payload = block.input or {}
+                    output, is_error = await run_workflow(
+                        self._client, payload.get("subtasks", []), self.config
+                    )
+                elif block.name == "bash":
+                    output, is_error = await handle_bash_block(block, self.config)
+                else:
+                    output, is_error = f"unknown tool: {block.name}", True
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": output,
+                        "is_error": is_error,
+                    }
+                )
+            self.messages.append({"role": "user", "content": tool_results})
+        return "(hit the main loop turn limit before finishing)"

--- a/orchestration/orchestration_mode_tools.py
+++ b/orchestration/orchestration_mode_tools.py
@@ -1,0 +1,285 @@
+"""Local tool layer for orchestration mode.
+
+Carries the three tools the orchestration-mode loop exposes and the parallel
+subagent fan-out:
+
+* ``WORKFLOW_TOOL`` — the standing-consent fan-out tool. Its description holds
+  the behavioural contract: opt-in normally, standing consent while the mode is
+  on, plus the quality patterns the model can reach for.
+* ``BASH_TOOL`` — the Anthropic-defined ``bash_20250124`` tool, executed
+  locally (no sandbox — see :func:`run_bash`).
+* ``REPORT_TOOL`` — ``report_findings``; a subagent calls it once to return
+  structured findings instead of prose.
+
+Concurrency follows the house idiom (``asyncio.gather`` + ``Semaphore``; cf.
+``agents/elite_web_builder/director.py`` and ``llm/round_table.py``), not the
+reference's ``ThreadPoolExecutor``.
+
+WARNING: :func:`run_bash` runs model-written commands directly on this machine
+with no sandbox, and the fan-out runs several of those subagents in parallel.
+This is for trusted local experimentation only; add sandboxing before any other
+use.
+
+Spec: docs/superpowers/specs/2026-06-01-orchestration-mode-design.html
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids an import cycle
+    from anthropic import AsyncAnthropic
+
+    from orchestration.orchestration_mode import ModeConfig
+
+logger = structlog.get_logger(__name__)
+
+
+SUBAGENT_SYSTEM = (
+    "You are one agent in a larger parallel fan-out, assigned a single subtask. "
+    "Investigate it directly, using bash to check facts rather than guessing, and "
+    "finish by calling report_findings exactly once. Return findings, not narration."
+)
+
+
+WORKFLOW_TOOL: dict[str, Any] = {
+    "name": "Workflow",
+    "description": (
+        "Orchestrate a multi-agent workflow: split a large task into independent "
+        "subtasks and run them as parallel agents, then collect their results.\n\n"
+        "Opt-in: only use this tool when the user explicitly asks for a workflow, or "
+        "when a system message confirms that orchestration mode is on.\n\n"
+        "Quality patterns: adversarial verification (a second wave of agents checks the "
+        "first wave's findings against the source), a completeness critic (one agent "
+        "hunts for what the others missed), and multi-phase sequencing (understand, "
+        "design, implement, and review as separate workflow calls, reading results "
+        "between phases). A useful default is hybrid: scout inline first to discover the "
+        "work-list, then fan out over it.\n\n"
+        "Standing consent: while a system message confirms orchestration mode is on, "
+        "that opt-in is standing. Author and run a workflow for every substantive task "
+        "by default, and lean toward verifying findings adversarially. Work solo only on "
+        "conversational turns or trivial mechanical edits. When a system message says the "
+        "mode is off, revert to the opt-in rule above."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "subtasks": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Independent subtask prompts to run as parallel agents",
+            }
+        },
+        "required": ["subtasks"],
+    },
+}
+
+
+BASH_TOOL: dict[str, Any] = {"type": "bash_20250124", "name": "bash"}
+
+
+REPORT_TOOL: dict[str, Any] = {
+    "name": "report_findings",
+    "description": (
+        "Report the final findings for your subtask. Call this exactly once, when you "
+        "are done investigating; it ends your task."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "summary": {
+                "type": "string",
+                "description": "Two or three sentences of synthesis",
+            },
+            "findings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "claim": {
+                            "type": "string",
+                            "description": "The finding, one sentence",
+                        },
+                        "evidence": {
+                            "type": "string",
+                            "description": "How it was verified (file, line, or command output)",
+                        },
+                        "severity": {
+                            "type": "string",
+                            "enum": ["high", "medium", "low", "info"],
+                        },
+                    },
+                    "required": ["claim", "evidence", "severity"],
+                },
+            },
+        },
+        "required": ["summary", "findings"],
+    },
+}
+
+
+def normalize_subtasks(raw: Any) -> list[str]:
+    """Accept the subtasks input in whatever shape the model emits.
+
+    The model may pass an array, the array JSON-encoded as a single string, or a
+    newline-separated list. Anything unusable normalizes to an empty list.
+    """
+    value = raw
+    if isinstance(raw, str):
+        try:
+            value = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            value = raw.splitlines() if "\n" in raw else [raw]
+    if not isinstance(value, list):
+        return []
+    return [task.strip() for task in value if isinstance(task, str) and task.strip()]
+
+
+async def run_bash(command: str, *, timeout_seconds: int, max_chars: int) -> tuple[str, bool]:
+    """Run a shell command, returning ``(output, is_error)``.
+
+    No sandbox: the command runs with this process's permissions. Output is
+    truncated to ``max_chars`` so a runaway command cannot flood the context.
+    """
+    logger.info("orchestration_mode.bash", command=command)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "bash",
+            "-c",
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+    except OSError as exc:
+        return f"bash error: {exc}", True
+
+    try:
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return f"command timed out after {timeout_seconds}s", True
+
+    output = stdout.decode("utf-8", "replace").strip() or "(no output)"
+    if len(output) > max_chars:
+        output = output[:max_chars] + f"\n(truncated at {max_chars} chars)"
+    if proc.returncode != 0:
+        return f"(exit code {proc.returncode})\n{output}", True
+    return output, False
+
+
+async def handle_bash_block(block: Any, config: ModeConfig) -> tuple[str, bool]:
+    """Execute one ``bash`` tool-use block. Honours the ``restart`` action."""
+    payload = getattr(block, "input", None) or {}
+    if payload.get("restart") is True:
+        return "Shell restarted.", False
+    command = payload.get("command")
+    if not isinstance(command, str) or not command:
+        return "bash error: no command was provided.", True
+    return await run_bash(
+        command,
+        timeout_seconds=config.bash_timeout_seconds,
+        max_chars=config.tool_result_max_chars,
+    )
+
+
+async def run_subagent(client: AsyncAnthropic, prompt: str, config: ModeConfig) -> str:
+    """One subagent: a small nested agent loop with bash + report_findings.
+
+    Subagents inherit the main loop's effort level and run on the cheaper
+    ``subagent_model``. Returns the structured ``report_findings`` JSON, or the
+    final text if the subagent stops without reporting.
+    """
+    messages: list[dict[str, Any]] = [{"role": "user", "content": prompt}]
+    for _ in range(config.max_subagent_turns):
+        async with client.messages.stream(
+            model=config.subagent_model,
+            max_tokens=config.max_tokens,
+            system=SUBAGENT_SYSTEM,
+            thinking={"type": "adaptive"},
+            output_config={"effort": config.effort},
+            tools=[BASH_TOOL, REPORT_TOOL],
+            messages=messages,
+        ) as stream:
+            response = await stream.get_final_message()
+        messages.append({"role": "assistant", "content": response.content})
+
+        if response.stop_reason == "pause_turn":
+            continue
+        if response.stop_reason != "tool_use":
+            text = "".join(b.text for b in response.content if getattr(b, "type", None) == "text")
+            if response.stop_reason == "max_tokens":
+                text += "\n\n(warning: subagent response was truncated at max_tokens)"
+            return text
+
+        tool_results: list[dict[str, Any]] = []
+        report: str | None = None
+        for block in response.content:
+            if getattr(block, "type", None) != "tool_use":
+                continue
+            if block.name == "report_findings":
+                report = json.dumps(block.input, indent=2)
+                output, is_error = "Findings recorded.", False
+            elif block.name == "bash":
+                output, is_error = await handle_bash_block(block, config)
+            else:
+                output, is_error = f"unknown tool: {block.name}", True
+            tool_results.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": output,
+                    "is_error": is_error,
+                }
+            )
+        if report is not None:
+            return report
+        messages.append({"role": "user", "content": tool_results})
+    return "(subagent hit the turn limit before finishing)"
+
+
+async def run_workflow(
+    client: AsyncAnthropic, raw_subtasks: Any, config: ModeConfig
+) -> tuple[str, bool]:
+    """Run subtasks as parallel subagents and collect their structured reports.
+
+    Caps the number run at ``config.max_parallel_agents`` and surfaces any
+    overflow (never silently truncated). One failing subagent degrades to an
+    error string instead of ending the run.
+    """
+    all_subtasks = normalize_subtasks(raw_subtasks)
+    subtasks = all_subtasks[: config.max_parallel_agents]
+    dropped = len(all_subtasks) - len(subtasks)
+    if not subtasks:
+        return "Workflow error: no usable subtasks were provided.", True
+
+    logger.info("orchestration_mode.fanout", count=len(subtasks), dropped=dropped)
+    semaphore = asyncio.Semaphore(config.max_parallel_agents)
+
+    async def _bounded(prompt: str) -> str:
+        async with semaphore:
+            return await run_subagent(client, prompt, config)
+
+    results = await asyncio.gather(
+        *(_bounded(prompt) for prompt in subtasks), return_exceptions=True
+    )
+
+    sections: list[str] = []
+    for index, (task, result) in enumerate(zip(subtasks, results, strict=True)):
+        if isinstance(result, BaseException):
+            # Isolation boundary: one bad subagent must not end the run.
+            result = f"(subagent failed: {type(result).__name__}: {result})"
+        sections.append(f"[agent {index + 1}: {task}]\n{result}")
+
+    joined = "\n\n".join(sections)
+    if dropped > 0:
+        joined = (
+            f"(note: {dropped} subtasks beyond max_parallel_agents="
+            f"{config.max_parallel_agents} were not run; rerun them in a follow-up "
+            f"Workflow call)\n\n" + joined
+        )
+    return joined, False

--- a/tests/orchestration/test_orchestration_mode.py
+++ b/tests/orchestration/test_orchestration_mode.py
@@ -1,0 +1,429 @@
+"""Tests for orchestration mode (orchestration/orchestration_mode.py + _tools).
+
+The orchestration-mode loop is the first streaming tool-use feedback loop in
+the repo. These tests pin the contract WITHOUT any live API call — the
+Anthropic client is faked at the boundary (mirrors the AsyncMock injection in
+tests/llm/test_verification.py). The only real subprocesses are the local bash
+tests, which run harmless commands (echo / sleep / printf).
+
+Design spec: docs/superpowers/specs/2026-06-01-orchestration-mode-design.html
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orchestration.orchestration_mode import (
+    MODE_ENTER,
+    MODE_EXIT,
+    MODE_REFRESH,
+    SYSTEM_PROMPT,
+    ModeAgent,
+    ModeConfig,
+    ReminderTransport,
+)
+from orchestration.orchestration_mode_tools import (
+    WORKFLOW_TOOL,
+    handle_bash_block,
+    normalize_subtasks,
+    run_bash,
+    run_workflow,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes — stand in for the Anthropic streaming client at the boundary.
+# ---------------------------------------------------------------------------
+
+
+def _text_block(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="text", text=text)
+
+
+def _tool_block(name: str, payload: dict, block_id: str = "tool-1") -> SimpleNamespace:
+    return SimpleNamespace(type="tool_use", name=name, input=payload, id=block_id)
+
+
+def _message(stop_reason: str, content: list) -> SimpleNamespace:
+    return SimpleNamespace(stop_reason=stop_reason, content=content)
+
+
+class _FakeStream:
+    """Async context manager mirroring client.messages.stream(...)."""
+
+    def __init__(self, message: SimpleNamespace) -> None:
+        self._message = message
+
+    async def __aenter__(self) -> _FakeStream:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    async def get_final_message(self) -> SimpleNamespace:
+        return self._message
+
+
+class _FakeMessages:
+    def __init__(self, messages: list[SimpleNamespace]) -> None:
+        self._queue = list(messages)
+        self.calls: list[dict] = []
+
+    def stream(self, **kwargs: object) -> _FakeStream:
+        self.calls.append(kwargs)
+        return _FakeStream(self._queue.pop(0))
+
+
+class _FakeClient:
+    def __init__(self, messages: list[SimpleNamespace]) -> None:
+        self.messages = _FakeMessages(messages)
+
+
+def _agent(messages: list[SimpleNamespace], **kwargs: object) -> ModeAgent:
+    return ModeAgent(client=_FakeClient(messages), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Mode state machine — pure, no API.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_enter_emitted_once_then_silent() -> None:
+    agent = _agent([], mode_on=True)
+    assert agent._due_reminder_texts() == [MODE_ENTER]
+    # Not yet at the refresher threshold → nothing more owed.
+    assert agent._due_reminder_texts() == []
+
+
+@pytest.mark.unit
+def test_refresh_emitted_at_threshold() -> None:
+    config = ModeConfig(turns_between_refreshers=3)
+    agent = _agent([], config=config, mode_on=True)
+    agent._due_reminder_texts()  # consumes ENTER, resets counter
+    agent._turns_since_reminder = 3
+    assert agent._due_reminder_texts() == [MODE_REFRESH]
+
+
+@pytest.mark.unit
+def test_exit_emitted_once_after_turn_off() -> None:
+    agent = _agent([], mode_on=True)
+    agent._due_reminder_texts()  # ENTER
+    agent.set_mode(False)
+    assert agent._due_reminder_texts() == [MODE_EXIT]
+    # Mode off → nothing further owed.
+    assert agent._due_reminder_texts() == []
+
+
+@pytest.mark.unit
+def test_no_exit_if_never_announced() -> None:
+    agent = _agent([], mode_on=True)
+    agent.set_mode(False)  # turned off before any ENTER was emitted
+    assert agent._due_reminder_texts() == []
+
+
+@pytest.mark.unit
+def test_setmode_noop_when_unchanged() -> None:
+    agent = _agent([], mode_on=True)
+    agent._due_reminder_texts()
+    agent.set_mode(True)  # already on
+    assert agent._due_reminder_texts() == []
+
+
+# ---------------------------------------------------------------------------
+# Reminder transport.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_user_reminder_folds_into_single_user_turn() -> None:
+    agent = _agent([], config=ModeConfig(reminder_transport=ReminderTransport.USER_REMINDER))
+    messages = agent._build_user_messages("hi there", ["HELLO"])
+    # Folded into ONE user turn — no consecutive same-role turns.
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    content = messages[0]["content"]
+    assert isinstance(content, list)
+    assert content[0] == {"type": "text", "text": "hi there"}
+    assert "<system-reminder>" in content[1]["text"]
+    assert "HELLO" in content[1]["text"]
+
+
+@pytest.mark.unit
+def test_system_role_emits_standalone_system_message() -> None:
+    agent = _agent([], config=ModeConfig(reminder_transport=ReminderTransport.SYSTEM_ROLE))
+    messages = agent._build_user_messages("hi there", ["HELLO"])
+    assert messages[0] == {"role": "user", "content": "hi there"}
+    assert messages[1] == {"role": "system", "content": "HELLO"}
+
+
+@pytest.mark.unit
+def test_no_reminder_yields_plain_user_turn() -> None:
+    agent = _agent([])
+    assert agent._build_user_messages("hi there", []) == [{"role": "user", "content": "hi there"}]
+
+
+# ---------------------------------------------------------------------------
+# Standing consent text lives in the tool description.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_workflow_tool_carries_standing_consent() -> None:
+    description = WORKFLOW_TOOL["description"].lower()
+    assert "standing consent" in description
+    assert "orchestration mode" in description
+    assert WORKFLOW_TOOL["input_schema"]["required"] == ["subtasks"]
+
+
+# ---------------------------------------------------------------------------
+# normalize_subtasks — array / json-string / newline / junk.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_normalize_subtasks_accepts_array() -> None:
+    assert normalize_subtasks(["a", " b ", ""]) == ["a", "b"]
+
+
+@pytest.mark.unit
+def test_normalize_subtasks_accepts_json_string() -> None:
+    assert normalize_subtasks('["x", "y"]') == ["x", "y"]
+
+
+@pytest.mark.unit
+def test_normalize_subtasks_accepts_newlines() -> None:
+    assert normalize_subtasks("one\ntwo\n") == ["one", "two"]
+
+
+@pytest.mark.unit
+def test_normalize_subtasks_rejects_junk() -> None:
+    assert normalize_subtasks(42) == []
+    assert normalize_subtasks([1, 2, None]) == []
+
+
+# ---------------------------------------------------------------------------
+# Fan-out — cap + per-subagent failure isolation.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_workflow_caps_and_notes_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def fake_subagent(client: object, prompt: str, config: object) -> str:
+        calls.append(prompt)
+        return f"done:{prompt}"
+
+    monkeypatch.setattr("orchestration.orchestration_mode_tools.run_subagent", fake_subagent)
+    config = ModeConfig(max_parallel_agents=3)
+    subtasks = [f"task-{i}" for i in range(5)]
+    output, is_error = await run_workflow(_FakeClient([]), subtasks, config)
+
+    assert is_error is False
+    assert len(calls) == 3  # capped
+    assert "2 subtasks" in output  # 2 dropped, surfaced not silent
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_workflow_isolates_failed_subagent(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def flaky(client: object, prompt: str, config: object) -> str:
+        if prompt == "boom":
+            raise RuntimeError("kaboom")
+        return f"ok:{prompt}"
+
+    monkeypatch.setattr("orchestration.orchestration_mode_tools.run_subagent", flaky)
+    output, is_error = await run_workflow(_FakeClient([]), ["fine", "boom"], ModeConfig())
+
+    assert is_error is False
+    assert "ok:fine" in output
+    assert "subagent failed" in output.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_workflow_empty_is_error() -> None:
+    output, is_error = await run_workflow(_FakeClient([]), [], ModeConfig())
+    assert is_error is True
+
+
+# ---------------------------------------------------------------------------
+# turn() — streaming loop, tool dispatch, cache integrity, reminder placement.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_turn_returns_text_on_end_turn() -> None:
+    agent = _agent([_message("end_turn", [_text_block("final answer")])])
+    result = await agent.turn("hi")
+    assert result == "final answer"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_turn_places_reminder_after_user_turn() -> None:
+    agent = _agent([_message("end_turn", [_text_block("ok")])], mode_on=True)
+    await agent.turn("do the thing")
+    # One user turn, reminder folded in as a trailing content block — the
+    # user's text stays first so the cached prefix ahead of it is untouched.
+    first = agent.messages[0]
+    assert first["role"] == "user"
+    assert first["content"][0] == {"type": "text", "text": "do the thing"}
+    assert "<system-reminder>" in first["content"][1]["text"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_turn_system_prefix_is_byte_stable() -> None:
+    agent = _agent(
+        [
+            _message("tool_use", [_tool_block("bash", {"command": "echo hi"})]),
+            _message("end_turn", [_text_block("done")]),
+        ]
+    )
+    await agent.turn("run something")
+    systems = [call["system"] for call in agent._client.messages.calls]
+    assert len(systems) == 2
+    assert all(s == SYSTEM_PROMPT for s in systems)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_turn_dispatches_workflow(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow_mock = AsyncMock(return_value=("fanned out", False))
+    monkeypatch.setattr("orchestration.orchestration_mode.run_workflow", workflow_mock)
+    agent = _agent(
+        [
+            _message("tool_use", [_tool_block("Workflow", {"subtasks": ["a", "b"]})]),
+            _message("end_turn", [_text_block("synth")]),
+        ]
+    )
+    result = await agent.turn("review repo")
+    assert result == "synth"
+    workflow_mock.assert_awaited_once()
+    assert workflow_mock.await_args.args[1] == ["a", "b"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_turn_unknown_tool_is_error() -> None:
+    agent = _agent(
+        [
+            _message("tool_use", [_tool_block("nope", {})]),
+            _message("end_turn", [_text_block("recovered")]),
+        ]
+    )
+    await agent.turn("x")
+    # The tool_result fed back must be flagged is_error.
+    tool_result_turn = agent.messages[-2]  # user turn carrying tool_result
+    block = tool_result_turn["content"][0]
+    assert block["is_error"] is True
+    assert "unknown tool" in block["content"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_turn_pause_turn_continues() -> None:
+    agent = _agent(
+        [
+            _message("pause_turn", [_text_block("thinking...")]),
+            _message("end_turn", [_text_block("resumed answer")]),
+        ]
+    )
+    result = await agent.turn("long task")
+    assert result == "resumed answer"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_turn_max_tokens_drops_truncated_turn() -> None:
+    agent = _agent([_message("max_tokens", [_text_block("partial")])])
+    result = await agent.turn("x")
+    assert "partial" in result
+    assert "truncated" in result.lower()
+    # The truncated assistant turn must not poison history.
+    assert all(m.get("role") != "assistant" for m in agent.messages)
+
+
+# ---------------------------------------------------------------------------
+# Local bash tool.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_bash_captures_output() -> None:
+    output, is_error = await run_bash("echo hello", timeout_seconds=10, max_chars=8000)
+    assert is_error is False
+    assert "hello" in output
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_bash_truncates() -> None:
+    output, _ = await run_bash("printf 'x%.0s' $(seq 1 500)", timeout_seconds=10, max_chars=50)
+    assert "truncated" in output.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_bash_times_out() -> None:
+    output, is_error = await run_bash("sleep 5", timeout_seconds=1, max_chars=8000)
+    assert is_error is True
+    assert "timed out" in output.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_bash_nonzero_exit_flagged() -> None:
+    output, is_error = await run_bash("exit 3", timeout_seconds=10, max_chars=8000)
+    assert is_error is True
+    assert "3" in output
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_handle_bash_block_restart() -> None:
+    block = SimpleNamespace(input={"restart": True})
+    output, is_error = await handle_bash_block(block, ModeConfig())
+    assert is_error is False
+    assert "restart" in output.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_handle_bash_block_missing_command_is_error() -> None:
+    block = SimpleNamespace(input={})
+    output, is_error = await handle_bash_block(block, ModeConfig())
+    assert is_error is True
+
+
+# ---------------------------------------------------------------------------
+# Live smoke — excluded by default addopts (`-m "not integration"`). Costs a
+# few cents per run; run only with the founder's go-ahead:
+#     pytest tests/orchestration/test_orchestration_mode.py -m integration
+# It is the ONLY thing that proves the request shape end-to-end against the real
+# API: the folded <system-reminder> transport (mode on) plus effort="xhigh" on
+# the streaming endpoint with adaptive thinking. The prompt is deliberately
+# trivial so the standing-consent instruction keeps the model solo (no fan-out,
+# no local bash).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_live_smoke_single_turn() -> None:
+    import os
+
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        pytest.skip("ANTHROPIC_API_KEY not set")
+
+    agent = ModeAgent(mode_on=True)  # mode on → folded reminder is exercised
+    result = await agent.turn("Reply with exactly one word: hi")
+    assert isinstance(result, str)
+    assert result.strip()


### PR DESCRIPTION
## Summary

Refactors Anthropic's "Build an orchestration mode" loop theory into DevSkyy house idiom. An **orchestration mode** is a session-level switch: when on, the agent runs every substantive request at max effort and fans work out to parallel subagents by default; when off, the same Workflow tool reverts to per-request opt-in. Built from three documented pieces — never an API flag:

1. **Effort** — `output_config={"effort":"xhigh"}` (matches the shipping `scripts/nano_banana/tournament.py` precedent).
2. **Mid-conversation mode reminder** — toggles "fan out by default" on/off; rides *with* the user turn so the cached `system` prefix never changes.
3. **Standing consent** — written into the `Workflow` tool's description.

This is the **first streaming tool-use feedback loop in the repo** — it composes the previously-scattered streaming (`catalog_retriever.py`), tool-use (`articulate_layer0.py`), and effort (`tournament.py`) skeletons into one loop.

## What's in it

| File | Role |
|------|------|
| `orchestration/orchestration_mode.py` | `ModeAgent` async loop, `ModeConfig` (frozen), `ReminderTransport`. State machine (`_due_reminder_texts`) split from transport (`_build_user_messages`). |
| `orchestration/orchestration_mode_tools.py` | `Workflow` (standing-consent), `bash_20250124` (local, **no sandbox**), `report_findings`; `asyncio.gather`+`Semaphore` subagent fan-out. |
| `tests/orchestration/test_orchestration_mode.py` | 29 unit tests + 1 gated live smoke. |
| `orchestration/__init__.py`, `orchestration/CLAUDE.md` | Lazy-import wiring + surface-table row. |
| `docs/superpowers/specs/2026-06-01-orchestration-mode-design.html` | Design spec. |

## Refactored to house idiom (over the doc's literal Python)

- sync `Anthropic` → **async `AsyncAnthropic`** (orchestration/ is async-only)
- `ThreadPoolExecutor` → **`asyncio.gather` + `Semaphore`** (the `director.py:603` / `round_table.py:1323` idiom)
- `print(...stderr)` → **`structlog`**
- hardcoded model string → **`llm.model_ids` constants** (`ORCHESTRATOR_MODEL`, `SUBAGENT_MODEL`)

## Transport detail (alternation-safe)

The Messages API trains on alternating user/assistant turns. The runs-today `USER_REMINDER` transport **folds the reminder into the user turn's content** as an extra `<system-reminder>` text block (not a separate user message, which would create consecutive user turns). The `SYSTEM_ROLE` seam emits standalone `role:"system"` messages — and the latest anthropic SDK already types `role:"system"` + `MidConversationSystemBlockParam` (Context7-verified), so the seam is forward-compatible, not hypothetical.

## Test plan

- [x] 29 unit tests — mocked Anthropic boundary, **zero API spend**. Cover: mode state machine (ENTER/REFRESH/EXIT), folded transport, cache-prefix byte-stability, tool dispatch routing, fan-out cap + per-subagent failure isolation, `normalize_subtasks`, bash timeout/truncation/restart, `max_tokens` handling.
- [x] **1 live integration smoke — PASSED** against real `claude-opus-4-7` on `messages.stream` with `effort="xhigh"` + adaptive thinking + the folded transport. No `roles must alternate` 400, no effort rejection. (Marked `integration`, deselected by default `addopts` → no spend in normal runs.)
- [x] `ruff` / `black` / `isort` / `mypy` (1302 files) clean via pre-commit gate.

Run unit tests: `pytest tests/orchestration/test_orchestration_mode.py`
Run live smoke (costs ~cents, needs a key in env): `pytest tests/orchestration/test_orchestration_mode.py -m integration`

## Notes for the reviewer

- **CI is expected RED at provisioning** (`runner=""`) due to the known org Actions/Vercel account block (since 2026-05-28) — this is infra, not code. Verify locally with the commands above.
- **Key resolution gotcha:** root `.env` is 0 bytes and `config` does not surface `ANTHROPIC_API_KEY`; the key lives in purpose env files. The module relies on the SDK's env fallback, so any runtime entrypoint must export `ANTHROPIC_API_KEY` into the environment. Documented in the spec.
- **Local bash tool has no sandbox** — intended for trusted local experimentation; add sandboxing before any other use (timeout + output truncation are in place).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an orchestration mode: a session-level switch that runs requests at max effort and fans work to parallel subagents by default using a streaming tool-use loop. Introduces `ModeAgent` with mid-conversation reminders and standing consent for the `Workflow` tool.

- **New Features**
  - `orchestration/orchestration_mode.py`: `ModeAgent`, `ModeConfig`, `ReminderTransport`. Async `messages.stream` loop on `AsyncAnthropic`, static `system` prefix, reminders folded into the user turn by default, `output_config={"effort":"xhigh"}`.
  - `orchestration/orchestration_mode_tools.py`: `Workflow` (standing-consent), `bash_20250124` (local, no sandbox), `report_findings`. Parallel subagents via `asyncio.gather` + `Semaphore`, per-subagent failure isolation, `normalize_subtasks` support.
  - Tests/docs/wiring: 29 unit tests + 1 gated live smoke; wired in `orchestration/__init__.py` and `orchestration/CLAUDE.md`; design spec at `docs/superpowers/specs/2026-06-01-orchestration-mode-design.html`.

<sup>Written for commit 58cca538a263aedfbfe85fbeb6691f5547fbb6cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Orchestration Mode: enables mid-conversation reminder injection, parallel subagent execution, and structured workflow dispatch.
  * Added local bash tool execution with timeout and output truncation support.
  * Supports configurable reminder transport modes and adaptive effort levels for agent interactions.
  * Implemented concurrent fan-out execution with bounded parallelism and exception isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->