### PR TITLE
fix(security): resolve 7 bandit HIGH/HIGH findings blocking security CI gate

### DIFF
--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -1767,6 +1767,44 @@
       "status": "FIXED",
       "fixed_at": "2026-05-19T19:50:00-07:00",
       "fixed_in_commit": "TBD-this-session"
+    },
+    {
+      "id": "bug-106",
+      "timestamp": "2026-06-09T19:05:00-07:00",
+      "error_message": "AttributeError: property 'name' of 'ReplicateProvider' object has no setter (tests/test_p0_ssrf_replicate.py fixture)",
+      "file": "tests/test_p0_ssrf_replicate.py",
+      "root_cause": "Fixture used ReplicateProvider.__new__ then assigned p.name, but name is a read-only @property returning a constant \u2014 assignment never worked; tests were committed without a green run",
+      "fix": "Removed the p.name assignment (property already returns 'replicate'); 20/20 pass",
+      "tags": [
+        "pytest",
+        "fixture",
+        "property",
+        "ssrf",
+        "worktree-sweep"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-06-09"
+    },
+    {
+      "id": "bug-119",
+      "timestamp": "2026-06-09T19:30:00-07:00",
+      "error_message": "Founder review: sg-006/sg-014 renders showed 'WRONG PRODUCT \u2014 rendered the signature windbreaker outfit'; 41 of 79 renders flagged total",
+      "file": "wordpress-theme/skyyrose-flagship/data/dossiers/mint-lavender-hoodie.md",
+      "root_cause": "sg-006/sg-014 dossiers describe a white chevron zip-up garment (the windbreaker-set design) instead of the mint pullover/sweats shown in their techflats \u2014 dossier was Claude-authored (cmem #11235) from wrong reference photos; its reference_image field points at a mislabeled file that is actually the black sherpa jacket. gpt-image-2 obeyed dossier text over the reference image.",
+      "fix": "sg-006/sg-014 added to config.EXCLUDED_SKUS until founder re-authors dossiers; founder verbatim corrections from review board injected into prompts via data/render-corrections.json; new photorealistic_not_flat QC gate; MATERIAL/PHOTOREALISM/BRANDING-IS-EXHAUSTIVE prompt directives",
+      "tags": [
+        "oai-render",
+        "dossier-contamination",
+        "wrong-product",
+        "canonical-sources",
+        "ml-drafted-dossier"
+      ],
+      "related_bugs": [
+        "bug-118"
+      ],
+      "occurrences": 1,
+      "last_seen": "2026-06-09T19:30:00-07:00"
     }
   ]
 }

--- a/.wolf/cerebrum.md
+++ b/.wolf/cerebrum.md
@@ -151,3 +151,15 @@ Before writing or modifying ANY code that touches an external library, SDK, or A
 This applies to: google-genai / Gemini SDK, FLUX API clients, httpx, Pydantic, LangGraph, any library not in stdlib.
 Goal: eliminate fix cycles caused by outdated or assumed API knowledge — spend tokens on features, not corrections.
 - **2026-04-29** — Wrote code changes to `audit_filter.py` and `vision_audit_agent.py` WITHOUT first running Context7 to verify the Gemini REST API pattern. The fixes themselves were correct (pure string logic), but the workflow was wrong. **Rule: Context7 `resolve` + `query-docs` is MANDATORY before every task that touches any external library — not just pipeline/workflow tasks. Every task. No exceptions.**
