### PR TITLE
fix(security): validate provider-returned URLs before download in replicate_provider (SSRF)

### DIFF
--- a/services/three_d/replicate_provider.py
+++ b/services/three_d/replicate_provider.py
@@ -36,7 +36,22 @@ from services.three_d.provider_interface import (
     ThreeDTimeoutError,
 )
 
+from security.ssrf_protection import SSRFProtection
+
 logger = logging.getLogger(__name__)
+
+# Services-layer SSRF guard: blocks private IPs, localhost, and cloud metadata
+# services (169.254.169.254, etc.) but imposes NO domain allowlist so that
+# Replicate CDN URLs (e.g. replicate.delivery, pbxt.cdn.replicate.com) are
+# accepted.  Do NOT replace this with the global `ssrf_protection` singleton
+# from security/ssrf_protection.py — that instance restricts to a narrow
+# OpenAI/Anthropic/Google allowlist which would reject provider-returned URLs.
+_services_ssrf = SSRFProtection(
+    allowed_domains=None,  # no domain allowlist — accept any non-private host
+    block_private_ips=True,
+    block_localhost=True,
+    block_metadata_services=True,
+)
 
 
 # =============================================================================
@@ -147,7 +162,23 @@ class ReplicateProvider:
         output_format: OutputFormat,
         correlation_id: str,
     ) -> str:
-        """Download generated model to local storage."""
+        """Download generated model to local storage.
+
+        The URL is sourced from Replicate's API response and must be validated
+        before fetching to prevent SSRF attacks (e.g. a compromised/spoofed
+        provider response redirecting to 169.254.169.254 or an internal host).
+        """
+        # SSRF guard: validate before any network I/O
+        try:
+            _services_ssrf.validate_url(url)
+        except ValueError as exc:
+            raise ThreeDProviderError(
+                f"Model download URL failed SSRF validation: {exc}",
+                provider=self.name,
+                correlation_id=correlation_id,
+                retryable=False,
+            ) from exc
+
         http_client = await self._get_http_client()
 
         try:

--- a/tasks/codebase-cleanup/decisions/06-roundtable-publish-status.md
+++ b/tasks/codebase-cleanup/decisions/06-roundtable-publish-status.md
@@ -1,0 +1,94 @@
+# Finding #6 — Round Table Auto-Publishes WordPress Posts Without Review Gate
+
+**Date:** 2026-05-06
+**Severity:** HIGH (data integrity / unintended publication)
+**Status:** INVESTIGATE ONLY — no code change made
+
+---
+
+## Location
+
+`frontend/lib/autonomous/round-table-auto-trigger.ts` line 99–101
+
+```typescript
+// CRITICAL: Deploy as PUBLISHED post (not draft)
+const response = await syncService.syncRoundTableResult(result, {
+  status: 'publish', // Auto-publish winner
+```
+
+---
+
+## Current Behavior
+
+`deployWinnerToWordPressWithRetry()` unconditionally passes `status: 'publish'` to the WordPress
+sync service. Every LLM Round Table competition winner is immediately live on the production
+WordPress site (`skyyrose.co`) without any human review step. The in-code comment "CRITICAL: Deploy
+as PUBLISHED post (not draft)" indicates this was an explicit intentional decision at the time of
+writing, not an accident.
+
+The trigger is wired into the autonomous pipeline: once the round table competition concludes and a
+winner is scored, deployment is automatic and fires without user confirmation.
+
+---
+
+## Risk Assessment
+
+- **Content risk:** AI-generated copy goes live before brand review. A hallucinated product detail
+  or off-brand phrasing becomes customer-visible immediately.
+- **WooCommerce coupling:** If `syncRoundTableResult` also creates/updates WooCommerce products
+  (not confirmed — would require reading `lib/wordpress/sync-service.ts`), a bad run could corrupt
+  live product listings.
+- **No rollback gate:** Retry logic (`maxRetries`) retries the publish call on failure. A transient
+  network error followed by a successful retry means the post exists in WordPress but may not be
+  captured in `localStorage` sync history, making it harder to find and unpublish.
+
+---
+
+## Recommendation
+
+Change `status: 'publish'` to `status: 'draft'` and add an explicit approval step before
+promotion.
+
+Suggested minimal change:
+
+```typescript
+const response = await syncService.syncRoundTableResult(result, {
+  status: 'draft', // Human review required before publish
+  title: `LLM Round Table Winner: ${result.prompt_preview.substring(0, 60)}`,
+})
+```
+
+If the owner requires auto-publish for operational reasons, a middle-ground is to add a
+configurable flag:
+
+```typescript
+const publishStatus = process.env.NEXT_PUBLIC_ROUNDTABLE_AUTO_PUBLISH === 'true'
+  ? 'publish'
+  : 'draft'
+```
+
+This keeps the current behavior when the env var is explicitly set and defaults to safe (draft)
+in all other environments.
+
+---
+
+## Open Question for Owner
+
+**Was the `status: 'publish'` intentional for production, or was it set for testing and never
+reverted?**
+
+The comment "CRITICAL: Deploy as PUBLISHED post (not draft)" implies an intentional design choice,
+possibly driven by a workflow requirement (e.g., round table results feed a social content
+calendar and must be live before a scheduled share). If that is the case, the risk is accepted and
+this finding can be closed as WONTFIX with a comment explaining the operational reason.
+
+If the intent was to auto-draft for later review, the fix is a one-line change.
+
+---
+
+## Files Examined
+
+- `frontend/lib/autonomous/round-table-auto-trigger.ts` — confirmed `status: 'publish'` at line 101
+- `frontend/lib/autonomous/CLAUDE.md` — no additional context
+- Did NOT read `frontend/lib/wordpress/sync-service.ts` — WooCommerce coupling is unconfirmed;
+  recommend reading it before implementing any fix.

