### PR TITLE
fix(mcp): devskyy stdio server runs standalone (stderr diagnostics + empty-key header) + fastmcp 3.0 pin

### DIFF
--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -2178,5 +2178,25 @@
     ],
     "occurrences": 1,
     "last_seen": "2026-06-15"
+  },
+  {
+    "id": "bug-136",
+    "timestamp": "2026-06-15",
+    "error_message": "devskyy_list_agents tool -> GET /api/v1/agents/list returned 422 Unprocessable Content; the agent list never loaded.",
+    "file": "mcp_tools/tools/resources.py",
+    "root_cause": "The tool requested endpoint 'agents/list'. No such route exists: agents_router has GET / (prefix /api/v1/agents, JWT-gated) and a /{agent_name} catch-all. '/api/v1/agents/list' fell through to the catch-all and failed validation (422). The canonical unauthenticated agent-list endpoint is GET /api/v1/agents (api/v1/monitoring.py:540), which returns 200.",
+    "fix": "Repoint the tool to _make_api_request('agents') -> GET /api/v1/agents (200, no auth). Also dropped the hardcoded '54 agents' wording per project_agent_count (count is API-driven). Added tests/mcp/test_api_client.py asserting endpoint path + Bearer-header behavior.",
+    "tags": [
+      "mcp",
+      "fastapi",
+      "routing",
+      "422",
+      "devskyy_list_agents"
+    ],
+    "related_bugs": [
+      "bug-135"
+    ],
+    "occurrences": 1,
+    "last_seen": "2026-06-15"
   }
 ]

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -5,7 +5,7 @@
     "error_message": "Significant refactor of ",
     "file": "wordpress-theme/skyyrose-flagship/assets/css/preorder-gateway.css",
     "root_cause": "2 lines replaced/restructured",