+
+### 2026-06-09 — Worktree sweep learnings
+- **Commits landed on a feature branch AFTER its PR merges are stranded** — `2b0d245df` (oai_render pipeline) sat on `feat/legal-policies-shipping-sync` a day after PR #532 merged; main never got it. After any PR merges, new work goes on a NEW branch off fresh main.
+- **`git cherry` patch-equivalence is useless against squash-merged history** — showed 0 equiv even for fully-landed work. Verify "is X in main" by grepping for the actual fix content, not by commit graph.
+- **Branches that never get a PR rot silently** — both genuinely-lost items (SSRF fix, pipeline3d) were worktree-local branches with no PR. Everything that entered the PR pipeline survived even with red CI. Push + PR immediately, draft if undecided.
+
+### 2026-06-09 — Render review board session
+- **Do-Not-Repeat:** sg-006/sg-014 dossiers were ML-drafted from wrong photos (cmem #11235) → rendered the wrong product entirely. Dossier rule is absolute: founder-authored only. Before ANY render run, spot-check that each dossier's garment-type lock matches its techflat.
+- **Key Learning:** `data/product-references/sg-006-and-sg-014-mint-lavender-set-techflat.jpeg` is MISLABELED — it's actually the black sherpa jacket photo. Don't trust product-reference filenames; verify content.
+- **Key Learning:** Founder review annotations live in `renders/oai/_review/review-state.json` (review board: `scripts/oai-render-review.py`, port 8944) and flow into prompts via `data/render-corrections.json` → FOUNDER CORRECTIONS block in prompt.py. Keyed by SKU, lines verbatim.
+- **Key Learning:** Split techflats (assets/techflats/split/) are FLAT vector drawings — SKUs whose only garment ref is a split techflat (bridge shorts, kids sets) rendered flat/vector-looking. PHOTOREALISM directive + photorealistic_not_flat QC gate added; if still failing, those SKUs need real photos.
+- **Key Learning:** renders/oai PNGs were deleted from disk ~2-4PM 2026-06-09 (culprit unknown; not mac-cleanup.sh). Paid render outputs must be backed up off-tree immediately after a run — evidence sheets + annotations now committed to the branch for durability.

--- a/agents/social_media_agent.py
+++ b/agents/social_media_agent.py
@@ -572,7 +572,7 @@ class SocialMediaAgent:
         hooks = collection.get("caption_hooks", [])
         if hooks:
             # Deterministic selection based on product name hash
-            hook_idx = int(hashlib.md5(name.encode()).hexdigest()[:8], 16) % len(hooks)
+            hook_idx = int(hashlib.md5(name.encode(), usedforsecurity=False).hexdigest()[:8], 16) % len(hooks)
             caption_parts.append(hooks[hook_idx])
 
         # Platform-specific formatting

--- a/imagery/product_training_dataset.py
+++ b/imagery/product_training_dataset.py
@@ -298,7 +298,7 @@ async def download_product_images(
 
             for idx, image_url in enumerate(product.image_urls):
                 # Generate cache filename from URL hash
-                url_hash = hashlib.md5(image_url.encode()).hexdigest()[:12]
+                url_hash = hashlib.md5(image_url.encode(), usedforsecurity=False).hexdigest()[:12]
                 extension = Path(image_url).suffix or ".jpg"
                 cache_path = sku_dir / f"image_{idx}_{url_hash}{extension}"
 

--- a/prompts/rag_mcp_hybrid.py
+++ b/prompts/rag_mcp_hybrid.py
@@ -194,7 +194,7 @@ class QueryCache:
     def _make_key(self, query: str, k: int, strategy: RetrievalStrategy) -> str:
         """Create cache key from query parameters."""
         key_str = f"{query}:{k}:{strategy.value}"
-        return hashlib.md5(key_str.encode()).hexdigest()
+        return hashlib.md5(key_str.encode(), usedforsecurity=False).hexdigest()
 
     def get(self, query: str, k: int, strategy: RetrievalStrategy) -> list[RetrievalResult] | None:
         """Get cached result if available."""

--- a/scripts/ecommerce_image_pro.py
+++ b/scripts/ecommerce_image_pro.py
@@ -381,7 +381,7 @@ class EcommerceImageProcessor:
 
         # Truncate and add hash for uniqueness
         if len(clean) > 25:
-            hash_suffix = hashlib.md5(name.encode()).hexdigest()[:6].upper()
+            hash_suffix = hashlib.md5(name.encode(), usedforsecurity=False).hexdigest()[:6].upper()
             clean = f"{clean[:20]}_{hash_suffix}"
 
         return f"{prefix}_{clean}".upper()

--- a/scripts/merge_all_training_data.py
+++ b/scripts/merge_all_training_data.py
@@ -120,7 +120,7 @@ def create_caption(filepath: str, filename: str) -> str:
 def file_hash(filepath: Path) -> str:
     """Get MD5 hash of file for deduplication."""
     with open(filepath, "rb") as f:
-        return hashlib.md5(f.read()).hexdigest()
+        return hashlib.md5(f.read(), usedforsecurity=False).hexdigest()
 
 
 def is_primary_image(filename: str) -> bool:

--- a/scripts/validate_wordpress_env.py
+++ b/scripts/validate_wordpress_env.py
@@ -53,19 +53,19 @@ def run_wp_cli(command: str) -> tuple[bool, str]:
     if not wp_path or not wp_cli:
         return False, "WP-CLI path not configured"
 
-    full_command = (
-        f'cd {wp_path} && php {wp_cli} {command} --allow-root 2>&1 | grep -v "Deprecated:"'
-    )
+    argv = ["php", wp_cli, *command.split(), "--allow-root"]
 
     try:
         result = subprocess.run(
-            full_command,
-            shell=True,
-            capture_output=True,
+            argv,
+            cwd=wp_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             text=True,
             timeout=30,
         )
-        return result.returncode == 0, result.stdout.strip()
+        output = "\n".join(line for line in result.stdout.splitlines() if "Deprecated:" not in line)
+        return result.returncode == 0, output.strip()
     except subprocess.TimeoutExpired:
         return False, "Command timed out"
     except Exception as e:

--- a/services/image_deduplication.py
+++ b/services/image_deduplication.py
@@ -109,7 +109,7 @@ class ImageDeduplicator:
         if algo == HashAlgorithm.SHA256:
             content_hash = hashlib.sha256(content).hexdigest()
         elif algo == HashAlgorithm.MD5:
-            content_hash = hashlib.md5(content).hexdigest()
+            content_hash = hashlib.md5(content, usedforsecurity=False).hexdigest()
         elif algo == HashAlgorithm.PHASH:
             content_hash = self._compute_phash(content)
         else:


### PR DESCRIPTION
## Summary
- 6x B324 weak-MD5 findings patched with `usedforsecurity=False` (cache keys / dedup hashes — non-cryptographic use)
- 1x B602 `shell=True` in `scripts/validate_wordpress_env.py` refactored to arg-list subprocess with `cwd` + Python-side grep filter

## Why
ci-local security gate fails on HIGH severity + HIGH confidence bandit findings. This debt blocks PR #539 and #540 from going green locally. GitHub Actions remains account-blocked, so ci-local mirror is the merge gate.

## Test plan
- [x] pre-push ci-local mirror passed (exit 0) on this branch
- [x] Diff is 13 insertions / 13 deletions across 7 files — no behavior change beyond subprocess refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves 7 Bandit HIGH/HIGH findings to unblock the ci-local security gate for PRs #539 and #540. No functional changes, except a safer subprocess call in WordPress env validation.

- **Bug Fixes**
  - Marked non-cryptographic `hashlib.md5` calls as `usedforsecurity=False` for cache keys and dedup hashes (6x B324).
  - Replaced `shell=True` in `scripts/validate_wordpress_env.py` (B602) with arg-list `subprocess.run`, `cwd` set, merged stdout/stderr, and a Python-side "Deprecated:" filter.

<sup>Written for commit 670f6bf81156b834380b7d11344bec675ddba91f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved test suite failures related to property assignment constraints.
  * Fixed render quality and product accuracy issues by implementing corrected reference imagery, updated prompt directives, and stricter quality-control gating to prevent branding/product misalignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->