--- a/tasks/codebase-cleanup/status/wave2-A-p0.md
+++ b/tasks/codebase-cleanup/status/wave2-A-p0.md
@@ -1,0 +1,61 @@
+# Wave 2 Agent A — P0 Leftover Security: Final Status
+
+**Date:** 2026-05-06
+**Branch (auth):** `fix/p0-wave2-auth-rollout`
+**Branch (SSRF):** `fix/p0-wave2-ssrf-allowlist`
+
+---
+
+## Summary Table
+
+| # | Finding | Branch | Status | Notes |
+|---|---------|--------|--------|-------|
+| 2 | 12 unauthenticated endpoints (cost/data exposure) | `fix/p0-wave2-auth-rollout` | DONE — pushed | REST endpoints gated with `Depends(get_current_user)`; WebSocket endpoints gated with `?token=<jwt>` query param; WooCommerce webhook deferred (HMAC-SHA256, not JWT); 401 regression tests in `tests/test_p0_auth_regression.py` |
+| 4 | SSRF — `_download_model` fetches provider-returned URLs without validation | `fix/p0-wave2-ssrf-allowlist` | DONE — pushed | `_services_ssrf` module-level instance added to `services/three_d/replicate_provider.py`; SSRF check in `_download_model()` before HTTP I/O; blocked URLs raise `ThreeDProviderError(retryable=False)`; 16 unit tests in `tests/test_p0_ssrf_replicate.py` |
+| 6 | Round Table auto-publishes WordPress posts as `'publish'` | — | INVESTIGATED — decision memo written | See `tasks/codebase-cleanup/decisions/06-roundtable-publish-status.md`; change is one line but requires owner confirmation on intent before fixing |
+
+---
+
+## Finding #2 Detail
+
+**Files modified:**
+- `api/websocket.py` — JWT validation via `jwt_manager.validate_token(token)` on all 6 WebSocket routes; query-param `?token=` added to each handler signature
+- `api/v1/catalog.py` — `Depends(get_current_user)` on `/answer`, `/answer/stream`, `/cache/clear`
+- `api/virtual_tryon.py` — `Depends(get_current_user)` on all 4 FASHN endpoints
+- `api/ar_sessions.py` — `Depends(get_current_user)` on 3 write endpoints
+- `api/v1/sync.py` — `Depends(get_current_user)` on `POST /trigger`, `POST /rt-to-hf`
+- `api/v1/wordpress.py` — `Depends(get_current_user)` on both endpoints
+- `api/v1/wordpress_agent.py` — `Depends(get_current_user)` on `/execute`; `/webhooks/dispatch` left unauthenticated with `# SECURITY-DEFERRED-WEBHOOK-HMAC` comment
+
+**Tests added:** `tests/test_p0_auth_regression.py`
+
+**Deferral — WooCommerce webhook:** `/webhooks/dispatch` is called by WooCommerce with HMAC-SHA256 signatures in the `X-WC-Webhook-Signature` header. Adding JWT auth would break WooCommerce delivery. Correct fix is to validate the HMAC signature against `WOOCOMMERCE_SECRET`. Tracked as `SECURITY-DEFERRED-WEBHOOK-HMAC` in the source comment.
+
+---
+
+## Finding #4 Detail
+
+**Root cause:** `_download_model()` in `services/three_d/replicate_provider.py` called `http_client.get(url)` on a URL supplied by the Replicate API response without any validation. An attacker who controls the Replicate response (or a compromised Replicate account) could route requests to internal services including the AWS metadata endpoint at `169.254.169.254`.
+
+**Fix:** `_services_ssrf` instance uses `SSRFProtection(allowed_domains=None, block_private_ips=True, block_localhost=True, block_metadata_services=True)`. The production global `ssrf_protection` was not reused because it has a narrow OpenAI/Anthropic/Google domain allowlist that would reject Replicate CDN URLs (e.g., `replicate.delivery`).
+
+**Tests added:** `tests/test_p0_ssrf_replicate.py` — 16 tests covering blocked addresses, allowed CDN URLs, correct exception type, and `retryable=False` flag.
+
+---
+
+## Finding #6 Detail
+
+See `tasks/codebase-cleanup/decisions/06-roundtable-publish-status.md` for full analysis.
+
+**Short version:** `round-table-auto-trigger.ts:101` passes `status: 'publish'` to the WordPress sync service. All round table winners go live on `skyyrose.co` without human review. The in-code comment marks this as intentional. Recommended fix is `status: 'draft'` or an env-var gate, but owner must confirm intent before the line is changed.
+
+---
+
+## Branches Pushed
+
+```
+fix/p0-wave2-auth-rollout      → pushed (prior session)
+fix/p0-wave2-ssrf-allowlist    → pushed 2026-05-06
+```
+
+No PRs opened per task constraint.

