### PR TITLE
fix(render): skip paired looks whose member SKU is excluded

### DIFF
--- a/scripts/oai_render/pipeline.py
+++ b/scripts/oai_render/pipeline.py
@@ -368,14 +368,29 @@ def run(
                 if references.has_back_source(s):
                     plans.append(plan_sku(s, catalog, dossier_index, style="ghost", view="back"))
             elif st == "on-model":
-                pairs = references.get_pairs_for_sku(s)
+                # A pair is only renderable when NO member is excluded — an excluded
+                # member's dossier is known-bad and would corrupt the paired look.
+                pairs = [
+                    pr
+                    for pr in references.get_pairs_for_sku(s)
+                    if not any(m in config.EXCLUDED_SKUS for m in pr.skus)
+                ]
+                for pr in references.get_pairs_for_sku(s):
+                    excluded = [m for m in pr.skus if m in config.EXCLUDED_SKUS]
+                    if excluded:
+                        log.warning(
+                            "Skipping paired look %s: member(s) %s excluded (%s)",
+                            pr.pair_id,
+                            ", ".join(excluded),
+                            "; ".join(config.EXCLUDED_SKUS[m] for m in excluded)[:120],
+                        )
                 if pairs:
                     for pr in pairs:  # paired SKU: one paired look per pair, no solo on-model
                         if pr.pair_id in seen_pairs:
                             continue
                         seen_pairs.add(pr.pair_id)
                         plans.append(plan_pair(pr, catalog, dossier_index))
-                else:
+                else:  # no renderable pair → solo on-model so the SKU still gets a hero
                     plans.append(
                         plan_sku(s, catalog, dossier_index, style="on-model", view="front")
                     )

--- a/tests/pipelines/test_oai_render_hardening.py
+++ b/tests/pipelines/test_oai_render_hardening.py
@@ -362,3 +362,16 @@ def test_qc_schema_gates_flat_renders():
 def test_contaminated_mint_lavender_skus_excluded():
     assert "sg-006" in config.EXCLUDED_SKUS
     assert "sg-014" in config.EXCLUDED_SKUS
+
+
+def test_pair_with_excluded_member_falls_back_to_solo(monkeypatch):
+    from scripts.oai_render import pipeline, references
+
+    monkeypatch.setitem(config.EXCLUDED_SKUS, "sg-014", "test: contaminated dossier")
+    catalog = references.load_catalog()
+    dossiers = references.build_dossier_index()
+    result = pipeline.run(["sg-013"], catalog, dossiers, styles=["on-model"], dry_run=True)
+    plans = [p for p in result["plans"] if p.error is None]
+    assert len(plans) == 1
+    assert plans[0].style == "on-model"
+    assert not plans[0].output_slug.startswith("pair__")


### PR DESCRIPTION
## Summary

- Follow-up to #540: this commit (`2b2ab382a`) was the local branch tip and was stranded when only `4091879215` was pushed in that PR.
- Prevents `EXCLUDED_SKUS` members (e.g. `sg-014`) from injecting contaminated dossiers into paired-look prompts; pair is skipped with a logged reason and the requesting SKU falls back to a solo render.
- Part of the 2026-06-10 consolidation sweep.

## Test plan

- [ ] `tests/pipelines/test_oai_render_hardening.py` — all 25 tests green (incl. 1 new paired-looks skip test)
- [ ] `tests/pipelines/clothing_3d/` — 27 tests green (no regressions)
- [ ] Total: 52/52 passed locally in worktree at `2b2ab382a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip paired-look renders when any member SKU is in `EXCLUDED_SKUS`. We log the reason and fall back to a solo on-model render so the requesting SKU still gets a hero image.

- **Bug Fixes**
  - Filter out pairs with any excluded member during planning.
  - Log skipped pair with `pair_id`, excluded SKUs, and reason.
  - Fallback to a solo on-model plan when no valid pair exists.
  - Added a test for the fallback; existing tests remain green.

<sup>Written for commit 2b2ab382a49478de8dc68be5da121c8f114225b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