-    "fix": "Rewrote 5→12 lines (2 removed) | Also: .po-rv {; .po-rv--visible {",
+    "fix": "Rewrote 5\u219212 lines (2 removed) | Also: .po-rv {; .po-rv--visible {",
     "tags": [
       "auto-detected",
       "refactor",
@@ -21,7 +21,7 @@
     "error_message": "Significant refactor of ",
     "file": "wordpress-theme/skyyrose-flagship/assets/js/preorder-gateway.js",
     "root_cause": "2 lines replaced/restructured",
-    "fix": "Rewrote 21→26 lines (2 removed)",
+    "fix": "Rewrote 21\u219226 lines (2 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -36,7 +36,7 @@
     "timestamp": "2026-04-08T00:59:15.259Z",
     "error_message": "Missing error handling in after_compositor",
     "file": "../elite-layer-2/skyyrose/elite_studio/graph/edges.py",
-    "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+    "root_cause": "Code path had no error handling \u2014 exceptions would propagate uncaught",
     "fix": "Added try/catch block",
     "tags": [
       "auto-detected",
@@ -68,7 +68,7 @@
     "timestamp": "2026-04-08T03:20:12.400Z",
     "error_message": "Missing await",
     "file": "../elite-layer-3/agent_sdk/worker.py",
-    "root_cause": "Async call without await — returned Promise instead of value",
+    "root_cause": "Async call without await \u2014 returned Promise instead of value",
     "fix": "Added await to async call",
     "tags": [
       "auto-detected",
@@ -101,7 +101,7 @@
     "error_message": "Significant refactor of ",
     "file": "scripts/deploy-theme.sh",
     "root_cause": "7 lines replaced/restructured",
-    "fix": "Rewrote 14→25 lines (7 removed) | Also: # 2. Enable maintenance mode (DEPLOY-02); wp_remote \"maintenance-mode activate\" | Also: scp -P \"${SSH_PORT:-22}\" $key_flag -o StrictHostKe; ssh -p \"${SSH_PORT:-22}\" $key_flag -o StrictHostKe",
+    "fix": "Rewrote 14\u219225 lines (7 removed) | Also: # 2. Enable maintenance mode (DEPLOY-02); wp_remote \"maintenance-mode activate\" | Also: scp -P \"${SSH_PORT:-22}\" $key_flag -o StrictHostKe; ssh -p \"${SSH_PORT:-22}\" $key_flag -o StrictHostKe",
     "tags": [
       "auto-detected",
       "refactor",
@@ -133,7 +133,7 @@
     "error_message": "Significant refactor of ",
     "file": "../elite-layer-3/skyyrose/elite_studio/queue/dead_letter.py",
     "root_cause": "2 lines replaced/restructured",
-    "fix": "Rewrote 4→4 lines (2 removed)",
+    "fix": "Rewrote 4\u21924 lines (2 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -149,7 +149,7 @@
     "error_message": "Significant refactor of ",
     "file": "../elite-layer-3/tests/test_elite_queue_consumer.py",
     "root_cause": "6 lines replaced/restructured",
-    "fix": "Rewrote 19→12 lines (6 removed)",
+    "fix": "Rewrote 19\u219212 lines (6 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -165,7 +165,7 @@
     "error_message": "Significant refactor of ",
     "file": "../elite-layer-3/skyyrose/elite_studio/queue/consumer.py",
     "root_cause": "3 lines replaced/restructured",
-    "fix": "Rewrote 42→63 lines (3 removed) | Also: logger.error(\"EliteStudioWorker: job %s failed: %s; self._dlq.move_to_dlq(",
+    "fix": "Rewrote 42\u219263 lines (3 removed) | Also: logger.error(\"EliteStudioWorker: job %s failed: %s; self._dlq.move_to_dlq(",
     "tags": [
       "auto-detected",
       "refactor",
@@ -245,7 +245,7 @@
     "error_message": "Significant refactor of ",
     "file": "../elite-layer-4/tests/test_quality_classifier.py",
     "root_cause": "16 lines replaced/restructured",
-    "fix": "Rewrote 61→78 lines (16 removed)",
+    "fix": "Rewrote 61\u219278 lines (16 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -277,7 +277,7 @@
     "error_message": "Significant refactor of ",
     "file": "skyyrose/elite_studio/character/agent.py",
     "root_cause": "10 lines replaced/restructured",
-    "fix": "Rewrote 17→20 lines (10 removed)",
+    "fix": "Rewrote 17\u219220 lines (10 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -308,8 +308,8 @@
     "timestamp": "2026-04-14T20:27:02.379Z",
     "error_message": "CSS fix: hover",
     "file": "frontend/components/mascot/MascotBubble.tsx",
-    "root_cause": "hover: scale-110 hover:shadow-xl hover:shadow-[#B76E79]/40 → scale-105",
-    "fix": "Changed hover: scale-110 hover:shadow-xl hover:shadow-[#B76E79]/40 → scale-105",
+    "root_cause": "hover: scale-110 hover:shadow-xl hover:shadow-[#B76E79]/40 \u2192 scale-105",
+    "fix": "Changed hover: scale-110 hover:shadow-xl hover:shadow-[#B76E79]/40 \u2192 scale-105",
     "tags": [
       "auto-detected",
       "style-fix",
@@ -325,7 +325,7 @@
     "error_message": "Significant refactor of ",
     "file": "frontend/components/mascot/MascotBubble.tsx",
     "root_cause": "2 lines replaced/restructured",
-    "fix": "Rewrote 11→17 lines (2 removed) | Also: import Image from 'next/image';; // Canonical Skyy character image — the real masco | Also: <div className=\"h-10 w-10 rounded-full bg-white/20; <Image",
+    "fix": "Rewrote 11\u219217 lines (2 removed) | Also: import Image from 'next/image';; // Canonical Skyy character image \u2014 the real masco | Also: <div className=\"h-10 w-10 rounded-full bg-white/20; <Image",
     "tags": [
       "auto-detected",
       "refactor",
@@ -357,7 +357,7 @@
     "error_message": "Wrong operator: || should be &&",
     "file": "wordpress-theme/skyyrose-flagship/assets/js/skyy-3d.js",
     "root_cause": "Used \"||\" instead of \"&&\"",
-    "fix": "Changed operator || → &&",
+    "fix": "Changed operator || \u2192 &&",
     "tags": [
       "auto-detected",
       "operator-fix",
@@ -389,7 +389,7 @@
     "error_message": "Significant refactor of ",
     "file": "tests/test_character_system.py",
     "root_cause": "2 lines replaced/restructured",
-    "fix": "Rewrote 4→5 lines (2 removed)",
+    "fix": "Rewrote 4\u21925 lines (2 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -405,7 +405,7 @@
     "error_message": "Significant refactor of ",
     "file": "wordpress-theme/skyyrose-flagship/assets/js/skyy-3d.js",
     "root_cause": "5 lines replaced/restructured",
-    "fix": "Rewrote 8→3 lines (5 removed)",
+    "fix": "Rewrote 8\u21923 lines (5 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -469,7 +469,7 @@
     "error_message": "Wrong reference: true should be false",
     "file": ".claude/settings.json",
     "root_cause": "Used \"true\" instead of \"false\"",
-    "fix": "Changed true → false",
+    "fix": "Changed true \u2192 false",
     "tags": [
       "auto-detected",
       "wrong-reference",
@@ -500,7 +500,7 @@
     "timestamp": "2026-04-16T00:36:57.368Z",
     "error_message": "Missing error handling in catches",
     "file": "../.claude/agents/gsd-codebase-mapper.md",
-    "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+    "root_cause": "Code path had no error handling \u2014 exceptions would propagate uncaught",
     "fix": "Added try/catch block",
     "tags": [
       "auto-detected",
@@ -517,7 +517,7 @@
     "error_message": "Wrong reference: agent_sdk should be sdk",
     "file": "tests/test_hybrid_simple.py",
     "root_cause": "Used \"agent_sdk\" instead of \"sdk\"",
-    "fix": "Changed agent_sdk → sdk",
+    "fix": "Changed agent_sdk \u2192 sdk",
     "tags": [
       "auto-detected",
       "wrong-reference",
@@ -532,7 +532,7 @@
     "timestamp": "2026-04-16T00:37:50.155Z",
     "error_message": "Missing error handling in unknown",
     "file": "../.claude/agents/gsd-integration-checker.md",
-    "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+    "root_cause": "Code path had no error handling \u2014 exceptions would propagate uncaught",
     "fix": "Added try/catch block",
     "tags": [
       "auto-detected",
@@ -549,7 +549,7 @@
     "error_message": "Wrong reference: agent_sdk should be sdk",
     "file": "tests/integration/test_hybrid_integration.py",
     "root_cause": "Used \"agent_sdk\" instead of \"sdk\"",
-    "fix": "Changed agent_sdk → sdk",
+    "fix": "Changed agent_sdk \u2192 sdk",
     "tags": [
       "auto-detected",
       "wrong-reference",
@@ -565,7 +565,7 @@
     "error_message": "Wrong reference: agent_sdk should be sdk",
     "file": "examples/multi_agent_workflow.py",
     "root_cause": "Used \"agent_sdk\" instead of \"sdk\"",
-    "fix": "Changed agent_sdk → sdk",
+    "fix": "Changed agent_sdk \u2192 sdk",
     "tags": [
       "auto-detected",
       "wrong-reference",
@@ -581,7 +581,7 @@
     "error_message": "Wrong reference: agent_sdk should be sdk",
     "file": "examples/basic_query.py",
     "root_cause": "Used \"agent_sdk\" instead of \"sdk\"",
-    "fix": "Changed agent_sdk → sdk",
+    "fix": "Changed agent_sdk \u2192 sdk",
     "tags": [
       "auto-detected",
       "wrong-reference",
@@ -597,7 +597,7 @@
     "error_message": "Wrong reference: agent_sdk should be sdk",
     "file": "examples/continuous_conversation.py",
     "root_cause": "Used \"agent_sdk\" instead of \"sdk\"",
-    "fix": "Changed agent_sdk → sdk",
+    "fix": "Changed agent_sdk \u2192 sdk",
     "tags": [
       "auto-detected",
       "wrong-reference",
@@ -613,7 +613,7 @@
     "error_message": "Significant refactor of ",
     "file": "tasks/todo.md",
     "root_cause": "7 lines replaced/restructured",
-    "fix": "Rewrote 7→7 lines (7 removed)",
+    "fix": "Rewrote 7\u21927 lines (7 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -629,7 +629,7 @@
     "error_message": "Significant refactor of ",
     "file": "sdk/python/agent_sdk/super_agents/__init__.py",
     "root_cause": "6 lines replaced/restructured",
-    "fix": "Rewrote 6→6 lines (6 removed)",
+    "fix": "Rewrote 6\u21926 lines (6 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -661,7 +661,7 @@
     "error_message": "Wrong reference: str should be StrEnum",
     "file": "services/image_ingestion.py",
     "root_cause": "Used \"str\" instead of \"StrEnum\"",
-    "fix": "Changed str → StrEnum",
+    "fix": "Changed str \u2192 StrEnum",
     "tags": [
       "auto-detected",
       "wrong-reference",
@@ -692,7 +692,7 @@
     "timestamp": "2026-04-16T20:42:51.359Z",
     "error_message": "Missing error handling in unknown",
     "file": "tests/test_rag_integration.py",
-    "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+    "root_cause": "Code path had no error handling \u2014 exceptions would propagate uncaught",
     "fix": "Added try/catch block",
     "tags": [
       "auto-detected",
@@ -709,7 +709,7 @@
     "error_message": "Significant refactor of ",
     "file": "scripts/generate_catalog.py",
     "root_cause": "2 lines replaced/restructured",
-    "fix": "Rewrote 16→21 lines (2 removed)",
+    "fix": "Rewrote 16\u219221 lines (2 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -725,7 +725,7 @@
     "error_message": "Significant refactor of ",
     "file": "scripts/generate_catalog.py",
     "root_cause": "18 lines replaced/restructured",
-    "fix": "Rewrote 21→3 lines (18 removed)",
+    "fix": "Rewrote 21\u21923 lines (18 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -741,7 +741,7 @@
     "error_message": "Significant refactor of ",
     "file": "skyyrose/elite_studio/catalog.py",
     "root_cause": "2 lines replaced/restructured",
-    "fix": "Rewrote 16→20 lines (2 removed) | Also: # 4. jerseys.sku_to_patch — every mapped SKU must ; jersey_series = series_by_name.get(\"Jersey Series\" | Also: # 4. jerseys.sku_to_patch — every mapped SKU must ; #    (We intentionally do NOT require membership i",
+    "fix": "Rewrote 16\u219220 lines (2 removed) | Also: # 4. jerseys.sku_to_patch \u2014 every mapped SKU must ; jersey_series = series_by_name.get(\"Jersey Series\" | Also: # 4. jerseys.sku_to_patch \u2014 every mapped SKU must ; #    (We intentionally do NOT require membership i",
     "tags": [
       "auto-detected",
       "refactor",
@@ -756,7 +756,7 @@
     "timestamp": "2026-04-17T13:52:01.770Z",
     "error_message": "Missing error handling in _validate_integrity",
     "file": "skyyrose/elite_studio/catalog.py",
-    "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+    "root_cause": "Code path had no error handling \u2014 exceptions would propagate uncaught",
     "fix": "Added try/catch block",
     "tags": [
       "auto-detected",
@@ -773,7 +773,7 @@
     "error_message": "Significant refactor of ",
     "file": "scripts/generate_catalog.py",
     "root_cause": "3 lines replaced/restructured",
-    "fix": "Rewrote 8→10 lines (3 removed) | Also: \"Jersey Series\": {; \"Every SkyyRose jersey lives here. Sport-specific ",
+    "fix": "Rewrote 8\u219210 lines (3 removed) | Also: \"Jersey Series\": {; \"Every SkyyRose jersey lives here. Sport-specific ",
     "tags": [
       "auto-detected",
       "refactor",
@@ -789,7 +789,7 @@
     "error_message": "Wrong reference: legacy should be d99",
     "file": "skyyrose/elite_studio/tests/test_catalog_validation.py",
     "root_cause": "Used \"legacy\" instead of \"d99\"",
-    "fix": "Changed legacy → d99",
+    "fix": "Changed legacy \u2192 d99",
     "tags": [
       "auto-detected",
       "wrong-reference",
@@ -805,7 +805,7 @@
     "error_message": "Significant refactor of ",
     "file": "skyyrose/elite_studio/catalog.py",
     "root_cause": "2 lines replaced/restructured",
-    "fix": "Rewrote 4→6 lines (2 removed)",
+    "fix": "Rewrote 4\u21926 lines (2 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -821,7 +821,7 @@
     "error_message": "Significant refactor of ",
     "file": "skyyrose/elite_studio/prompts/library.py",
     "root_cause": "3 lines replaced/restructured",
-    "fix": "Rewrote 7→9 lines (3 removed)",
+    "fix": "Rewrote 7\u21929 lines (3 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -853,7 +853,7 @@
     "error_message": "Significant refactor of ",
     "file": "skyyrose/elite_studio/tests/test_brand_enforcement.py",
     "root_cause": "11 lines replaced/restructured",
-    "fix": "Rewrote 37→68 lines (11 removed)",
+    "fix": "Rewrote 37\u219268 lines (11 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -885,7 +885,7 @@
     "error_message": "Significant refactor of ",
     "file": "core/middleware/tenant.py",
     "root_cause": "4 lines replaced/restructured",
-    "fix": "Rewrote 16→29 lines (4 removed) | Also: # decode_token without verification — we only want; options={\"verify_signature\": False, \"verify_exp\": ",
+    "fix": "Rewrote 16\u219229 lines (4 removed) | Also: # decode_token without verification \u2014 we only want; options={\"verify_signature\": False, \"verify_exp\": ",
     "tags": [
       "auto-detected",
       "refactor",
@@ -900,7 +900,7 @@
     "timestamp": "2026-04-19T00:43:18.486Z",
     "error_message": "Missing await",
     "file": "skyyrose/elite_studio/queue/producer.py",
-    "root_cause": "Async call without await — returned Promise instead of value",
+    "root_cause": "Async call without await \u2014 returned Promise instead of value",
     "fix": "Added await to async call | Also: return _run_sync(_async_enqueue(job_data)); async def aenqueue_creative(",
     "tags": [
       "auto-detected",
@@ -949,7 +949,7 @@
     "error_message": "Significant refactor of ",
     "file": "skyyrose/elite_studio/prompts/cache.py",
     "root_cause": "3 lines replaced/restructured",
-    "fix": "Rewrote 4→24 lines (3 removed) | Also: def check(self, prompt: str, intent: str, threshol; key = f\"{self.CACHE_PREFIX}:{_prompt_hash(prompt,  | Also: def store(self, original: str, enhanced: Any, ttl:; key = f\"{self.CACHE_PREFIX}:{_prompt_hash(original",
+    "fix": "Rewrote 4\u219224 lines (3 removed) | Also: def check(self, prompt: str, intent: str, threshol; key = f\"{self.CACHE_PREFIX}:{_prompt_hash(prompt,  | Also: def store(self, original: str, enhanced: Any, ttl:; key = f\"{self.CACHE_PREFIX}:{_prompt_hash(original",
     "tags": [
       "auto-detected",
       "refactor",
@@ -965,7 +965,7 @@
     "error_message": "Wrong reference: _prompt_hash should be _context_digest",
     "file": "skyyrose/elite_studio/prompts/enhancer.py",
     "root_cause": "Used \"_prompt_hash\" instead of \"_context_digest\"",
-    "fix": "Changed _prompt_hash → _context_digest",
+    "fix": "Changed _prompt_hash \u2192 _context_digest",
     "tags": [
       "auto-detected",
       "wrong-reference",
@@ -981,7 +981,7 @@
     "error_message": "Significant refactor of ",
     "file": "skyyrose/elite_studio/prompts/enhancer.py",
     "root_cause": "3 lines replaced/restructured",
-    "fix": "Rewrote 6→10 lines (3 removed)",
+    "fix": "Rewrote 6\u219210 lines (3 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -1012,7 +1012,7 @@
     "timestamp": "2026-04-19T00:51:54.224Z",
     "error_message": "Missing error handling in closeDialog",
     "file": "wordpress-theme/skyyrose-flagship/assets/js/smart-showcase.js",
-    "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+    "root_cause": "Code path had no error handling \u2014 exceptions would propagate uncaught",
     "fix": "Added try/catch block",
     "tags": [
       "auto-detected",
@@ -1029,7 +1029,7 @@
     "error_message": "Significant refactor of ",
     "file": "wordpress-theme/skyyrose-flagship/assets/js/experience-analyzer.js",
     "root_cause": "5 lines replaced/restructured",
-    "fix": "Rewrote 10→14 lines (5 removed)",
+    "fix": "Rewrote 10\u219214 lines (5 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -1061,7 +1061,7 @@
     "error_message": "Significant refactor of ",
     "file": "core/middleware/tenant.py",
     "root_cause": "3 lines replaced/restructured",
-    "fix": "Rewrote 17→15 lines (3 removed) | Also: # No secret configured — refuse to trust any token; # to unverified decoding; that was the previous se",
+    "fix": "Rewrote 17\u219215 lines (3 removed) | Also: # No secret configured \u2014 refuse to trust any token; # to unverified decoding; that was the previous se",
     "tags": [
       "auto-detected",
       "refactor",
@@ -1093,7 +1093,7 @@
     "error_message": "Significant refactor of ",
     "file": "sdk/python/agent_sdk/worker.py",
     "root_cause": "5 lines replaced/restructured",
-    "fix": "Rewrote 8→6 lines (5 removed)",
+    "fix": "Rewrote 8\u21926 lines (5 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -1108,7 +1108,7 @@
     "timestamp": "2026-04-19T07:13:31.997Z",
     "error_message": "Missing await",
     "file": "../.claude/plans/i-want-you-to-shiny-clarke.md",
-    "root_cause": "Async call without await — returned Promise instead of value",
+    "root_cause": "Async call without await \u2014 returned Promise instead of value",
     "fix": "Added await to async call",
     "tags": [
       "auto-detected",
@@ -1125,7 +1125,7 @@
     "error_message": "Incorrect value in code",
     "file": "../.claude/plans/i-want-you-to-shiny-clarke.md",
     "root_cause": "Had `collection=\"",
-    "fix": "Changed to `api/v1/media.py:43–51`",
+    "fix": "Changed to `api/v1/media.py:43\u201351`",
     "tags": [
       "auto-detected",
       "wrong-value",
@@ -1141,7 +1141,7 @@
     "error_message": "Significant refactor of ",
     "file": "../.claude/plans/i-want-you-to-shiny-clarke.md",
     "root_cause": "6 lines replaced/restructured",
-    "fix": "Rewrote 6→8 lines (6 removed)",
+    "fix": "Rewrote 6\u21928 lines (6 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -1157,7 +1157,7 @@
     "error_message": "Significant refactor of ",
     "file": "scripts/deploy-theme.sh",
     "root_cause": "4 lines replaced/restructured",
-    "fix": "Rewrote 14→24 lines (4 removed) | Also: local key_path=\"${SSH_KEY_PATH:-$HOME/.ssh/skyyros; local ssh_opts=\"-o StrictHostKeyChecking=yes -p ${ | Also: # 3. Transfer files (DEPLOY-01); log_error \"Site may be in a broken state — investi | Also: declare -A PHASE_TIMES=(); declare -A PHASE_STARTED=()",
+    "fix": "Rewrote 14\u219224 lines (4 removed) | Also: local key_path=\"${SSH_KEY_PATH:-$HOME/.ssh/skyyros; local ssh_opts=\"-o StrictHostKeyChecking=yes -p ${ | Also: # 3. Transfer files (DEPLOY-01); log_error \"Site may be in a broken state \u2014 investi | Also: declare -A PHASE_TIMES=(); declare -A PHASE_STARTED=()",
     "tags": [
       "auto-detected",
       "refactor",
@@ -1173,7 +1173,7 @@
     "error_message": "Significant refactor of ",
     "file": "scripts/deploy-theme.sh",
     "root_cause": "12 lines replaced/restructured",
-    "fix": "Rewrote 13→5 lines (12 removed)",
+    "fix": "Rewrote 13\u21925 lines (12 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -1189,7 +1189,7 @@
     "error_message": "Significant refactor of ",
     "file": "scripts/deploy-theme.sh",
     "root_cause": "28 lines replaced/restructured",
-    "fix": "Rewrote 41→14 lines (28 removed)",
+    "fix": "Rewrote 41\u219214 lines (28 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -1205,7 +1205,7 @@
     "error_message": "Wrong reference: DEPLOY_LOCK_FD should be DEPLOY_LOCK_HELD",
     "file": "scripts/deploy-theme.sh",
     "root_cause": "Used \"DEPLOY_LOCK_FD\" instead of \"DEPLOY_LOCK_HELD\"",
-    "fix": "Changed DEPLOY_LOCK_FD → DEPLOY_LOCK_HELD",
+    "fix": "Changed DEPLOY_LOCK_FD \u2192 DEPLOY_LOCK_HELD",
     "tags": [
       "auto-detected",
       "wrong-reference",
@@ -1237,7 +1237,7 @@
     "error_message": "Significant refactor of ",
     "file": "../.claude/plans/well-lets-audit-separately-humming-beacon.md",
     "root_cause": "5 lines replaced/restructured",
-    "fix": "Rewrote 6→27 lines (5 removed)",
+    "fix": "Rewrote 6\u219227 lines (5 removed)",
     "tags": [
       "auto-detected",
       "refactor",
@@ -1300,8 +1300,8 @@
     "timestamp": "2026-04-19T17:32:01.512Z",
     "error_message": "CSS fix: value",
     "file": "frontend/app/admin/social-media/page.tsx",
-    "root_cause": "value: 'lh-004', label: 'Love Hurts Varsity Jacket', collection: 'love-hurts' → 'lh-006', label: 'The Fannie', collection: 'love-hurts'",
-    "fix": "Changed value: 'lh-004', label: 'Love Hurts Varsity Jacket', collection: 'love-hurts' → 'lh-006', label: 'The Fannie', collection: 'love-hurts'",
+    "root_cause": "value: 'lh-004', label: 'Love Hurts Varsity Jacket', collection: 'love-hurts' \u2192 'lh-006', label: 'The Fannie', collection: 'love-hurts'",
+    "fix": "Changed value: 'lh-004', label: 'Love Hurts Varsity Jacket', collection: 'love-hurts' \u2192 'lh-006', label: 'The Fannie', collection: 'love-hurts'",
     "tags": [
       "auto-detected",
       "style-fix",
@@ -1314,10 +1314,10 @@
   {
     "id": "bug-091",
     "timestamp": "2026-04-27T22:34:00.000Z",
-    "error_message": "front-page.php uses wc_get_products() to count products per collection — breaks when WooCommerce categories are not synced to CSV catalog",
+    "error_message": "front-page.php uses wc_get_products() to count products per collection \u2014 breaks when WooCommerce categories are not synced to CSV catalog",
     "file": "wordpress-theme/skyyrose-flagship/front-page.php",
     "root_cause": "wc_get_products() queries WC product categories, which are separate from the CSV catalog. Category sync is not guaranteed. Result: count is 0 when WC categories don't exist.",
-    "fix": "Replaced wc_get_products() block with count(skyyrose_get_collection_products($col['slug'])) — reads directly from CSV catalog helper",
+    "fix": "Replaced wc_get_products() block with count(skyyrose_get_collection_products($col['slug'])) \u2014 reads directly from CSV catalog helper",
     "tags": [
       "wc_get_products",
       "catalog",
@@ -1355,10 +1355,10 @@
   {
     "id": "bug-093",
     "timestamp": "2026-04-27T22:34:00.000Z",
-    "error_message": "TypeError: e.target.closest is not a function — SVG elements and other non-Element nodes dispatched to document-level event listeners don't have .closest()",
+    "error_message": "TypeError: e.target.closest is not a function \u2014 SVG elements and other non-Element nodes dispatched to document-level event listeners don't have .closest()",
     "file": "wordpress-theme/skyyrose-flagship/assets/js/experience-analyzer.js",
     "root_cause": "SVG child elements (path, circle, use, etc.) are SVGElement not HTMLElement and may not implement .closest() in older browsers. document-level capture listeners receive events from any element on the page including SVG internals.",
-    "fix": "Added typeof guard before every .closest() call: getCardData(), mouseenter listener, mouseleave listener, click listener — each now checks !el || typeof el.closest !== 'function' before calling.",
+    "fix": "Added typeof guard before every .closest() call: getCardData(), mouseenter listener, mouseleave listener, click listener \u2014 each now checks !el || typeof el.closest !== 'function' before calling.",
     "tags": [
       "svg",
       "closest",
@@ -1373,7 +1373,7 @@
   {
     "id": "bug-094",
     "timestamp": "2026-04-27T22:34:00.000Z",
-    "error_message": "404.php references skyyrose-mascot-reference.png which does not exist in assets/images/mascot/ — only skyy-canonical.jpeg exists",
+    "error_message": "404.php references skyyrose-mascot-reference.png which does not exist in assets/images/mascot/ \u2014 only skyy-canonical.jpeg exists",
     "file": "wordpress-theme/skyyrose-flagship/404.php",
     "root_cause": "404.php used an old filename (skyyrose-mascot-reference.png) that was never created. The canonical mascot file is skyy-canonical.jpeg.",
     "fix": "Replaced both references (path and URL) to skyyrose-mascot-reference.png with skyy-canonical.jpeg in the mascot fallback block of 404.php.",
@@ -1392,7 +1392,7 @@
     "timestamp": "2026-05-03T12:29:48.891633+00:00",
     "error_message": "[Resolved] Voyage free-tier rate limit (10K TPM, 3 RPM) blocked full catalog indexing",
     "file": "scripts/index_skyyrose_catalog.py + Voyage path via CatalogRetriever",
-    "root_cause": "No payment method on Voyage account → free-tier throttle. Catalog (~32K tokens) blew the 10K TPM cap.",
+    "root_cause": "No payment method on Voyage account \u2192 free-tier throttle. Catalog (~32K tokens) blew the 10K TPM cap.",
     "fix": "Added payment method on https://dashboard.voyageai.com/. Standard rate limits unlocked. 33-SKU catalog indexes in 1.60s. 200M free tokens still apply.",
     "tags": [
       "voyage",
@@ -1408,10 +1408,10 @@
   {
     "id": "bug-096",
     "timestamp": "2026-05-11T20:50:00.000Z",
-    "error_message": "Tripo generate_multiview_image hallucinated brand canon on 30 SKUs (120 renders) — invented 'rose-on-cloud' motif on br-001, rendered br-011 hockey jersey as cyan/teal hoodie with invented crest, applied off-canon patch to wrong location on sg-007 signature beanie",
+    "error_message": "Tripo generate_multiview_image hallucinated brand canon on 30 SKUs (120 renders) \u2014 invented 'rose-on-cloud' motif on br-001, rendered br-011 hockey jersey as cyan/teal hoodie with invented crest, applied off-canon patch to wrong location on sg-007 signature beanie",
     "file": "scripts/tripo_dispatch.py + skyyrose/elite_studio/agents/tripo_agent.py",
-    "root_cause": "Tripo `generate_multiview_image` template runs FLUX.1 Kontext with naked image-only input — accepts NO prompt, NO logo overlay, NO dossier branding spec, NO palette token. With no canon anchor, FLUX defaults to training-set priors. Dispatch boundary had no guard distinguishing branded SKUs (which Tripo cannot render correctly) from unbranded clean tech-flats (which it can). Additionally, SKUs with empty catalog `image` column silently fell back to `front_model_image` (a model-on shot), which the template re-builds from scratch — changing garment type entirely (jersey → hoodie). No QA gate caught the regression; STOP-AND-SHOW manifest showed cost only, no output preview.",
-    "fix": "scripts/tripo_dispatch.py — added classify_skus() function that blocks at the dispatch boundary: (1) SKUs whose dossier frontmatter has `logo_reference:` populated are blocked as BRANDED with directive to route via ADK render_pipeline. (2) SKUs with empty `image` column or missing tech-flat file are blocked as NO TECH-FLAT. --force-branded escape hatch added with WARNING and still-required explicit y to dispatch. Per-SKU block reason printed in manifest before y/N prompt. 12 unit tests in tests/test_tripo_dispatch_guards.py covering both guards plus escape hatch. renders/output/tripo/QUARANTINE.md written marking all 120 existing outputs as discard-do-not-publish. Cerebrum Do-Not-Repeat entry added 2026-05-11.",
+    "root_cause": "Tripo `generate_multiview_image` template runs FLUX.1 Kontext with naked image-only input \u2014 accepts NO prompt, NO logo overlay, NO dossier branding spec, NO palette token. With no canon anchor, FLUX defaults to training-set priors. Dispatch boundary had no guard distinguishing branded SKUs (which Tripo cannot render correctly) from unbranded clean tech-flats (which it can). Additionally, SKUs with empty catalog `image` column silently fell back to `front_model_image` (a model-on shot), which the template re-builds from scratch \u2014 changing garment type entirely (jersey \u2192 hoodie). No QA gate caught the regression; STOP-AND-SHOW manifest showed cost only, no output preview.",
+    "fix": "scripts/tripo_dispatch.py \u2014 added classify_skus() function that blocks at the dispatch boundary: (1) SKUs whose dossier frontmatter has `logo_reference:` populated are blocked as BRANDED with directive to route via ADK render_pipeline. (2) SKUs with empty `image` column or missing tech-flat file are blocked as NO TECH-FLAT. --force-branded escape hatch added with WARNING and still-required explicit y to dispatch. Per-SKU block reason printed in manifest before y/N prompt. 12 unit tests in tests/test_tripo_dispatch_guards.py covering both guards plus escape hatch. renders/output/tripo/QUARANTINE.md written marking all 120 existing outputs as discard-do-not-publish. Cerebrum Do-Not-Repeat entry added 2026-05-11.",
     "tags": [
       "tripo",
       "flux-kontext",
@@ -1428,7 +1428,7 @@
   {
     "id": "bug-097",
     "timestamp": "2026-05-12T22:32:00Z",
-    "error_message": "CURS-03: luxury cursor JS loads on immersive templates (slug='immersive') — no exclusion gate in enqueue.php",
+    "error_message": "CURS-03: luxury cursor JS loads on immersive templates (slug='immersive') \u2014 no exclusion gate in enqueue.php",
     "file": "wordpress-theme/skyyrose-flagship/inc/enqueue.php",
     "root_cause": "wp_enqueue_script('skyyrose-luxury-cursor', ...) lives inside skyyrose_enqueue_global_scripts() at lines 249-259 with no conditional check. Template slug detection exists (skyyrose_get_current_template_slug() maps template-immersive-*.php to 'immersive') but is not consulted before cursor JS enqueue. Result: cursor JS loads on all pages including immersive templates where the cursor is CSS-hidden.",
     "fix": "FIXED in theme 1.1.2 (commit 016f7025f, deployed 2026-05-12). wordpress-theme/skyyrose-flagship/inc/enqueue.php lines 247-263: wrapped the luxury-cursor wp_enqueue_script() block in `if ('immersive' !== skyyrose_get_current_template_slug())`. The template slug helper was already available in the same file (no new dependency). After deploy, live verification confirmed zero <script> tags loading luxury-cursor.js on /experience-black-rose/. Regression test tests/test_luxury_cursor.py::test_cursor_not_loaded_on_immersive flipped from intentional-fail to pass (3/3 green).",
@@ -1444,7 +1444,7 @@
     "related_bugs": [],
     "occurrences": 1,
     "last_seen": "2026-05-12T23:35:00Z",
-    "regression_test": "tests/test_luxury_cursor.py::test_cursor_not_loaded_on_immersive (commit 818868654) — FAILS until fix is deployed",
+    "regression_test": "tests/test_luxury_cursor.py::test_cursor_not_loaded_on_immersive (commit 818868654) \u2014 FAILS until fix is deployed",
     "resolved": true
   },
   {
@@ -1452,8 +1452,8 @@
     "timestamp": "2026-05-12T22:30:00Z",
     "error_message": "DATA-01: /collection-black-rose/, /collection-love-hurts/, /collection-signature/, /collection-kids-capsule/ all returned HTTP 200 but served the homepage (page-id-9822, page-template-front-page-php) instead of the matching template-collection-*.php. Collection pages were absent from the WordPress DB.",
     "file": "wordpress-theme/skyyrose-flagship/inc/theme-activation-setup.php",
-    "root_cause": "skyyrose_run_activation_setup() runs once via add_action('init', ...) at priority 30, gated by `if get_option('skyyrose_activation_setup_version') === SKYYROSE_SETUP_VERSION return;`. The stored option was '4.0.0', matching the constant, so the init runner short-circuited on every request. However, the four collection pages had been deleted from the WP admin at some point (or never created on this site's initial activation), so skyyrose_create_required_pages() never re-ran to recreate them. wp_safe_redirect logic in inc/redirects.php only handled legacy /collections/{slug}/ -> /collection-{slug}/ rewrites — it assumed the canonical destination pages existed, which they did not.",
-    "fix": "Bumped SKYYROSE_SETUP_VERSION constant from '4.0.0' to '4.1.0' in inc/theme-activation-setup.php (commit 016f7025f, theme 1.1.2). On next request after deploy the init runner sees the version mismatch, fires skyyrose_run_activation_setup(), which calls skyyrose_create_required_pages(). That function iterates the slug map (already includes the four collection slugs at lines 69-88) and runs wp_insert_post() for any slug returned as missing by get_page_by_path(), assigning _wp_page_template meta to point at the matching template-collection-*.php. Post-deploy verified live: /collection-black-rose/ = page-id-9454, love-hurts=9455, signature=9456, kids-capsule=9651 — all routing to their correct templates.",
+    "root_cause": "skyyrose_run_activation_setup() runs once via add_action('init', ...) at priority 30, gated by `if get_option('skyyrose_activation_setup_version') === SKYYROSE_SETUP_VERSION return;`. The stored option was '4.0.0', matching the constant, so the init runner short-circuited on every request. However, the four collection pages had been deleted from the WP admin at some point (or never created on this site's initial activation), so skyyrose_create_required_pages() never re-ran to recreate them. wp_safe_redirect logic in inc/redirects.php only handled legacy /collections/{slug}/ -> /collection-{slug}/ rewrites \u2014 it assumed the canonical destination pages existed, which they did not.",
+    "fix": "Bumped SKYYROSE_SETUP_VERSION constant from '4.0.0' to '4.1.0' in inc/theme-activation-setup.php (commit 016f7025f, theme 1.1.2). On next request after deploy the init runner sees the version mismatch, fires skyyrose_run_activation_setup(), which calls skyyrose_create_required_pages(). That function iterates the slug map (already includes the four collection slugs at lines 69-88) and runs wp_insert_post() for any slug returned as missing by get_page_by_path(), assigning _wp_page_template meta to point at the matching template-collection-*.php. Post-deploy verified live: /collection-black-rose/ = page-id-9454, love-hurts=9455, signature=9456, kids-capsule=9651 \u2014 all routing to their correct templates.",
     "tags": [
       "data-01",
       "wp-init-hook",
@@ -1473,10 +1473,10 @@
   {
     "id": "bug-099",
     "timestamp": "2026-05-14T00:35:15Z",
-    "error_message": "Stop hook error: Hook JSON output validation failed — (root): Invalid input",
+    "error_message": "Stop hook error: Hook JSON output validation failed \u2014 (root): Invalid input",
     "file": ".claude/hooks/learning-reminder.sh",
     "root_cause": "Stop hook emitted {hookSpecificOutput.additionalContext: ...} JSON. That schema is valid only for UserPromptSubmit and PostToolUse. Stop accepts only {decision, reason, continue, stopReason, suppressOutput, systemMessage}. Claude Code schema validator rejected the unknown root-level shape.",
-    "fix": "Replaced jq stdout JSON emission with stderr printf. Stop fires after Claude finishes, so additionalContext injection is moot — the reminder is for the human, stderr is the right channel. Stdout now empty, schema validator passes. Marker file deletion preserved.",
+    "fix": "Replaced jq stdout JSON emission with stderr printf. Stop fires after Claude finishes, so additionalContext injection is moot \u2014 the reminder is for the human, stderr is the right channel. Stdout now empty, schema validator passes. Marker file deletion preserved.",
     "tags": [
       "hooks",
       "claude-code",
@@ -1536,10 +1536,10 @@
   {
     "id": "bug-102",
     "timestamp": "2026-05-16T08:10:00-07:00",
-    "error_message": "Phase 14 INFRA-01 regression: scripts/nano_banana/catalog.py bypasses skyyrose.core.catalog_loader (independent csv.DictReader) — single-source-of-truth contract broken; Plan 14-02 SUMMARY claim false",
+    "error_message": "Phase 14 INFRA-01 regression: scripts/nano_banana/catalog.py bypasses skyyrose.core.catalog_loader (independent csv.DictReader) \u2014 single-source-of-truth contract broken; Plan 14-02 SUMMARY claim false",
     "file": "scripts/nano_banana/catalog.py",
-    "root_cause": "Plan 14-02 added a catalog_loader shim (commit 51dc3ff8b). Later commits a22074ab3 and 8737e3714 overwrote scripts/nano_banana/catalog.py with a standalone csv.DictReader parser (lines 8, 26-55), regressing INFRA-01. Data stays consistent (same canonical CSV file) but the three pipelines no longer share the catalog adapter — the contract, not the data, is violated.",
-    "fix": "Option A applied. Rewrote scripts/nano_banana/catalog.py load_catalog() + module docstring + CATALOG_CSV constant to source rows via skyyrose.core.catalog_loader.read_catalog_rows / bool_col / CATALOG_CSV (env-overridable). Removed the local csv.DictReader. Preserved the richer HEAD functions untouched (find_source_image, find_back_source, load_products, load_specs, get_material_spec — load-bearing per cli.py/produce_async.py) and kept engine_override + back_source_override; added garment_type from garment_type_lock (INFRA-04 alignment). Added CI regression gate tests/test_catalog_csv_integrity.py::test_nano_banana_catalog_routes_through_core_loader asserting nb.read_catalog_rows IS core.read_catalog_rows, canonical CATALOG_CSV, and no csv.DictReader in load_catalog. Verified: 21/21 integrity tests green incl. test_python_loaders_agree_on_sku_set; nano+elite agree on 33 SKUs; black/ruff/isort clean.",
+    "root_cause": "Plan 14-02 added a catalog_loader shim (commit 51dc3ff8b). Later commits a22074ab3 and 8737e3714 overwrote scripts/nano_banana/catalog.py with a standalone csv.DictReader parser (lines 8, 26-55), regressing INFRA-01. Data stays consistent (same canonical CSV file) but the three pipelines no longer share the catalog adapter \u2014 the contract, not the data, is violated.",
+    "fix": "Option A applied. Rewrote scripts/nano_banana/catalog.py load_catalog() + module docstring + CATALOG_CSV constant to source rows via skyyrose.core.catalog_loader.read_catalog_rows / bool_col / CATALOG_CSV (env-overridable). Removed the local csv.DictReader. Preserved the richer HEAD functions untouched (find_source_image, find_back_source, load_products, load_specs, get_material_spec \u2014 load-bearing per cli.py/produce_async.py) and kept engine_override + back_source_override; added garment_type from garment_type_lock (INFRA-04 alignment). Added CI regression gate tests/test_catalog_csv_integrity.py::test_nano_banana_catalog_routes_through_core_loader asserting nb.read_catalog_rows IS core.read_catalog_rows, canonical CATALOG_CSV, and no csv.DictReader in load_catalog. Verified: 21/21 integrity tests green incl. test_python_loaders_agree_on_sku_set; nano+elite agree on 33 SKUs; black/ruff/isort clean.",
     "tags": [
       "phase-14",
       "INFRA-01",
@@ -1564,7 +1564,7 @@
     "error_message": "5 prod modules reference data/product-catalog.csv as 'single source of truth' but that file is NOT on the main tree and NOT git-tracked (only the canonical wordpress-theme/skyyrose-flagship/data/skyyrose-catalog.csv is tracked)",
     "file": "database/seed_catalog.py",
     "root_cause": "Legacy second-CSV references predating the catalog_loader consolidation. Affected: database/seed_catalog.py, agents/social_media_agent.py, scripts/nano-banana-vton.py, agents/claude_sdk/domain_agents/content.py, renders/preflight.py (comments). They point at a phantom data/product-catalog.csv path.",
-    "fix": "PENDING — OUT OF bug-102/Phase 14 scope (would touch DB seeding + social agent + vton, unrelated subsystems — scope-creep risk). Handoff target for the deferred v1.3 Site Fix milestone's first task (audit CSV -> one canonical source). Do NOT fix inside Phase 14.",
+    "fix": "PENDING \u2014 OUT OF bug-102/Phase 14 scope (would touch DB seeding + social agent + vton, unrelated subsystems \u2014 scope-creep risk). Handoff target for the deferred v1.3 Site Fix milestone's first task (audit CSV -> one canonical source). Do NOT fix inside Phase 14.",
     "tags": [
       "single-source-of-truth",
       "legacy",
@@ -1582,9 +1582,9 @@
   {
     "id": "bug-104",
     "timestamp": "2026-05-16T08:35:00-07:00",
-    "error_message": "(eval):17: PIPESTATUS[0]: parameter not set  — verification harness for devworkflows scripts failed under set -u",
+    "error_message": "(eval):17: PIPESTATUS[0]: parameter not set  \u2014 verification harness for devworkflows scripts failed under set -u",
     "file": "scripts/devworkflows/ (verification harness, not the scripts themselves)",
-    "root_cause": "The Bash tool executes commands via zsh (env Shell: zsh), not bash. PIPESTATUS is a bash-only array; zsh exposes pipe exit codes as the lowercase 1-indexed `pipestatus` array. With `set -u`, referencing the unset PIPESTATUS made the harness abort. The 3 devworkflow scripts were unaffected (they run under their own `#!/usr/bin/env bash` shebang) — only the inline test harness tripped.",
+    "root_cause": "The Bash tool executes commands via zsh (env Shell: zsh), not bash. PIPESTATUS is a bash-only array; zsh exposes pipe exit codes as the lowercase 1-indexed `pipestatus` array. With `set -u`, referencing the unset PIPESTATUS made the harness abort. The 3 devworkflow scripts were unaffected (they run under their own `#!/usr/bin/env bash` shebang) \u2014 only the inline test harness tripped.",
     "fix": "In Bash-tool one-liners, never use ${PIPESTATUS[*]}. Capture exit status directly: run the command, then `rc=$?` on the next line (no pipe), or redirect to a file and read $? immediately. Reserve PIPESTATUS for code inside `bash script.sh` files.",
     "tags": [
       "zsh",
@@ -1604,7 +1604,7 @@
     "timestamp": "2026-05-19T19:50:00-07:00",
     "error_message": "br-011 deep-dive RCA revealed 3 drift gaps in tripo guard + catalog/dossier alignment + QUARANTINE.md mischaracterization (post-bug-096 hardening)",
     "file": "scripts/tripo_dispatch.py + tests/test_tripo_dispatch_guards.py + wordpress-theme/skyyrose-flagship/data/skyyrose-catalog.csv + renders/output/tripo/QUARANTINE.md",
-    "root_cause": "(1) classify_skus only checked tech-flat file existence — ignored authoritative catalog render_is_tech_flat column. br-011 had a 12.6MB PNG flagged 0 (branded product render). --force-branded would have approved it. (2) QUARANTINE.md row 24 mischaracterized br-011 as NHL Authentic cut, no hood, mesh side panels — dossier says Hockey-style pullover hoodie. Garment shape rendered correct; only branding hallucinated. (3) Catalog garment_type_lock=jersey conflicted with dossier hoodie construction.",
+    "root_cause": "(1) classify_skus only checked tech-flat file existence \u2014 ignored authoritative catalog render_is_tech_flat column. br-011 had a 12.6MB PNG flagged 0 (branded product render). --force-branded would have approved it. (2) QUARANTINE.md row 24 mischaracterized br-011 as NHL Authentic cut, no hood, mesh side panels \u2014 dossier says Hockey-style pullover hoodie. Garment shape rendered correct; only branding hallucinated. (3) Catalog garment_type_lock=jersey conflicted with dossier hoodie construction.",
     "fix": "Added _is_catalog_tech_flat() helper and inserted middle guard layer in classify_skus: BRANDED -> CATALOG TECH-FLAT FLAG -> FILE EXISTS. Updated 4 existing tests + added 3 new (total 16/16). Catalog br-011 garment_type_lock: jersey -> hoodie. QUARANTINE.md row 24 corrected + Fix section bumped to 4 guards + test count 12 -> 16.",
     "tags": [
       "tripo",
@@ -1629,7 +1629,7 @@
     "timestamp": "2026-06-09T19:05:00-07:00",
     "error_message": "AttributeError: property 'name' of 'ReplicateProvider' object has no setter (tests/test_p0_ssrf_replicate.py fixture)",
     "file": "tests/test_p0_ssrf_replicate.py",
-    "root_cause": "Fixture used ReplicateProvider.__new__ then assigned p.name, but name is a read-only @property returning a constant — assignment never worked; tests were committed without a green run",
+    "root_cause": "Fixture used ReplicateProvider.__new__ then assigned p.name, but name is a read-only @property returning a constant \u2014 assignment never worked; tests were committed without a green run",
     "fix": "Removed the p.name assignment (property already returns 'replicate'); 20/20 pass",
     "tags": [
       "pytest",
@@ -1647,8 +1647,8 @@
     "timestamp": "2026-06-12T09:15:00-07:00",
     "error_message": "deploy-theme.sh reported 'Deploy complete (verified live)' but live site still served pre-deploy theme v1.5.30; scp died mid-upload (Connection reset by peer), remote tar hit 'Unexpected EOF in archive', swap never ran",
     "file": "scripts/deploy-theme.sh",
-    "root_cause": "try_rsync() is called as `if try_rsync` — bash suppresses errexit inside any function invoked as a condition, so the failed scp and failed remote extract fell through to log_success. verify_live() only checked the homepage (HTTP 200 + size), which the OLD theme passes identically.",
-    "fix": "Three layers: (1) scp retry loop x3 with local-vs-remote byte-size verification before extract; (2) explicit failure check on the remote extract/swap SSH command, REMOTE_SWAP_ID now set only after a successful swap; (3) verify_live() version-stamp gate — live style.css 'Version:' must equal local THEME_DIR/style.css or the script fails and auto-rollback fires.",
+    "root_cause": "try_rsync() is called as `if try_rsync` \u2014 bash suppresses errexit inside any function invoked as a condition, so the failed scp and failed remote extract fell through to log_success. verify_live() only checked the homepage (HTTP 200 + size), which the OLD theme passes identically.",
+    "fix": "Three layers: (1) scp retry loop x3 with local-vs-remote byte-size verification before extract; (2) explicit failure check on the remote extract/swap SSH command, REMOTE_SWAP_ID now set only after a successful swap; (3) verify_live() version-stamp gate \u2014 live style.css 'Version:' must equal local THEME_DIR/style.css or the script fails and auto-rollback fires.",
     "tags": [
       "deploy",
       "bash",
@@ -1670,7 +1670,7 @@
   {
     "id": "bug-108",
     "timestamp": "2026-06-12T09:15:00-07:00",
-    "error_message": "Post-release verification falsely concluded 'pre-order page IS live with new markup' — combined grep 'po-gateway|preorder-hero.mp4' matched on preorder-hero.mp4 which the OLD pre-port template also references via hero-cinematic",
+    "error_message": "Post-release verification falsely concluded 'pre-order page IS live with new markup' \u2014 combined grep 'po-gateway|preorder-hero.mp4' matched on preorder-hero.mp4 which the OLD pre-port template also references via hero-cinematic",
     "file": "(verification procedure, not code)",
     "root_cause": "Combined-alternation grep where one alternative exists in BOTH old and new code proves nothing. preorder-hero.mp4 predates the port; only po-* classes are unique to the new template.",
     "fix": "Verify releases with markers unique to the NEW code only (po-gateway, lp-split), one pattern per grep, plus the version-stamp gate which is implementation-independent.",
@@ -1688,7 +1688,7 @@
   {
     "id": "bug-109",
     "timestamp": "2026-06-10",
-    "error_message": "Uncaught SyntaxError: Identifier 'ASSET_PREFIX' has already been declared — all v2 JS dead, dock/grid never populated",
+    "error_message": "Uncaught SyntaxError: Identifier 'ASSET_PREFIX' has already been declared \u2014 all v2 JS dead, dock/grid never populated",
     "file": "prototypes/landing-collections/v2-shop-rail/{catalog-adapter,app}.js",
     "root_cause": "Two top-level scripts on one page both declared const ASSET_PREFIX in shared global scope",
     "fix": "Wrapped both files in IIFEs; skill updated to require IIFE wrapping in multi-script briefs",
@@ -1707,7 +1707,7 @@
     "timestamp": "2026-06-10",
     "error_message": "v2 dock rendered default rose-gold accent instead of Black Rose silver",
     "file": "prototypes/landing-collections/v2-shop-rail/index.html",
-    "root_cause": "data-collection attribute on <main> but dock element sits after </main> — token override never reached it",
+    "root_cause": "data-collection attribute on <main> but dock element sits after </main> \u2014 token override never reached it",
     "fix": "Moved data-collection to <body> so all descendants inherit collection tokens",
     "tags": [
       "css-tokens",
@@ -1724,7 +1724,7 @@
     "error_message": "Black Rose script logotype invisible on #0A0A0A background (v2 + v5 heroes)",
     "file": "prototypes/landing-collections/{v2-shop-rail,v5-collection-morph}/styles.css",
     "root_cause": "br-brand-script-logotype is black lettering; brightness filters cannot lift pure black pixels",
-    "fix": "Scoped [data-collection=black-rose] .lp-hero__lockup { filter: invert(1) grayscale(1) } — silver-white matches BR register",
+    "fix": "Scoped [data-collection=black-rose] .lp-hero__lockup { filter: invert(1) grayscale(1) } \u2014 silver-white matches BR register",
     "tags": [
       "design",
       "lockup",
@@ -1754,7 +1754,7 @@
   {
     "id": "bug-113",
     "timestamp": "2026-06-10",
-    "error_message": "Delivered prototype HTML files rendered unstyled skeletons when downloaded — all assets referenced via relative paths escaping into the repo tree",
+    "error_message": "Delivered prototype HTML files rendered unstyled skeletons when downloaded \u2014 all assets referenced via relative paths escaping into the repo tree",
     "file": "prototypes/landing-collections/v*/index.html",
     "root_cause": "Skill output contract allowed multi-file pages with cross-tree relative asset paths; 'verified in place' hid the escape",
     "fix": "build-standalone.py inlines CSS/JS + embeds all images/fonts as data URIs + MutationObserver shim resolves adapter-built paths; skill now mandates single-file locked-and-loaded delivery + isolated-copy verification",
@@ -1771,7 +1771,7 @@
   {
     "id": "bug-114",
     "timestamp": "2026-06-10",
-    "error_message": "v2 referenced images/products/jersey-last-oakland-baseball/<file> — subdirectory holds only collection-card images, front-model file is flat",
+    "error_message": "v2 referenced images/products/jersey-last-oakland-baseball/<file> \u2014 subdirectory holds only collection-card images, front-model file is flat",
     "file": "prototypes/landing-collections/v2-shop-rail/catalog-adapter.js",
     "root_cause": "Builder invented per-product-subdir paths instead of using brief's verified flat paths",
     "fix": "Normalized 3 subdir refs to flat verified filenames; rebuilt standalone",
@@ -1786,7 +1786,7 @@
   {
     "id": "bug-115",
     "timestamp": "2026-06-10",
-    "error_message": "Signature Sherpa render (red-rose closed jacket) mis-filed as black-rose-sherpa-jacket/black-rose-sherpa-jacket-front-model.webp — surfaced as 'Signature Sherpa in the Black Rose Collection' on v2 mockup; founder flagged",
+    "error_message": "Signature Sherpa render (red-rose closed jacket) mis-filed as black-rose-sherpa-jacket/black-rose-sherpa-jacket-front-model.webp \u2014 surfaced as 'Signature Sherpa in the Black Rose Collection' on v2 mockup; founder flagged",
     "file": "wordpress-theme/skyyrose-flagship/assets/images/products/",
     "root_cause": "Render output saved under wrong product's subdir during earlier render pipeline runs; filename treated as identity without pixel verification",
     "fix": "git mv to signature-sherpa-jacket-front-closed.{webp,avif}; CSV sg-009 front_model_image -> new file (upgrade from ghost); br-006 confirmed correct on flat hooded render; CLAUDE.md learning + cerebrum entries added",
@@ -1825,7 +1825,7 @@
     "error_message": "Stop-hook pytest: AssertionError Status code 204 must not have a response body (api/v1/rag_anything.py:201 via main_enterprise import)",
     "file": "api/v1/rag_anything.py",
     "root_cause": "PEP 563 stringified `-> None` return annotation resolves to NoneType, which FastAPI 0.133 treats as a response model on a 204 route. Fix (response_model=None + comment) was landed by a parallel session; hook raced the fix window",
-    "fix": "No change needed — verified current tree: direct import clean, tests/test_new_api_endpoints.py 13/13 pass. Pattern for any new 204 route: always pass response_model=None explicitly",
+    "fix": "No change needed \u2014 verified current tree: direct import clean, tests/test_new_api_endpoints.py 13/13 pass. Pattern for any new 204 route: always pass response_model=None explicitly",
     "tags": [
       "fastapi",
       "204",
@@ -1841,9 +1841,9 @@
   {
     "id": "bug-119",
     "timestamp": "2026-06-09T19:30:00-07:00",
-    "error_message": "Founder review: sg-006/sg-014 renders showed 'WRONG PRODUCT — rendered the signature windbreaker outfit'; 41 of 79 renders flagged total",
+    "error_message": "Founder review: sg-006/sg-014 renders showed 'WRONG PRODUCT \u2014 rendered the signature windbreaker outfit'; 41 of 79 renders flagged total",
     "file": "wordpress-theme/skyyrose-flagship/data/dossiers/mint-lavender-hoodie.md",
-    "root_cause": "sg-006/sg-014 dossiers describe a white chevron zip-up garment (the windbreaker-set design) instead of the mint pullover/sweats shown in their techflats — dossier was Claude-authored (cmem #11235) from wrong reference photos; its reference_image field points at a mislabeled file that is actually the black sherpa jacket. gpt-image-2 obeyed dossier text over the reference image.",
+    "root_cause": "sg-006/sg-014 dossiers describe a white chevron zip-up garment (the windbreaker-set design) instead of the mint pullover/sweats shown in their techflats \u2014 dossier was Claude-authored (cmem #11235) from wrong reference photos; its reference_image field points at a mislabeled file that is actually the black sherpa jacket. gpt-image-2 obeyed dossier text over the reference image.",
     "fix": "sg-006/sg-014 added to config.EXCLUDED_SKUS until founder re-authors dossiers; founder verbatim corrections from review board injected into prompts via data/render-corrections.json; new photorealistic_not_flat QC gate; MATERIAL/PHOTOREALISM/BRANDING-IS-EXHAUSTIVE prompt directives",
     "tags": [
       "oai-render",
@@ -1881,7 +1881,7 @@
   {
     "id": "bug-121",
     "timestamp": "2026-06-05",
-    "error_message": "Nano Banana dry-run for lh-006 (Love Hurts Joggers White) resolved SOURCE: the-fannie-pack-photo.jpg — wrong product. A paid generate would have rendered a fanny pack labeled as white joggers.",
+    "error_message": "Nano Banana dry-run for lh-006 (Love Hurts Joggers White) resolved SOURCE: the-fannie-pack-photo.jpg \u2014 wrong product. A paid generate would have rendered a fanny pack labeled as white joggers.",
     "file": "scripts/nano_banana/source_map.py",
     "root_cause": "source_map.py hardcoded lh-006 -> the-fannie-pack-photo.jpg from when lh-006 was a fanny pack. SKU was reassigned to the white joggers in the catalog, but the shadow source_map was never updated. catalog.py find_source() checks source_map (step 2) BEFORE the CSV render_source_override (step 3), so the stale .jpg won.",
     "fix": "Repointed source_map.py lh-006 front -> P/'lh-006-joggers-white.jpeg' (the real white flat), back None. Free dry-run re-verified SOURCE: lh-006-joggers-white.jpeg. Same dual-source-of-truth trap as the catalog image fix (bug-001).",
@@ -1925,7 +1925,7 @@
   {
     "id": "bug-123",
     "timestamp": "2026-06-06",
-    "error_message": "Appended a duplicate lh-007 'The Fannie' row to the catalog CSV — The Fannie was already canonical at lh-005.",
+    "error_message": "Appended a duplicate lh-007 'The Fannie' row to the catalog CSV \u2014 The Fannie was already canonical at lh-005.",
     "file": "wordpress-theme/skyyrose-flagship/data/skyyrose-catalog.csv",
     "root_cause": "Trusted the conversation ('the fannie needs to be added') over the CSV source of truth; did not grep the full catalog first, so missed that lh-005 = The Fannie already. WC also had two Fannie products (correct lh-005/#10077 + stray lh-006/#9879) which reinforced the wrong mental model.",
     "fix": "Reverted lh-007 row. Conformed WC to the CSV instead: lh-006/#9879 (stray Fannie) -> Love Hurts Joggers (White); real Fannie left untouched at lh-005/#10077. Lesson: before adding ANY product, grep the full catalog CSV for the name/SKU.",
@@ -1948,7 +1948,7 @@
   {
     "id": "bug-124",
     "timestamp": "2026-06-11T00:40:00Z",
-    "error_message": "PR #540 merged missing its branch tip: push used 409187921:feat/oai-render-pipeline assuming 2b2ab382a was the parent, but 2b2ab382a (paired-looks skip fix) was the CHILD/tip — stranded after merge",
+    "error_message": "PR #540 merged missing its branch tip: push used 409187921:feat/oai-render-pipeline assuming 2b2ab382a was the parent, but 2b2ab382a (paired-looks skip fix) was the CHILD/tip \u2014 stranded after merge",
     "file": "scripts/oai_render/ (paired-looks logic)",
     "root_cause": "Commit order assumption inverted: standup notes listed '409187921 + 2b2ab382a' and executor verified the range existed but not the parent-child direction; pushing the older SHA silently excluded the tip",
     "fix": "Recovery PR #544 pushed 2b2ab382a as fix/oai-render-paired-looks-skip, 52/52 pipeline tests green, merged 0f0ea0c43. Lesson: push BRANCH TIPS or verify with `git log -1 --format=%P <sha>` before sha:branch pushes; post-merge gate `merge-base --is-ancestor <every-sha> origin/main` caught it",
@@ -1966,10 +1966,10 @@
   {
     "id": "bug-125",
     "timestamp": "2026-06-11T07:30:00Z",
-    "error_message": "AssertionError: Status code 204 must not have a response body — app import crashed at api/v1/rag_anything.py:201, collected by new Stop-hook pytest run",
+    "error_message": "AssertionError: Status code 204 must not have a response body \u2014 app import crashed at api/v1/rag_anything.py:201, collected by new Stop-hook pytest run",
     "file": "api/v1/rag_anything.py",
     "root_cause": "PEP 563 (`from __future__ import annotations`) stringifies the handler's `-> None` return annotation; FastAPI 0.115 get_type_hints resolves it to the NoneType CLASS, which is truthy as response_model, tripping the 204-no-body assert at route registration. Only route in repo combining future-import + `-> None` + 204.",
-    "fix": "Explicit `response_model=None` on the @router.delete decorator. 4 sibling 204 routes (elite_studio, v2/assets, v2/creative, v2/webhooks) have future-import but UNannotated handlers — dormant; adding `-> None` to them without response_model=None will re-trigger this.",
+    "fix": "Explicit `response_model=None` on the @router.delete decorator. 4 sibling 204 routes (elite_studio, v2/assets, v2/creative, v2/webhooks) have future-import but UNannotated handlers \u2014 dormant; adding `-> None` to them without response_model=None will re-trigger this.",
     "tags": [
       "fastapi",
       "pep563",
@@ -2005,10 +2005,10 @@
   {
     "id": "bug-127",
     "timestamp": "2026-06-12T08:45:00Z",
-    "error_message": "pytest hangs forever at interpreter shutdown (threading._shutdown) after running aos kernel tests — 12h45m elapsed, 0.75s CPU",
+    "error_message": "pytest hangs forever at interpreter shutdown (threading._shutdown) after running aos kernel tests \u2014 12h45m elapsed, 0.75s CPU",
     "file": "tests/aos/kernel/*.py, tests/aos/test_execute_plan.py, tests/aos/test_smoke_real_agent.py",
     "root_cause": "Six kernel fixtures booted Kernel (opens aiosqlite audit connection = non-daemon thread) and `return k` with no teardown; leaked threads block threading._shutdown at exit. Hang is silent because piped output stays buffered.",
-    "fix": "Converted all 6 fixtures to `yield k` + `await k.close()` (closes audit conn). tests/aos now exits in 26s wall. Diagnostic trick: SIGINT the hung process — buffered pipe flushes + traceback shows _thread_shutdown.",
+    "fix": "Converted all 6 fixtures to `yield k` + `await k.close()` (closes audit conn). tests/aos now exits in 26s wall. Diagnostic trick: SIGINT the hung process \u2014 buffered pipe flushes + traceback shows _thread_shutdown.",
     "tags": [
       "pytest",
       "thread-leak",
@@ -2042,10 +2042,10 @@
   {
     "id": "bug-129",
     "timestamp": "2026-06-12T09:05:00Z",
-    "error_message": "Stop-hook pytest: AttributeError 'BaseModelOutputWithPooling' object has no attribute 'squeeze' in test_clip_alignment — NOT reproducible afterward",
+    "error_message": "Stop-hook pytest: AttributeError 'BaseModelOutputWithPooling' object has no attribute 'squeeze' in test_clip_alignment \u2014 NOT reproducible afterward",
     "file": "tests/elite_studio/test_clip_alignment.py (no change needed)",
-    "root_cause": "Async Stop-hook test run raced `pip install headroom-ai[all]` mid-swap of transformers 4.57.6→5.11.0; pytest imported a half-replaced package. Isolated rerun and full tests/elite_studio/ green on settled 5.11.0.",
-    "fix": "None — transient. Rule: treat Stop-hook failures that coincide with dependency installs as suspect; re-run the failing test on the settled env before touching code.",
+    "root_cause": "Async Stop-hook test run raced `pip install headroom-ai[all]` mid-swap of transformers 4.57.6\u21925.11.0; pytest imported a half-replaced package. Isolated rerun and full tests/elite_studio/ green on settled 5.11.0.",
+    "fix": "None \u2014 transient. Rule: treat Stop-hook failures that coincide with dependency installs as suspect; re-run the failing test on the settled env before touching code.",
     "tags": [
       "stop-hook",
       "pip-race",
@@ -2062,9 +2062,9 @@
   {
     "id": "bug-130",
     "timestamp": "2026-06-12T09:30:00Z",
-    "error_message": "test_generator_node_routes_adk_engine_to_invoker: assert 0 == 1 — monkeypatch on graph.nodes._invoke_adk_render_engine never reached the call site",
+    "error_message": "test_generator_node_routes_adk_engine_to_invoker: assert 0 == 1 \u2014 monkeypatch on graph.nodes._invoke_adk_render_engine never reached the call site",
     "file": "skyyrose/elite_studio/graph/nodes/layer1.py",
-    "root_cause": "nodes flat-module → package split kept the _shim() call-time-lookup pattern for GeneratorAgent/VisionAgent etc., but the adk-render branch called _invoke_adk_render_engine via layer1's own import-time binding from ._shared — patches on the package namespace (the documented patch target) were invisible to it",
+    "root_cause": "nodes flat-module \u2192 package split kept the _shim() call-time-lookup pattern for GeneratorAgent/VisionAgent etc., but the adk-render branch called _invoke_adk_render_engine via layer1's own import-time binding from ._shared \u2014 patches on the package namespace (the documented patch target) were invisible to it",
     "fix": "Route the adk branch through _shim()._invoke_adk_render_engine(...) like every other patchable callable; ruff --fix removed the now-dead direct import. 19/19 hardening tests green.",
     "tags": [
       "monkeypatch",
@@ -2118,9 +2118,9 @@
   {
     "id": "bug-133",
     "timestamp": "2026-06-13T23:51:09Z",
-    "error_message": "tests/test_rag_integration.py::test_rag_document_chunking — AssertionError: Document should be split into multiple chunks (Stop-hook full-suite run only)",
+    "error_message": "tests/test_rag_integration.py::test_rag_document_chunking \u2014 AssertionError: Document should be split into multiple chunks (Stop-hook full-suite run only)",
     "file": "tests/test_rag_integration.py",
-    "root_cause": "NOT test-order pollution (first-pass label was wrong). test_rag_document_chunking + test_rag_context_caching are real-dependency integration tests (real ChromaDB + sentence-transformers all-MiniLM-L6-v2, loaded per-call in orchestration/auto_ingestion._generate_embeddings) left UNMARKED while their siblings carry @pytest.mark.slow. They leaked into the fast gate (addopts -m \"not slow and not integration\", used by the Stop hook + pre-commit). Under full-suite load the HF model load/encode intermittently throws; _ingest_file wraps embeddings + add_documents in a broad except that swallows it, leaving documents_created=0, so the assert fails with the misleading \"should be split into multiple chunks\". Flaky/nondeterministic, not order-deterministic — a clean re-run passed.",
+    "root_cause": "NOT test-order pollution (first-pass label was wrong). test_rag_document_chunking + test_rag_context_caching are real-dependency integration tests (real ChromaDB + sentence-transformers all-MiniLM-L6-v2, loaded per-call in orchestration/auto_ingestion._generate_embeddings) left UNMARKED while their siblings carry @pytest.mark.slow. They leaked into the fast gate (addopts -m \"not slow and not integration\", used by the Stop hook + pre-commit). Under full-suite load the HF model load/encode intermittently throws; _ingest_file wraps embeddings + add_documents in a broad except that swallows it, leaving documents_created=0, so the assert fails with the misleading \"should be split into multiple chunks\". Flaky/nondeterministic, not order-deterministic \u2014 a clean re-run passed.",
     "fix": "Marked both leaking tests @pytest.mark.slow to match their siblings, routing them out of the fast Stop-hook/pre-commit gate into the slow lane where real-dep tests belong. Assertion unchanged, not weakened. Verified: 0 tests from test_rag_integration.py collected under the fast gate; all 4 pass under -m slow.",
     "tags": [
       "flaky",
@@ -2137,5 +2137,24 @@
     "occurrences": 1,
     "last_seen": "2026-06-13T23:51:09Z",
     "status": "resolved"
+  },
+  {
+    "id": "bug-134",
+    "timestamp": "2026-06-15",
+    "error_message": "UnicodeEncodeError: 'utf-8' codec can't encode characters in position 626-627: surrogates not allowed \u2014 devskyy_mcp.py crashed on startup when stdout was a pipe",
+    "file": "devskyy_mcp.py",
+    "root_cause": "The startup banner (emoji + box-drawing) was print()ed to STDOUT. MCP stdio servers use stdout as the JSON-RPC channel and clients launch them with a piped (non-tty) stdout; under that encoding the banner raised UnicodeEncodeError and killed the server before it served. Printing to stdout also corrupts the JSON-RPC stream even when it doesn't crash.",
+    "fix": "Route all human-readable output (warnings + banner) to sys.stderr and call sys.stderr.reconfigure(encoding='utf-8', errors='backslashreplace') so any unencodable glyph is escaped instead of raising. stdout now stays a clean JSON-RPC channel. Verified: stdout 0 bytes on boot, 38 tools returned over the stdio handshake.",
+    "tags": [
+      "mcp",
+      "stdio",
+      "unicode",
+      "fastmcp",
+      "devskyy_mcp",
+      "startup"
+    ],
+    "related_bugs": [],
+    "occurrences": 1,
+    "last_seen": "2026-06-15"
   }
 ]

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -2156,5 +2156,27 @@
     "related_bugs": [],
     "occurrences": 1,
     "last_seen": "2026-06-15"
+  },
+  {
+    "id": "bug-135",
+    "timestamp": "2026-06-15",
+    "error_message": "MCP stdio tool calls failed end-to-end: (1) structlog logged to STDOUT, polluting the JSON-RPC channel; (2) empty DEVSKYY_API_KEY produced 'Authorization: Bearer ' -> httpx LocalProtocolError 'Illegal header value' before the request was sent.",
+    "file": "utils/logging_utils.py, devskyy_mcp.py, mcp_tools/api_client.py",
+    "root_cause": "structlog.PrintLoggerFactory() defaults to sys.stdout; for a stdio MCP server stdout is the JSON-RPC transport. Separately, api_client.py built the Authorization header unconditionally as f'Bearer {API_KEY}', so an empty key (the default \u2014 no key is configured anywhere) yielded a malformed header httpx refuses to send.",
+    "fix": "configure_logging() gained a `stream` param (default None -> stdout, FastAPI app unchanged); devskyy_mcp.py re-calls it with sys.stderr in stdio mode only. api_client.py now sets Authorization only when API_KEY is truthy. Verified: stdout 0 non-JSON-RPC lines, 0 bearer errors, tool_completed success=true, request reaches backend GET /api/v1/agents/list.",
+    "tags": [
+      "mcp",
+      "stdio",
+      "structlog",
+      "stdout",
+      "httpx",
+      "auth",
+      "devskyy_mcp"
+    ],
+    "related_bugs": [
+      "bug-134"
+    ],
+    "occurrences": 1,
+    "last_seen": "2026-06-15"
   }
 ]

--- a/devskyy_mcp.py
+++ b/devskyy_mcp.py
@@ -24,6 +24,8 @@ Usage:
 
 import sys
 
+from utils.logging_utils import configure_logging
+
 from mcp_tools import mcp  # noqa: F401 - re-export for deploy script compatibility
 from mcp_tools.server import API_BASE_URL, API_KEY
 
@@ -31,6 +33,9 @@ if __name__ == "__main__":
     # stdio transport uses STDOUT as the JSON-RPC channel \u2014 every human-readable
     # line must go to stderr, and must never crash startup on an unencodable glyph.
     sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+    # structlog defaults to stdout — re-route it to stderr for stdio mode so logs
+    # never pollute the JSON-RPC channel. Scoped here; the FastAPI app keeps stdout.
+    configure_logging(json_output=True, stream=sys.stderr)
 
     # Validate configuration
     if not API_KEY:

--- a/devskyy_mcp.py
+++ b/devskyy_mcp.py
@@ -22,16 +22,26 @@ Usage:
     }
 """
 
+import sys
+
 from mcp_tools import mcp  # noqa: F401 - re-export for deploy script compatibility
 from mcp_tools.server import API_BASE_URL, API_KEY
 
 if __name__ == "__main__":
+    # stdio transport uses STDOUT as the JSON-RPC channel \u2014 every human-readable
+    # line must go to stderr, and must never crash startup on an unencodable glyph.
+    sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
     # Validate configuration
     if not API_KEY:
-        print("\u26a0\ufe0f  Warning: DEVSKYY_API_KEY not set. Using empty key for testing.")
-        print("   Set it with: export DEVSKYY_API_KEY='your-key-here'")
+        print(
+            "\u26a0\ufe0f  Warning: DEVSKYY_API_KEY not set. Using empty key for testing.",
+            file=sys.stderr,
+        )
+        print("   Set it with: export DEVSKYY_API_KEY='your-key-here'", file=sys.stderr)
 
-    print(f"""
+    print(
+        f"""
 \u2554\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2557
 \u2551                                                                  \u2551
 \u2551   DevSkyy MCP Server v2.0.0 - Advanced Tool Use                 \u2551
@@ -72,7 +82,9 @@ if __name__ == "__main__":
 \ud83d\udd17 API Reference: {API_BASE_URL}/docs
 
 Starting MCP server on stdio...
-""")
+""",
+        file=sys.stderr,
+    )
 
     # Run the server
     mcp.run()

--- a/mcp_tools/api_client.py
+++ b/mcp_tools/api_client.py
@@ -63,10 +63,14 @@ async def _make_api_request(
         """Inner function for actual request execution"""
 
         headers = {
-            "Authorization": f"Bearer {API_KEY}",
             "Content-Type": "application/json",
             "X-Correlation-ID": correlation_id,  # Track across services
         }
+        # Only send Authorization when a key is configured. An empty key would
+        # produce the malformed header "Bearer " — httpx rejects it with
+        # LocalProtocolError before the request is even sent.
+        if API_KEY:
+            headers["Authorization"] = f"Bearer {API_KEY}"
 
         url = f"{API_BASE_URL}/api/v1/{endpoint}"
 

--- a/mcp_tools/tools/resources.py
+++ b/mcp_tools/tools/resources.py
@@ -25,7 +25,7 @@ from mcp_tools.types import ResponseFormat
 )
 @secure_tool("list_agents")
 async def list_agents(response_format: ResponseFormat = ResponseFormat.MARKDOWN) -> str:
-    """List all 54 DevSkyy AI agents with capabilities.
+    """List all DevSkyy AI agents with capabilities.
 
     Get a comprehensive directory of all available agents organized by category:
     - Infrastructure & System (Scanner, Fixer, Self-Healing, Security)
@@ -47,11 +47,13 @@ async def list_agents(response_format: ResponseFormat = ResponseFormat.MARKDOWN)
         response_format: Output format (markdown or json)
 
     Returns:
-        str: Complete agent directory with 54 agents
+        str: Complete agent directory of all available agents
     """
-    data = await _make_api_request("agents/list", method="GET")
+    # Canonical agents endpoint is GET /api/v1/agents (200, no auth). The old
+    # "agents/list" path fell through to the JWT-gated /{agent_name} catch-all → 422.
+    data = await _make_api_request("agents", method="GET")
 
-    return _format_response(data, response_format, "DevSkyy Agent Directory (54 Agents)")
+    return _format_response(data, response_format, "DevSkyy Agent Directory")
 
 
 @mcp.tool(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ api = [
 
 mcp = [
     "mcp>=1.23.0",
+    "fastmcp==3.0.0",  # standalone FastMCP 3.0 (pinned; SDK-bundled mcp.server.fastmcp still used by devskyy_mcp)
     "openai>=1.57.2",
     "anthropic>=0.75.0",
     "google-genai>=1.50.0",

--- a/tests/mcp/test_api_client.py
+++ b/tests/mcp/test_api_client.py
@@ -1,0 +1,69 @@
+"""Regression tests for mcp_tools/api_client.py request construction.
+
+Covers (bug-135):
+  - An empty DEVSKYY_API_KEY must NOT emit an "Authorization: Bearer " header.
+    The trailing-space-only value is rejected by httpx with LocalProtocolError
+    before the request is sent, which silently broke every backend tool call.
+  - A configured key IS sent as a Bearer token.
+  - The endpoint string maps to /api/v1/<endpoint> (the list_agents tool now
+    calls "agents", not the 422-returning "agents/list").
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import mcp_tools.api_client as ac
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> list[dict[str, str]]:
+        return [{"id": "agent-1"}]
+
+
+class _CapturingClient:
+    """Stand-in for httpx.AsyncClient that records the request kwargs."""
+
+    captured: dict = {}
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def __aenter__(self) -> _CapturingClient:
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+    async def request(self, *, method, url, headers, json=None, params=None) -> _FakeResponse:
+        _CapturingClient.captured = {"method": method, "url": url, "headers": dict(headers)}
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_empty_api_key_omits_authorization_header(monkeypatch):
+    monkeypatch.setattr(ac, "API_KEY", "")
+    monkeypatch.setattr(ac.httpx, "AsyncClient", _CapturingClient)
+    _CapturingClient.captured = {}
+
+    await ac._make_api_request("agents", method="GET")
+
+    cap = _CapturingClient.captured
+    assert cap["url"].endswith("/api/v1/agents")
+    assert "Authorization" not in cap["headers"], "empty key must not produce 'Bearer '"
+
+
+@pytest.mark.asyncio
+async def test_configured_api_key_sends_bearer(monkeypatch):
+    monkeypatch.setattr(ac, "API_KEY", "test-key-123")
+    monkeypatch.setattr(ac.httpx, "AsyncClient", _CapturingClient)
+    _CapturingClient.captured = {}
+
+    await ac._make_api_request("health", method="GET")
+
+    assert _CapturingClient.captured["headers"]["Authorization"] == "Bearer test-key-123"

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -9,6 +9,7 @@ Following Context7 best practices for structlog.
 import logging
 import uuid
 from contextvars import ContextVar
+from typing import TextIO
 
 import structlog
 
@@ -59,12 +60,15 @@ def clear_request_context() -> None:
     user_id_var.set("")
 
 
-def configure_logging(json_output: bool = True) -> None:
+def configure_logging(json_output: bool = True, stream: TextIO | None = None) -> None:
     """
     Configure structlog for the MCP server.
 
     Args:
         json_output: If True, use JSON renderer for production
+        stream: Log output stream. None (default) -> sys.stdout via PrintLoggerFactory.
+            The MCP stdio entrypoint passes sys.stderr so structlog never writes to
+            stdout, which is the JSON-RPC transport channel.
     """
     processors = [
         # Add correlation context from contextvars
@@ -94,7 +98,7 @@ def configure_logging(json_output: bool = True) -> None:
         processors=processors,
         wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
         context_class=dict,
-        logger_factory=structlog.PrintLoggerFactory(),
+        logger_factory=structlog.PrintLoggerFactory(file=stream),
         cache_logger_on_first_use=True,
     )
 


### PR DESCRIPTION
## What

Makes the `devskyy` MCP server actually run standalone over stdio, and pins the standalone FastMCP package. Found while wiring `devskyy` as a local stdio MCP server.

## Bugs fixed

**bug-134 — startup crash.** The banner (emoji + box-drawing) printed to **stdout** and raised `UnicodeEncodeError: surrogates not allowed` when stdout is a pipe (how MCP clients launch stdio servers), killing the server before it served. Also corrupted the JSON-RPC channel.
→ Banner + warnings routed to `sys.stderr`; `sys.stderr.reconfigure(errors="backslashreplace")` so an unencodable glyph escapes instead of crashing.

**bug-135 — tool execution broke end-to-end.**
- `structlog.PrintLoggerFactory()` defaults to **stdout** → per-request logs polluted the JSON-RPC channel. `configure_logging()` gains a `stream` param (default `None` → stdout, so the FastAPI app is unchanged); `devskyy_mcp.py` re-routes to `sys.stderr` **in stdio mode only**.
- `api_client.py` built `Authorization: Bearer {API_KEY}` unconditionally; the empty default key yielded `Bearer ` → httpx `LocalProtocolError` before sending. Header is now set only when a key is configured (no key is required for the local backend — `settings.API_KEY` is empty).

## Also
- Pin `fastmcp==3.0.0` in the `mcp` extras group (standalone FastMCP; the server still uses the SDK-bundled `mcp.server.fastmcp`).

## Verification (standalone, against live `uvicorn :8000`)
- boot: stdout **0 bytes**, banner on stderr, no crash
- stdio handshake: **38 tools** returned
- tool call: stdout **0 non-JSON-RPC lines**, **0 bearer errors**, `tool_completed success=true`, request reaches backend `GET /api/v1/agents/list`
- ruff/black/isort + mypy + fast tests green (pre-commit)

## Test plan
- [ ] `claude mcp get devskyy` → Connected (stdio)
- [ ] Invoke a tool from a client; confirm a clean JSON-RPC response

## Known follow-up (out of scope)
`/api/v1/agents/list` returns 422 to the tool (endpoint expects params the tool doesn't send) — a separate endpoint-contract mismatch, not this PR's header/logging bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `devskyy` MCP stdio server run standalone by keeping stdout strictly JSON‑RPC and moving banner/logs to stderr. Also fixes the agent list tool path, avoids empty `Authorization` headers, and pins `fastmcp` to 3.0.0.

- **Bug Fixes**
  - Send banner and warnings to stderr with backslash-escape on bad glyphs; no more UnicodeEncodeError on piped stdout.
  - In stdio mode, route `structlog` to stderr via `configure_logging(stream=sys.stderr)` to avoid JSON‑RPC stream pollution.
  - Only set `Authorization` when an API key exists; fixes `httpx` errors from a blank "Bearer ".
  - Point `list_agents` to GET `/api/v1/agents` (was `/agents/list` → 422) and drop the fixed "54" wording; tests cover endpoint path and Bearer header behavior.

- **Dependencies**
  - Pin `fastmcp==3.0.0` in the `mcp` extras (standalone FastMCP; SDK-bundled `mcp.server.fastmcp` still used).

<sup>Written for commit 4304c6d464ae5b37414ebb71e3775c8bc02b4003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Authorization header construction to prevent malformed headers when API credentials are missing or empty.
  * Improved output stream routing to prevent application logs from interfering with JSON-RPC protocol communication.

* **Chores**
  * Added FastMCP 3.0 as an optional dependency.
  * Updated bug tracking records with current deployment, rollback, and verification statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->