--- a/tests/test_p0_ssrf_replicate.py
+++ b/tests/test_p0_ssrf_replicate.py
@@ -1,0 +1,222 @@
+"""P0 SSRF regression tests — replicate_provider._download_model URL validation.
+
+Covers Finding #4 from the Wave 2 cleanup audit:
+  services/three_d/replicate_provider.py _download_model() fetched
+  provider-supplied URLs without SSRF validation.
+
+Tests verify that:
+1. The services-layer _services_ssrf instance blocks private IPs and metadata
+   services (169.254.169.254, 10.x.x.x, localhost, etc.) regardless of domain.
+2. Legitimate Replicate CDN URLs pass validation.
+3. ThreeDProviderError is raised (not raw ValueError) when _download_model
+   receives a blocked URL.
+4. The global ssrf_protection singleton correctly blocks the same addresses,
+   as a baseline sanity check.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# _services_ssrf instance — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestServicesSSRFInstance:
+    """The module-level _services_ssrf in replicate_provider blocks private addresses."""
+
+    @pytest.fixture
+    def ssrf(self):
+        from services.three_d.replicate_provider import _services_ssrf
+
+        return _services_ssrf
+
+    # --- Addresses that MUST be blocked ---
+
+    def test_blocks_aws_metadata_service(self, ssrf):
+        with pytest.raises(ValueError, match="169.254"):
+            ssrf.validate_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_blocks_aws_metadata_service_iam(self, ssrf):
+        with pytest.raises(ValueError):
+            ssrf.validate_url("http://169.254.169.254/latest/meta-data/iam/security-credentials/")
+
+    def test_blocks_localhost_http(self, ssrf):
+        with pytest.raises(ValueError):
+            ssrf.validate_url("http://localhost/internal")
+
+    def test_blocks_localhost_127(self, ssrf):
+        with pytest.raises(ValueError):
+            ssrf.validate_url("http://127.0.0.1:8080/admin")
+
+    def test_blocks_private_10_range(self, ssrf):
+        with pytest.raises(ValueError):
+            ssrf.validate_url("http://10.0.0.1/internal-api")
+
+    def test_blocks_private_192_168(self, ssrf):
+        with pytest.raises(ValueError):
+            ssrf.validate_url("http://192.168.1.100/api")
+
+    def test_blocks_private_172_16(self, ssrf):
+        with pytest.raises(ValueError):
+            ssrf.validate_url("http://172.16.0.1/data")
+
+    def test_blocks_file_protocol(self, ssrf):
+        with pytest.raises(ValueError):
+            ssrf.validate_url("file:///etc/passwd")
+
+    def test_blocks_gopher_protocol(self, ssrf):
+        with pytest.raises(ValueError):
+            ssrf.validate_url("gopher://127.0.0.1:25/smtp")
+
+    # --- Addresses that MUST be allowed (no domain allowlist) ---
+
+    def test_allows_replicate_cdn(self, ssrf):
+        """Standard Replicate CDN URLs must pass."""
+        # Should not raise — if it does, the test fails
+        ssrf.validate_url("https://replicate.delivery/pbxt/abc123/output.glb")
+
+    def test_allows_public_https(self, ssrf):
+        ssrf.validate_url("https://example.com/model.glb")
+
+    def test_allows_huggingface(self, ssrf):
+        ssrf.validate_url("https://huggingface.co/spaces/output/mesh.glb")
+
+
+# ---------------------------------------------------------------------------
+# _download_model — integration test with mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadModelSSRFGuard:
+    """_download_model must raise ThreeDProviderError on blocked URLs."""
+
+    @pytest.fixture
+    def provider(self):
+        from services.three_d.replicate_provider import ReplicateProvider
+
+        p = ReplicateProvider.__new__(ReplicateProvider)
+        p.name = "replicate"
+        p.config = MagicMock()
+        p.config.output_dir = "/tmp/replicate_test"
+        p._http_client = None
+        p._client = None
+        return p
+
+    @pytest.mark.asyncio
+    async def test_download_metadata_url_raises_provider_error(self, provider):
+        """Metadata service URL must raise ThreeDProviderError, not raw ValueError."""
+        from services.three_d.provider_interface import (
+            OutputFormat,
+            ThreeDProviderError,
+        )
+
+        with pytest.raises(ThreeDProviderError, match="SSRF"):
+            await provider._download_model(
+                url="http://169.254.169.254/latest/meta-data/",
+                output_format=OutputFormat.GLB,
+                correlation_id="test-corr-001",
+            )
+
+    @pytest.mark.asyncio
+    async def test_download_localhost_url_raises_provider_error(self, provider):
+        from services.three_d.provider_interface import (
+            OutputFormat,
+            ThreeDProviderError,
+        )
+
+        with pytest.raises(ThreeDProviderError, match="SSRF"):
+            await provider._download_model(
+                url="http://127.0.0.1:6379/",
+                output_format=OutputFormat.GLB,
+                correlation_id="test-corr-002",
+            )
+
+    @pytest.mark.asyncio
+    async def test_download_private_ip_raises_provider_error(self, provider):
+        from services.three_d.provider_interface import (
+            OutputFormat,
+            ThreeDProviderError,
+        )
+
+        with pytest.raises(ThreeDProviderError, match="SSRF"):
+            await provider._download_model(
+                url="http://10.0.0.1/internal",
+                output_format=OutputFormat.GLB,
+                correlation_id="test-corr-003",
+            )
+
+    @pytest.mark.asyncio
+    async def test_download_valid_url_proceeds_to_http(self, provider):
+        """A valid CDN URL must reach the HTTP client (not be blocked by SSRF)."""
+        from services.three_d.provider_interface import OutputFormat
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = b"GLB_BINARY_DATA"
+
+        mock_http = AsyncMock()
+        mock_http.get = AsyncMock(return_value=mock_response)
+        mock_http.is_closed = False
+
+        provider._http_client = mock_http
+
+        import os
+
+        os.makedirs("/tmp/replicate_test", exist_ok=True)
+
+        result = await provider._download_model(
+            url="https://replicate.delivery/pbxt/abc123/model.glb",
+            output_format=OutputFormat.GLB,
+            correlation_id="test-corr-valid",
+        )
+
+        mock_http.get.assert_awaited_once_with("https://replicate.delivery/pbxt/abc123/model.glb")
+        assert result.endswith(".glb")
+
+    @pytest.mark.asyncio
+    async def test_ssrf_error_is_not_retryable(self, provider):
+        """SSRF-blocked URLs should not be retried (retryable=False)."""
+        from services.three_d.provider_interface import (
+            OutputFormat,
+            ThreeDProviderError,
+        )
+
+        with pytest.raises(ThreeDProviderError) as exc_info:
+            await provider._download_model(
+                url="http://169.254.169.254/",
+                output_format=OutputFormat.GLB,
+                correlation_id="test-corr-004",
+            )
+
+        assert exc_info.value.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# Global ssrf_protection singleton — baseline sanity check
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalSSRFSingleton:
+    """The global ssrf_protection singleton also blocks these addresses."""
+
+    @pytest.fixture
+    def global_ssrf(self):
+        from security.ssrf_protection import ssrf_protection
+
+        return ssrf_protection
+
+    def test_global_blocks_metadata_service(self, global_ssrf):
+        with pytest.raises(ValueError):
+            global_ssrf.validate_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_global_blocks_localhost(self, global_ssrf):
+        with pytest.raises(ValueError):
+            global_ssrf.validate_url("http://localhost/")
+
+    def test_global_blocks_private_10(self, global_ssrf):
+        with pytest.raises(ValueError):
+            global_ssrf.validate_url("http://10.0.0.1/")

--- a/tests/test_p0_ssrf_replicate.py
+++ b/tests/test_p0_ssrf_replicate.py
@@ -99,7 +99,6 @@ class TestDownloadModelSSRFGuard:
         from services.three_d.replicate_provider import ReplicateProvider
 
         p = ReplicateProvider.__new__(ReplicateProvider)
-        p.name = "replicate"
         p.config = MagicMock()
         p.config.output_dir = "/tmp/replicate_test"
         p._http_client = None


### PR DESCRIPTION
## Summary
- Adds an SSRF guard to `ReplicateProvider._download_model`: provider-returned URLs are validated before any network I/O via a services-layer `SSRFProtection` instance (blocks private IPs, localhost, and cloud metadata services; no domain allowlist so Replicate CDN URLs pass).
- Blocked URLs raise `ThreeDProviderError` (non-retryable) instead of being fetched.
- 222-line regression suite `tests/test_p0_ssrf_replicate.py` — 20 tests covering metadata service, localhost, private-IP, valid-URL passthrough, and non-retryable semantics.
- Wave 2-A P0 status docs.

Branch dates from 2026-05-06 and was never PR'd — surfaced in the 2026-06-09 worktree sweep. Rebased context verified: zero conflicts vs current main, `SSRFProtection` API unchanged.

## Test plan
- [x] `pytest tests/test_p0_ssrf_replicate.py` — 20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents SSRF by validating provider-returned URLs in `ReplicateProvider._download_model` before any network I/O. Blocks private IPs, localhost, and metadata endpoints (no domain allowlist), raising a non-retryable `ThreeDProviderError`.

- **Bug Fixes**
  - Added `_services_ssrf` using `SSRFProtection` and validate URLs before fetch.
  - Blocked URLs raise `ThreeDProviderError(retryable=False)`.
  - Added `tests/test_p0_ssrf_replicate.py` covering blocked ranges, valid CDN URLs, and non-retryable behavior.
  - Added Wave 2-A P0 status and Round Table publish decision memos.

<sup>Written for commit d94a3d320f131a8a2e5e15c4ac3ccf0ef902a89c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by implementing URL validation for model downloads to prevent unauthorized network access.

* **Documentation**
  * Added security findings documentation and comprehensive implementation status reports for recent security improvements.

* **Tests**
  * Added regression tests to verify URL validation and security protection mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->