### PR TITLE
style(agents): wrap md5 hook-index line to satisfy black line-length

### DIFF
--- a/agents/social_media_agent.py
+++ b/agents/social_media_agent.py
@@ -572,7 +572,9 @@ class SocialMediaAgent:
         hooks = collection.get("caption_hooks", [])
         if hooks:
             # Deterministic selection based on product name hash
-            hook_idx = int(hashlib.md5(name.encode(), usedforsecurity=False).hexdigest()[:8], 16) % len(hooks)
+            hook_idx = int(
+                hashlib.md5(name.encode(), usedforsecurity=False).hexdigest()[:8], 16
+            ) % len(hooks)
             caption_parts.append(hooks[hook_idx])
 
         # Platform-specific formatting


### PR DESCRIPTION
Single trailing style commit from the bandit-debt branch; the security fixes (670f6bf81) already merged via PR #541. Zero overlap with open work. Part of 2026-06-10 consolidation sweep.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrapped the MD5-based hook index computation in `agents/social_media_agent.py` to meet `black` line-length limits. Style-only change with no functional impact.

<sup>Written for commit fad555a507bab4440e4aa9b3f56d195c0f5a7d2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting in caption generation logic for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->