### PR TITLE
feat(imagery): on-model lookbook pipeline + hardened generative scripts

### DIFF
--- a/llm/providers/replicate.py
+++ b/llm/providers/replicate.py
@@ -72,7 +72,9 @@ class ReplicateClient:
         "flux-dev": "black-forest-labs/flux-dev",
         "flux-schnell": "black-forest-labs/flux-schnell",
         "sd-3": "stability-ai/stable-diffusion-3",
-        # SkyyRose Custom LoRA (trained on 390 exact product images)
+        # SkyyRose Custom LoRA (trained on 604 exact product images; verified
+        # 2026-06-18 against the live Replicate model description — the prior
+        # "390" comment was stale).
         "skyyrose-lora": "devskyy/skyyrose-lora-v3:64dbb859fed83670e7cde81fc161c183bd9d0607fb7028b01bfc0a000ec114b4",
         # Image Enhancement
         "real-esrgan": "nightmareai/real-esrgan:42fed1c4974146d4d2414e2be2c5277c7fcf05fcc3a73abf41610695738c1d7b",
@@ -191,9 +193,7 @@ class ReplicateClient:
         client = self._get_client()
 
         input_params = {
-            "image": (
-                open(image_path, "rb") if not image_path.startswith("http") else image_path
-            ),  # noqa: SIM115
+            "image": (open(image_path, "rb") if not image_path.startswith("http") else image_path),  # noqa: SIM115
             "scale": scale,
             "face_enhance": face_enhance,
         }
@@ -214,9 +214,7 @@ class ReplicateClient:
         client = self._get_client()
 
         input_params = {
-            "image": (
-                open(image_path, "rb") if not image_path.startswith("http") else image_path
-            ),  # noqa: SIM115
+            "image": (open(image_path, "rb") if not image_path.startswith("http") else image_path),  # noqa: SIM115
         }
 
         output = client.run(self.MODELS["rembg"], input=input_params)
@@ -237,9 +235,7 @@ class ReplicateClient:
         client = self._get_client()
 
         input_params = {
-            "image": (
-                open(image_path, "rb") if not image_path.startswith("http") else image_path
-            ),  # noqa: SIM115
+            "image": (open(image_path, "rb") if not image_path.startswith("http") else image_path),  # noqa: SIM115
             "task": "image_captioning",
         }
 

--- a/scripts/build-lookbook-mask.py
+++ b/scripts/build-lookbook-mask.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Build a garment-preserving mask for a gpt-image-2 masked edit (FREE, local).
+
+Pipeline (no API, no spend):
+  1. Crop the source lookbook to the edit aspect (default 3:2) and resize to the
+     edit size, so source + mask + output all share one geometry.
+  2. Segment the foreground garment/display cluster with rembg (u2net, cached).
+  3. Clean the alpha: fill interior holes, dilate a protective margin so garment
+     edges are never clipped, feather the boundary for a clean regen seam.
+  4. Emit the OpenAI mask (alpha=255 over garments => FROZEN; alpha=0 over the
+     scene => REGENERATED — per OpenAI's "transparent areas are edited" rule).
+  5. Emit a human overlay: garments full-colour, the regen zone dimmed — so the
+     founder can see exactly what is locked before any paid edit.
+
+Outputs -> renders/oai/_lookbook/:
+  _prep-<stem>.png      prepped source (edit geometry)
+  _mask-<stem>.png      OpenAI mask (RGBA)
+  _overlay-<stem>.png   reviewable protected-region overlay
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+from PIL import Image
+from rembg import new_session, remove
+from scipy import ndimage
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_DIR = PROJECT_ROOT / "renders" / "oai" / "_lookbook"
+
+# Per-garment protect boxes in the prepped 1536x1024 frame. Salient-object
+# models miss scattered garments, so we segment each garment inside its own box
+# (where it IS the salient object) and union the cuts. Boxes are generous;
+# rembg tightens to the actual garment edge inside each.
+PRESETS: dict[str, list[tuple[int, int, int, int]]] = {
+    # Love Hurts lookbook: jacket / rose-shorts / track-pants / bag / black-shorts.
+    # The rose-under-glass is intentionally EXCLUDED so the scene can relight it.
+    "love-hurts": [
+        (430, 120, 810, 620),  # bomber jacket on the bust (hood + body)
+        (945, 135, 1220, 470),  # rose-print shorts, hanging upper-right
+        (1085, 520, 1350, 865),  # white track pants on the right throne
+        (1290, 365, 1490, 685),  # FANATIC bag, far right
+        (70, 585, 350, 790),  # black shorts draped on the left pew
+    ],
+}
+
+
+def crop_to_aspect(img: Image.Image, aspect_w: int, aspect_h: int) -> Image.Image:
+    """Centre-crop to the target aspect (keeps the mid-frame garments)."""
+    w, h = img.size
+    target = aspect_w / aspect_h
+    if w / h > target:  # too wide -> crop width
+        new_w = int(round(h * target))
+        x0 = (w - new_w) // 2
+        return img.crop((x0, 0, x0 + new_w, h))
+    new_h = int(round(w / target))  # too tall -> crop height
+    y0 = (h - new_h) // 2
+    return img.crop((0, y0, w, y0 + new_h))
+
+
+def clean_alpha(alpha: np.ndarray, *, dilate_px: int, feather_px: int) -> np.ndarray:
+    """Binarise -> fill holes -> dilate margin -> feather. Returns uint8 0..255."""
+    binary = alpha > 96
+    binary = ndimage.binary_fill_holes(binary)
+    # Drop tiny specks (keep components >= 0.05% of frame).
+    labels, n = ndimage.label(binary)
+    if n:
+        min_area = int(0.0005 * binary.size)
+        keep = np.zeros_like(binary)
+        for i in range(1, n + 1):
+            comp = labels == i
+            if comp.sum() >= min_area:
+                keep |= comp
+        binary = keep
+    mask = (binary * 255).astype(np.uint8)
+    if dilate_px > 0:
+        k = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (dilate_px * 2 + 1, dilate_px * 2 + 1))
+        mask = cv2.dilate(mask, k)
+    if feather_px > 0:
+        ksize = feather_px * 2 + 1
+        mask = cv2.GaussianBlur(mask, (ksize, ksize), 0)
+    return mask
+
+
+def segment_by_boxes(
+    img: Image.Image, boxes: list[tuple[int, int, int, int]], model: str
+) -> np.ndarray:
+    """Segment each garment inside its own box and union the alphas (full-frame)."""
+    w, h = img.size
+    full = np.zeros((h, w), dtype=np.uint8)
+    session = new_session(model)
+    for x0, y0, x1, y1 in boxes:
+        x0, y0 = max(0, x0), max(0, y0)
+        x1, y1 = min(w, x1), min(h, y1)
+        if x0 >= x1 or y0 >= y1:
+            print(f"WARN: box {(x0, y0, x1, y1)} clipped to zero — skipping", file=sys.stderr)
+            continue
+        crop = img.crop((x0, y0, x1, y1))
+        cut = remove(crop, session=session)
+        a = np.array(cut.split()[-1])
+        full[y0:y1, x0:x1] = np.maximum(full[y0:y1, x0:x1], a)
+    return full
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Build garment-preserving edit mask")
+    ap.add_argument("--source", type=Path, default=Path("/tmp/lh-lookbook-ref-hires.png"))
+    ap.add_argument("--width", type=int, default=1536)
+    ap.add_argument("--height", type=int, default=1024)
+    ap.add_argument("--dilate", type=int, default=10, help="protective margin px")
+    ap.add_argument("--feather", type=int, default=6, help="edge feather px")
+    ap.add_argument("--model", default="u2net", help="rembg model (u2net | isnet-general-use)")
+    ap.add_argument(
+        "--preset",
+        choices=sorted(PRESETS),
+        help="per-garment box preset (segments each garment separately, then unions)",
+    )
+    args = ap.parse_args()
+
+    if not args.source.exists():
+        print(f"ABORT: source not found: {args.source}")
+        return 2
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    stem = args.source.stem
+
+    src = Image.open(args.source).convert("RGB")
+    prepped = crop_to_aspect(src, args.width, args.height).resize(
+        (args.width, args.height), Image.LANCZOS
+    )
+    prep_path = OUTPUT_DIR / f"_prep-{stem}.png"
+    prepped.save(prep_path)
+
+    if args.preset:
+        alpha = segment_by_boxes(prepped, PRESETS[args.preset], args.model)
+    else:
+        cut = remove(prepped, session=new_session(args.model))  # RGBA, bg transparent
+        alpha = np.array(cut.split()[-1])
+    fg = clean_alpha(alpha, dilate_px=args.dilate, feather_px=args.feather)
+
+    # OpenAI mask: alpha=255 over garments (FROZEN), 0 over scene (REGEN).
+    mask_rgba = np.zeros((args.height, args.width, 4), dtype=np.uint8)
+    mask_rgba[..., 3] = fg
+    mask_path = OUTPUT_DIR / f"_mask-{stem}.png"
+    Image.fromarray(mask_rgba, "RGBA").save(mask_path)
+
+    # Human overlay: garments full-colour; regen zone dimmed + green-tinted.
+    base = np.array(prepped).astype(np.float32)
+    fg_f = (fg.astype(np.float32) / 255.0)[..., None]
+    dimmed = base * 0.30
+    dimmed[..., 1] = np.clip(dimmed[..., 1] + 40, 0, 255)  # green cast on regen zone
+    overlay = (base * fg_f + dimmed * (1 - fg_f)).astype(np.uint8)
+    overlay_path = OUTPUT_DIR / f"_overlay-{stem}.png"
+    Image.fromarray(overlay).save(overlay_path)
+
+    pct = 100.0 * (fg > 127).sum() / fg.size
+    print(f"prepped : {prep_path}  ({args.width}x{args.height})")
+    print(f"mask    : {mask_path}  (frozen={pct:.1f}% of frame)")
+    print(f"overlay : {overlay_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build-lookbook-mask.py
+++ b/scripts/build-lookbook-mask.py
@@ -122,8 +122,8 @@ def main() -> int:
     )
     args = ap.parse_args()
 
-    if not args.source.exists():
-        print(f"ABORT: source not found: {args.source}")
+    if not args.source.is_file():
+        print(f"ABORT: source not a readable file: {args.source}")
         return 2
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     stem = args.source.stem

--- a/scripts/gen-hero-previews.py
+++ b/scripts/gen-hero-previews.py
@@ -307,6 +307,18 @@ def run(engines: list[str]) -> int:
     return 1 if failures else 0
 
 
+def _confirm(engines: list[str], assume_yes: bool) -> bool:
+    """Real STOP-AND-SHOW gate before any paid call; fail-closed in non-TTY."""
+    print(build_manifest(engines))
+    if assume_yes:
+        print("\n--yes supplied — proceeding.")
+        return True
+    if not sys.stdin.isatty():
+        print("\nABORT: non-interactive (no TTY) and --yes not set.", file=sys.stderr)
+        return False
+    return input().strip().lower() in {"y", "yes"}
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Hero-scene preview generator")
     ap.add_argument("mode", choices=["plan", "go"])
@@ -316,11 +328,19 @@ def main() -> int:
         choices=["openai", "replicate"],
         help="restrict to one engine (repeatable); default = both",
     )
+    ap.add_argument(
+        "--yes",
+        action="store_true",
+        help="skip the interactive confirmation (required in non-TTY/automation)",
+    )
     args = ap.parse_args()
     engines = args.engine or ["openai", "replicate"]
     if args.mode == "plan":
         print(build_manifest(engines))
         return 0
+    if not _confirm(engines, args.yes):
+        print("Aborted — no images generated.", file=sys.stderr)
+        return 2
     return run(engines)
 
 

--- a/scripts/gen-hero-previews.py
+++ b/scripts/gen-hero-previews.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Immersive Hub hero-scene PREVIEW generator (OpenAI + open-model FLUX).
+
+Generates the 4 canonical collection hero backdrops (Signature / Black Rose /
+Love Hurts / Kids Capsule) from the Guardian-approved v2 prompts in
+``docs/brand/immersive-hero-prompts.md`` so the founder can compare engines
+BEFORE committing to Midjourney finals.
+
+Two engines, one image per scene each:
+  • openai    — gpt-image-2, images.generate, 1536x1024 high  ("open version")
+  • replicate — FLUX1.1 [pro] ultra, native 16:9               (best open model)
+
+Keys are read AT RUNTIME from ``.env.hf`` by python-dotenv — never printed.
+
+Usage
+-----
+  python scripts/gen-hero-previews.py plan                 # free; prints manifest
+  python scripts/gen-hero-previews.py go                   # PAID; both engines
+  python scripts/gen-hero-previews.py go --engine openai   # PAID; one engine
+  python scripts/gen-hero-previews.py go --engine replicate
+
+Output -> renders/oai/_hero_preview/<slug>-<engine>.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import sys
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+# ── Runtime key load (interpreter reads .env.hf; values never surface) ───────
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(PROJECT_ROOT / ".env.hf", override=False)
+except Exception as exc:  # pragma: no cover - dotenv is a hard dep here
+    print(f"FATAL: could not load .env.hf ({exc})", file=sys.stderr)
+    sys.exit(2)
+
+OUTPUT_DIR = PROJECT_ROOT / "renders" / "oai" / "_hero_preview"
+
+# ── Per-engine cost estimates (USD/image) — STOP-AND-SHOW floors ─────────────
+EST_COST = {
+    "openai": 0.30,  # gpt-image-2 high, 1536x1024 generate (no ref-image tokens)
+    "replicate": 0.06,  # FLUX1.1 [pro] ultra flat per-image on Replicate
+}
+HARD_CAP_USD = 10.0  # tiny preview run; abort if estimate somehow exceeds this
+
+
+@dataclass(frozen=True)
+class Scene:
+    slug: str
+    name: str
+    body: str  # scene description, MJ flags stripped
+    negative: str  # comma-joined bans (folded into prompt for no-negative models)
+
+    @property
+    def openai_prompt(self) -> str:
+        return f"{self.body}. Strictly do NOT include: {self.negative}."
+
+    @property
+    def flux_prompt(self) -> str:
+        return f"{self.body}. Avoid: {self.negative}."
+
+
+SCENES: list[Scene] = [
+    Scene(
+        slug="signature",
+        name="Signature — 4 AM on the Ledge",
+        body=(
+            "Oakland rooftop concrete parapet at 4 AM, single metallic rose-gold rose "
+            "resting on the ledge lower-left third, long warm shadow across raw aggregate "
+            "concrete toward camera, distant Bay Bridge cables glowing amber-gold in warm "
+            "predawn haze lower-right third, open gradient sky filling center and upper "
+            "two-thirds transitioning from deep gold #D4AF37 at horizon to near-black "
+            "#0A0A0A overhead, dust motes and faint fog drift across bridge cables, luxury "
+            "streetwear editorial, cinematic anamorphic wide, warm-golden grade throughout, "
+            "no model no people, calm empty sky center for an overlaid title, dark vignette "
+            "toward all four edges heaviest at top-center, Fear of God x Oaklandish x Kith "
+            "editorial mood, photographic, ultra-detailed, 8k"
+        ),
+        negative=(
+            "text, watermark, logo, people, figures, silhouettes, ornate baroque ballroom, "
+            "fairytale castle, European luxury interior, chandelier, marble columns, cold "
+            "blue tones, blue, navy, silver grade, beach, surfboard, tech-minimalism, "
+            "white studio"
+        ),
+    ),
+    Scene(
+        slug="black-rose",
+        name="Black Rose — Concrete Refusal",
+        body=(
+            "Rain-slick West Oakland freeway underpass at 2am, monolithic I-880 concrete "
+            "support column scarred with decades of graffiti ghosts filling the entire left "
+            "third of the frame from floor to top edge, a single black rose with "
+            "silver-chrome petal edges growing through a crack at the column base in the "
+            "lower-left third, hard silver key light raking at 25 degrees from camera-left "
+            "catching only the petal rims and casting a thin liquid-silver reflection stripe "
+            "across wet dark asphalt, Port of Oakland container crane silhouettes barely "
+            "resolved through cold fog at far right edge, vast dark open negative space in "
+            "the upper center and center-right of frame for a title overlay, deep "
+            "atmospheric void ceiling, monochrome — black #0A0A0A dominates every surface, "
+            "silver #C0C0C0 only on rose petal rims and asphalt reflection, cool moonlight, "
+            "zero color cast zero warmth, heavy radial vignette darkest at upper corners, "
+            "brutalist streetwear-luxury editorial, cinematic anamorphic, Fear of God x "
+            "Oaklandish mood, ultra-detailed, 8k"
+        ),
+        negative=(
+            "text, watermark, logo, people, blue, navy, warm color grading, gold tones, "
+            "red tones, baroque ballroom, fairytale castle, warm color interior decor, "
+            "ornate architecture, cartoon, stock photo"
+        ),
+    ),
+    Scene(
+        slug="love-hurts",
+        name="Love Hurts — The Beast at the Threshold",
+        body=(
+            "Rain-slick East Oakland industrial alley at deep night, wide cinematic "
+            "anamorphic shot, raw red-brick wall right third glistening with moisture, "
+            "corrugated iron gate left third slightly ajar revealing pure darkness beyond, "
+            "a single deep-crimson rose resting snapped on wet black asphalt at lower "
+            "center, rose petals luminous and intact against the dark ground, crimson neon "
+            "bleed off-screen left casting hard red fill across wet brick and asphalt "
+            "reflection pools, color palette blood-crimson #DC143C and deep shadow-crimson "
+            "#9B0F2E against near-black #0A0A0A, calm open dark negative space in the "
+            "center-vertical third of frame for title overlay, heavy vignette pulling to "
+            "near-black at all four corners, no people, no faces, presence felt only "
+            "through the open gate, Fear of God cinematic stillness meets Palm Angels "
+            "street-luxe detail meets Culture Kings drop-moment tension, Oakland civic "
+            "grit, luxury streetwear editorial, photographic, ultra-detailed, 8k"
+        ),
+        negative=(
+            "text, watermark, logo, ornate baroque ballroom, fairytale castle, gilded "
+            "interior, chandeliers, Valentine florals, soft-focus romance, pink, purple, "
+            "blue, navy, European fashion editorial, cartoon, people, faces"
+        ),
+    ),
+    Scene(
+        slug="kids-capsule",
+        name="Kids Capsule — The City Is the Throne",
+        body=(
+            "A child in a dark red-black colorblock luxury hoodie stands at the edge of a "
+            "raw concrete rooftop parapet in Oakland at magic-hour dusk, back "
+            "three-quarters to camera, facing the city skyline, posture unhurried and "
+            "grounded, a neatly folded purple-black colorblock hoodie resting on the "
+            "concrete ledge beside them, directional warm rose-gold sunlight from "
+            "camera-right catching the child's far shoulder and pooling on the rough "
+            "concrete surface, Oakland downtown skyline glowing amber-gold at building "
+            "faces, Port of Oakland crane silhouettes far left, Bay Bridge string-light arc "
+            "low on the right horizon, sky grading from deep warm gold #D4AF37 at the "
+            "horizon through rose-amber #B76E79 haze into deep indigo #1A1228 at the "
+            "zenith, entire upper sky as calm empty negative space for an overlaid title, "
+            "child occupies lower-left third frame, folded garment anchors lower-right, "
+            "concrete parapet as horizontal ground line, natural dark vignette at left and "
+            "right edges, cinematic anamorphic 16:9, luxury streetwear editorial, Kith "
+            "Kids x Oaklandish x Fear of God photographic mood, ultra-detailed, 8k"
+        ),
+        negative=(
+            "text, watermark, logo, crown, throne chair, throne, tiny crown, cartoon, "
+            "pastel, blue, navy, ornate baroque ballroom, fairytale castle, creepy, child "
+            "facing camera, staring at camera, soft focus, saccharine, generic stock photo, "
+            "European luxury house aesthetic, white background, floral props"
+        ),
+    ),
+]
+
+
+# ── Engines ──────────────────────────────────────────────────────────────────
+def gen_openai(scene: Scene) -> bytes:
+    """gpt-image-2 text-to-image, 1536x1024 landscape, high fidelity."""
+    from openai import OpenAI
+
+    key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if not key:
+        raise RuntimeError("OPENAI_API_KEY absent from .env.hf")
+    client = OpenAI(api_key=key, timeout=180.0)
+    resp = client.images.generate(
+        model="gpt-image-2",
+        prompt=scene.openai_prompt,
+        size="1536x1024",
+        quality="high",
+        n=1,
+    )
+    b64 = resp.data[0].b64_json
+    if not b64:
+        raise RuntimeError("openai returned no image data")
+    return base64.b64decode(b64)
+
+
+def gen_replicate(scene: Scene) -> bytes:
+    """FLUX1.1 [pro] ultra on Replicate, native 16:9."""
+    import replicate
+
+    key = os.environ.get("REPLICATE_API_TOKEN", "").strip()
+    if not key:
+        raise RuntimeError("REPLICATE_API_TOKEN absent from .env.hf")
+    output = replicate.Client(api_token=key).run(
+        "black-forest-labs/flux-1.1-pro-ultra",
+        input={
+            "prompt": scene.flux_prompt,
+            "aspect_ratio": "16:9",
+            "output_format": "png",
+            "safety_tolerance": 6,
+            "raw": False,
+        },
+    )
+    return _read_replicate_output(output)
+
+
+def _read_replicate_output(output: object) -> bytes:
+    """Normalize Replicate's FileOutput | list | url-string into raw bytes."""
+    if isinstance(output, list):
+        output = output[0]
+    if hasattr(output, "read"):  # FileOutput
+        data = output.read()
+        if not isinstance(data, bytes):
+            raise TypeError(f"FileOutput.read() returned {type(data).__name__}, expected bytes")
+        return data
+    url = str(output)
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or not (parsed.hostname or "").endswith("replicate.delivery"):
+        raise RuntimeError(f"refusing to fetch untrusted Replicate URL: {url!r}")
+    with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310 — validated above
+        return resp.read()
+
+
+ENGINES = {"openai": gen_openai, "replicate": gen_replicate}
+
+
+# ── Manifest / orchestration ─────────────────────────────────────────────────
+def build_manifest(engines: list[str]) -> str:
+    n = len(SCENES)
+    lines = [
+        "STOP — Confirm before proceeding (PAID hero-scene preview generation):",
+        "",
+        f"  Scenes      : {n}  (signature, black-rose, love-hurts, kids-capsule)",
+        f"  Engines     : {', '.join(engines)}",
+        f"  Images      : {n * len(engines)}",
+        "",
+        "  Engine      Model                            Size        $/img   Subtotal",
+        "  " + "-" * 70,
+    ]
+    total = 0.0
+    specs = {
+        "openai": ("gpt-image-2 (high)", "1536x1024"),
+        "replicate": ("FLUX1.1 [pro] ultra", "16:9 ~2K"),
+    }
+    for eng in engines:
+        model, size = specs[eng]
+        sub = n * EST_COST[eng]
+        total += sub
+        lines.append(f"  {eng:<11} {model:<32} {size:<11} ${EST_COST[eng]:<5.2f}  ${sub:.2f}")
+    lines += [
+        "  " + "-" * 70,
+        f"  EST. TOTAL  : ~${total:.2f}   (FLOOR estimate; OpenAI/Replicate bill actual)",
+        f"  Hard cap    : ${HARD_CAP_USD:.2f}" + ("  ⚠ EXCEEDED" if total > HARD_CAP_USD else ""),
+        "",
+        "  Keys present:",
+        f"    OPENAI_API_KEY     {'✓' if os.environ.get('OPENAI_API_KEY') else '✗ MISSING'}",
+        f"    REPLICATE_API_TOKEN{'  ✓' if os.environ.get('REPLICATE_API_TOKEN') else '  ✗ MISSING'}",
+        "",
+        f"  Output      : {OUTPUT_DIR.relative_to(PROJECT_ROOT)}/<slug>-<engine>.png",
+        "",
+        "Proceed? [y/N]",
+    ]
+    return "\n".join(lines)
+
+
+def run(engines: list[str]) -> int:
+    total_est = sum(len(SCENES) * EST_COST[e] for e in engines)
+    if total_est > HARD_CAP_USD:
+        print(f"ABORT: estimate ${total_est:.2f} exceeds hard cap ${HARD_CAP_USD:.2f}")
+        return 2
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    failures = 0
+    for scene in SCENES:
+        for eng in engines:
+            dest = OUTPUT_DIR / f"{scene.slug}-{eng}.png"
+            try:
+                print(f"[{eng}] {scene.slug} … generating", flush=True)
+                data = ENGINES[eng](scene)
+                dest.write_bytes(data)
+                print(f"[{eng}] {scene.slug} ✓ {dest}  ({len(data) // 1024} KB)", flush=True)
+            except Exception as exc:  # noqa: BLE001 — surface, continue other scenes
+                failures += 1
+                print(f"[{eng}] {scene.slug} ✗ {type(exc).__name__}: {exc}", file=sys.stderr)
+    print(f"\nDone. {len(SCENES) * len(engines) - failures} ok, {failures} failed -> {OUTPUT_DIR}")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Hero-scene preview generator")
+    ap.add_argument("mode", choices=["plan", "go"])
+    ap.add_argument(
+        "--engine",
+        action="append",
+        choices=["openai", "replicate"],
+        help="restrict to one engine (repeatable); default = both",
+    )
+    args = ap.parse_args()
+    engines = args.engine or ["openai", "replicate"]
+    if args.mode == "plan":
+        print(build_manifest(engines))
+        return 0
+    return run(engines)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen-hero-previews.py
+++ b/scripts/gen-hero-previews.py
@@ -29,9 +29,10 @@ import base64
 import os
 import sys
 import urllib.parse
-import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
+
+import httpx
 
 # ── Runtime key load (interpreter reads .env.hf; values never surface) ───────
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -226,8 +227,11 @@ def _read_replicate_output(output: object) -> bytes:
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme != "https" or not (parsed.hostname or "").endswith("replicate.delivery"):
         raise RuntimeError(f"refusing to fetch untrusted Replicate URL: {url!r}")
-    with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310 — validated above
-        return resp.read()
+    # follow_redirects=False so a CDN redirect cannot bounce the fetch to an
+    # unvalidated (internal) host after the allowlist check.
+    resp = httpx.get(url, follow_redirects=False, timeout=120.0)
+    resp.raise_for_status()
+    return resp.content
 
 
 ENGINES = {"openai": gen_openai, "replicate": gen_replicate}
@@ -277,6 +281,8 @@ def run(engines: list[str]) -> int:
     if total_est > HARD_CAP_USD:
         print(f"ABORT: estimate ${total_est:.2f} exceeds hard cap ${HARD_CAP_USD:.2f}")
         return 2
+    import openai
+
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     failures = 0
     for scene in SCENES:
@@ -287,6 +293,13 @@ def run(engines: list[str]) -> int:
                 data = ENGINES[eng](scene)
                 dest.write_bytes(data)
                 print(f"[{eng}] {scene.slug} ✓ {dest}  ({len(data) // 1024} KB)", flush=True)
+            except openai.AuthenticationError:
+                # Never print str(exc) — the OpenAI SDK echoes a partial key in it.
+                print(
+                    f"[{eng}] {scene.slug} ✗ AuthenticationError: check OPENAI_API_KEY",
+                    file=sys.stderr,
+                )
+                return 1
             except Exception as exc:  # noqa: BLE001 — surface, continue other scenes
                 failures += 1
                 print(f"[{eng}] {scene.slug} ✗ {type(exc).__name__}: {exc}", file=sys.stderr)

--- a/scripts/gen-lookbook-remake.py
+++ b/scripts/gen-lookbook-remake.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Lookbook remake via gpt-image-2 EDIT (garment-preserving).
+
+Takes the founder's existing Love Hurts lookbook (real garments already
+composited in) as the SOURCE image and re-renders it "better" — same garments,
+same layout, elevated scene. Because the garments come from the input image,
+they are preserved, never invented (the "actual clothing" guarantee).
+
+Two variants:
+  v1 elevated  — faithful: same garments/layout, better light, detail, depth.
+  v2 beauty    — push the Beauty-and-the-Beast enchanted-cathedral mood harder.
+
+Keys read at runtime from .env.hf by python-dotenv — never printed.
+
+Usage
+-----
+  python scripts/gen-lookbook-remake.py plan
+  python scripts/gen-lookbook-remake.py go                 # both variants
+  python scripts/gen-lookbook-remake.py go --variant v1    # one variant
+  python scripts/gen-lookbook-remake.py go --source /path/to/ref.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SOURCE = Path("/tmp/lh-lookbook-ref-hires.png")
+OUTPUT_DIR = PROJECT_ROOT / "renders" / "oai" / "_lookbook"
+# Masked mode (pixel-exact garments): prepped frame + garment mask from
+# build-lookbook-mask.py must share geometry (1536x1024).
+PREP_SOURCE = OUTPUT_DIR / "_prep-lh-lookbook-ref-hires.png"
+MASK_PATH = OUTPUT_DIR / "_mask-lh-lookbook-ref-hires.png"
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(PROJECT_ROOT / ".env.hf", override=False)
+except Exception as exc:  # pragma: no cover
+    print(f"FATAL: could not load .env.hf ({exc})", file=sys.stderr)
+    sys.exit(2)
+
+MODEL = "gpt-image-2"
+SIZE = "1536x1024"  # landscape, closest to the ~4:3 reference
+QUALITY = "high"
+EST_COST_PER_IMAGE = 0.40  # edit with 1 input image ≈ $0.35–0.40 (repo-verified floor)
+HARD_CAP_USD = 5.0
+
+_MIME = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".webp": "image/webp"}
+
+# The non-negotiable garment-preservation clause, prepended to every variant.
+PRESERVE = (
+    "This is a fashion lookbook of REAL garments. Keep every garment EXACTLY as "
+    "shown in the source image — identical designs, embroidery, printed text, "
+    "logos, colors, proportions, and on-scene placement. Do NOT redesign, "
+    "recolor, restyle, add, remove, or move any garment, bag, or the rose-under-"
+    "glass. Only improve the surrounding scene, lighting, materials, and detail. "
+)
+
+VARIANTS = {
+    "v1": (
+        PRESERVE + "Re-render this Love Hurts lookbook at higher production value: cleaner "
+        "studio-grade lighting, deeper shadow detail, richer stone and velvet "
+        "textures, crisp focus on each garment, subtle volumetric haze, refined "
+        "color grade in crimson and warm candlelight. Luxury streetwear editorial, "
+        "photographic, ultra-detailed, 8k. Keep the gothic-cathedral setting and "
+        "the same camera framing."
+    ),
+    "v2": (
+        PRESERVE + "Intensify the Beauty-and-the-Beast enchantment: the single crimson rose "
+        "under the glass cloche glowing softly as the heart of the room, dramatic "
+        "god-rays pouring through the stained-glass windows, taller candle "
+        "candelabra with warm flickering flame, heavier draped crimson and plum "
+        "velvet, slow-falling rose petals suspended in the light, weathered marble "
+        "and gold detailing, fairytale grandeur and romance-meets-darkness mood. "
+        "Cinematic, painterly luxury, ultra-detailed, 8k. Same gothic cathedral, "
+        "same garment placement."
+    ),
+}
+
+
+def _as_upload(path: Path) -> tuple[str, bytes, str]:
+    mime = _MIME.get(path.suffix.lower())
+    if mime is None:
+        raise ValueError(f"Unsupported source image type: {path}")
+    size = path.stat().st_size
+    if size > 20 * 1024 * 1024:  # OpenAI image-edit hard cap is 20 MB
+        raise ValueError(f"{path.name} is {size // 1024 // 1024} MB (OpenAI edit cap 20 MB)")
+    return (path.name, path.read_bytes(), mime)
+
+
+def gen_edit(source: Path, prompt: str, mask: Path | None = None) -> bytes:
+    from openai import OpenAI
+
+    key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if not key:
+        raise RuntimeError("OPENAI_API_KEY absent from .env.hf")
+    client = OpenAI(api_key=key, timeout=240.0)
+    kwargs: dict = {
+        "model": MODEL,
+        "image": [_as_upload(source)],
+        "prompt": prompt,
+        "size": SIZE,
+        "quality": QUALITY,
+        "n": 1,
+    }
+    if mask is not None:
+        # Masked edit: alpha=0 regions regenerate, alpha=255 (garments) frozen.
+        kwargs["mask"] = _as_upload(mask)
+    resp = client.images.edit(**kwargs)
+    b64 = resp.data[0].b64_json
+    if not b64:
+        raise RuntimeError("openai returned no image data")
+    return base64.b64decode(b64)
+
+
+def build_manifest(source: Path, variants: list[str], mask: Path | None) -> str:
+    n = len(variants)
+    total = n * EST_COST_PER_IMAGE
+    src_ok = source.exists()
+    mode = (
+        "MASKED (pixel-exact garments — frozen by mask)"
+        if mask
+        else "generative (garments redrawn)"
+    )
+    mask_line = (
+        f"  Mask        : {mask}  {'✓ exists' if mask and mask.exists() else '✗ MISSING'}"
+        if mask
+        else "  Mask        : (none — generative edit)"
+    )
+    lines = [
+        "STOP — Confirm before proceeding (PAID gpt-image-2 EDIT — lookbook remake):",
+        "",
+        f"  Model       : {MODEL} (edit, quality={QUALITY}, size={SIZE})",
+        f"  Mode        : {mode}",
+        f"  Source      : {source}  {'✓ exists' if src_ok else '✗ MISSING'}",
+        mask_line,
+        f"  Variants    : {', '.join(variants)}",
+        f"  Images      : {n}",
+        f"  Est. cost   : ~${total:.2f}  (FLOOR @ ${EST_COST_PER_IMAGE:.2f}/img; OpenAI bills actual)",
+        f"  Hard cap    : ${HARD_CAP_USD:.2f}" + ("  ⚠ EXCEEDED" if total > HARD_CAP_USD else ""),
+        f"  Key present : {'✓' if os.environ.get('OPENAI_API_KEY') else '✗ MISSING'}",
+        f"  Output      : {OUTPUT_DIR.relative_to(PROJECT_ROOT)}/love-hurts-remake-<variant>.png",
+        "",
+        "Proceed? [y/N]",
+    ]
+    return "\n".join(lines)
+
+
+def run(source: Path, variants: list[str], mask: Path | None) -> int:
+    if not source.exists():
+        print(f"ABORT: source image not found: {source}", file=sys.stderr)
+        return 2
+    if mask is not None and not mask.exists():
+        print(f"ABORT: mask not found: {mask}", file=sys.stderr)
+        return 2
+    total = len(variants) * EST_COST_PER_IMAGE
+    if total > HARD_CAP_USD:
+        print(f"ABORT: estimate ${total:.2f} exceeds hard cap ${HARD_CAP_USD:.2f}")
+        return 2
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    suffix = "-masked" if mask else ""
+    failures = 0
+    for v in variants:
+        dest = OUTPUT_DIR / f"love-hurts-remake-{v}{suffix}.png"
+        try:
+            print(f"[{v}] editing …", flush=True)
+            data = gen_edit(source, VARIANTS[v], mask=mask)
+            dest.write_bytes(data)
+            print(f"[{v}] ✓ {dest}  ({len(data) // 1024} KB)", flush=True)
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"[{v}] ✗ {type(exc).__name__}: {exc}", file=sys.stderr)
+    print(f"\nDone. {len(variants) - failures} ok, {failures} failed -> {OUTPUT_DIR}")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="gpt-image-2 lookbook remake")
+    ap.add_argument("mode", choices=["plan", "go"])
+    ap.add_argument(
+        "--source",
+        type=Path,
+        default=None,
+        help="default: prepped frame in masked mode, else raw ref",
+    )
+    ap.add_argument("--variant", action="append", choices=["v1", "v2"], help="default = both")
+    ap.add_argument(
+        "--masked",
+        action="store_true",
+        help="pixel-exact: use the prepped frame + garment mask (frozen garments)",
+    )
+    ap.add_argument("--mask", type=Path, default=None, help="override mask path (implies --masked)")
+    args = ap.parse_args()
+    variants = args.variant or ["v1", "v2"]
+
+    mask = None
+    if args.mask is not None:
+        mask = args.mask
+    elif args.masked:
+        mask = MASK_PATH
+    # In masked mode the source MUST match the mask geometry → the prepped frame.
+    source = args.source or (PREP_SOURCE if mask else DEFAULT_SOURCE)
+
+    if args.mode == "plan":
+        print(build_manifest(source, variants, mask))
+        return 0
+    return run(source, variants, mask)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen-lookbook-remake.py
+++ b/scripts/gen-lookbook-remake.py
@@ -185,6 +185,18 @@ def run(source: Path, variants: list[str], mask: Path | None) -> int:
     return 1 if failures else 0
 
 
+def _confirm(source: Path, variants: list[str], mask: Path | None, assume_yes: bool) -> bool:
+    """Real STOP-AND-SHOW gate before any paid call; fail-closed in non-TTY."""
+    print(build_manifest(source, variants, mask))
+    if assume_yes:
+        print("\n--yes supplied — proceeding.")
+        return True
+    if not sys.stdin.isatty():
+        print("\nABORT: non-interactive (no TTY) and --yes not set.", file=sys.stderr)
+        return False
+    return input().strip().lower() in {"y", "yes"}
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="gpt-image-2 lookbook remake")
     ap.add_argument("mode", choices=["plan", "go"])
@@ -201,6 +213,11 @@ def main() -> int:
         help="pixel-exact: use the prepped frame + garment mask (frozen garments)",
     )
     ap.add_argument("--mask", type=Path, default=None, help="override mask path (implies --masked)")
+    ap.add_argument(
+        "--yes",
+        action="store_true",
+        help="skip the interactive confirmation (required in non-TTY/automation)",
+    )
     args = ap.parse_args()
     variants = args.variant or ["v1", "v2"]
 
@@ -215,6 +232,9 @@ def main() -> int:
     if args.mode == "plan":
         print(build_manifest(source, variants, mask))
         return 0
+    if not _confirm(source, variants, mask, args.yes):
+        print("Aborted — no images generated.", file=sys.stderr)
+        return 2
     return run(source, variants, mask)
 
 

--- a/scripts/gen-lookbook-remake.py
+++ b/scripts/gen-lookbook-remake.py
@@ -162,6 +162,8 @@ def run(source: Path, variants: list[str], mask: Path | None) -> int:
     if total > HARD_CAP_USD:
         print(f"ABORT: estimate ${total:.2f} exceeds hard cap ${HARD_CAP_USD:.2f}")
         return 2
+    import openai
+
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     suffix = "-masked" if mask else ""
     failures = 0
@@ -172,6 +174,10 @@ def run(source: Path, variants: list[str], mask: Path | None) -> int:
             data = gen_edit(source, VARIANTS[v], mask=mask)
             dest.write_bytes(data)
             print(f"[{v}] ✓ {dest}  ({len(data) // 1024} KB)", flush=True)
+        except openai.AuthenticationError:
+            # Never print str(exc) — the OpenAI SDK echoes a partial key in it.
+            print(f"[{v}] ✗ AuthenticationError: check OPENAI_API_KEY", file=sys.stderr)
+            return 1
         except Exception as exc:  # noqa: BLE001
             failures += 1
             print(f"[{v}] ✗ {type(exc).__name__}: {exc}", file=sys.stderr)

--- a/scripts/oai_render/lookbook.py
+++ b/scripts/oai_render/lookbook.py
@@ -150,6 +150,40 @@ def _manifest(skus: list[str]) -> cost.CostManifest:
     return cost.CostManifest(entries=entries)
 
 
+def _run_batch(skus: list[str], scene: Path, collection: str | None, out_dir: Path) -> int:
+    """Render each SKU on-model, tracking spend against the hard cap. Returns exit code."""
+    import openai
+
+    tracker = cost.SpendTracker()
+    failures = 0
+    for sku in skus:
+        safe_sku = re.sub(r"[^a-z0-9\-]", "", sku.lower())
+        dest = out_dir / f"{safe_sku}-onmodel.png"
+        if not tracker.can_afford(config.EST_COST_PER_IMAGE_USD):
+            print(f"STOP: spend cap ${tracker.cap_usd:.2f} reached before {sku}", file=sys.stderr)
+            break
+        try:
+            print(f"[{sku}] rendering on-model ...", flush=True)
+            data = generate_one(sku, scene, collection, dest)
+            tracker.add(config.EST_COST_PER_IMAGE_USD)
+            print(f"[{sku}] [ok] {dest} ({len(data) // 1024} KB)", flush=True)
+        except openai.AuthenticationError:
+            # Never print str(exc) — the OpenAI SDK echoes a partial key in it.
+            print(
+                f"[{sku}] [fail] AuthenticationError: check {config.API_KEY_ENV}", file=sys.stderr
+            )
+            failures += 1
+            break  # every subsequent call fails identically
+        except (references.MissingReferenceError, FileNotFoundError) as exc:
+            print(f"[{sku}] [fail] {type(exc).__name__}: {exc}", file=sys.stderr)
+            failures += 1
+        except Exception as exc:  # noqa: BLE001 — surface, continue the batch
+            failures += 1
+            print(f"[{sku}] [fail] {type(exc).__name__}: {exc}", file=sys.stderr)
+    print(f"\nDone. spent ~${tracker.spent_usd:.2f}, {failures} failed -> {out_dir}")
+    return 1 if failures else 0
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="On-model lookbook (gpt-image-2 edit)")
     ap.add_argument("mode", choices=["plan", "generate"])
@@ -181,7 +215,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.mode == "plan":
         return 0
 
-    cost.enforce_cap(manifest)
+    try:
+        cost.enforce_cap(manifest)
+    except cost.CostCapExceeded as exc:
+        print(f"ABORT: {exc}", file=sys.stderr)
+        return 2
     if not args.yes:
         print("\nRefusing to spend without --yes (STOP-AND-SHOW gate).", file=sys.stderr)
         return 3
@@ -189,36 +227,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ABORT: {config.API_KEY_ENV} not set (add to .env.hf)", file=sys.stderr)
         return 2
 
-    import openai
-
-    tracker = cost.SpendTracker()
-    failures = 0
-    for sku in args.sku:
-        safe_sku = re.sub(r"[^a-z0-9\-]", "", sku.lower())
-        dest = out_dir / f"{safe_sku}-onmodel.png"
-        if not tracker.can_afford(config.EST_COST_PER_IMAGE_USD):
-            print(f"STOP: spend cap ${tracker.cap_usd:.2f} reached before {sku}", file=sys.stderr)
-            break
-        try:
-            print(f"[{sku}] rendering on-model ...", flush=True)
-            data = generate_one(sku, args.scene, args.collection, dest)
-            tracker.add(config.EST_COST_PER_IMAGE_USD)
-            print(f"[{sku}] [ok] {dest} ({len(data) // 1024} KB)", flush=True)
-        except openai.AuthenticationError:
-            # Never print str(exc) — the OpenAI SDK echoes a partial key in it.
-            print(
-                f"[{sku}] [fail] AuthenticationError: check {config.API_KEY_ENV}", file=sys.stderr
-            )
-            failures += 1
-            break  # every subsequent call fails identically
-        except (references.MissingReferenceError, FileNotFoundError) as exc:
-            print(f"[{sku}] [fail] {type(exc).__name__}: {exc}", file=sys.stderr)
-            failures += 1
-        except Exception as exc:  # noqa: BLE001 — surface, continue the batch
-            failures += 1
-            print(f"[{sku}] [fail] {type(exc).__name__}: {exc}", file=sys.stderr)
-    print(f"\nDone. spent ~${tracker.spent_usd:.2f}, {failures} failed -> {out_dir}")
-    return 1 if failures else 0
+    return _run_batch(args.sku, args.scene, args.collection, out_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/oai_render/lookbook.py
+++ b/scripts/oai_render/lookbook.py
@@ -1,0 +1,225 @@
+"""On-model lookbook generation — gpt-image-2 edit of a real garment into a scene.
+
+Folded from the engine-comparison prototype (renders/oai/_lookbook/_prototype/):
+gpt-image-2 **edit** won decisively over FASHN try-on and FLUX Kontext because it
+absorbs a flat product *techflat* + a styled scene in a single pass — producing a
+model who genuinely *wears* the garment in the scene, no floating. FASHN needs a
+ghost-mannequin/product garment image (wrong input contract for our flat
+techflats); Kontext's masked scene-drop produced blank output. Verdict + evidence:
+``renders/oai/_lookbook/_prototype/NOTES.md`` (bug-141 for the FASHN dead-end).
+
+This module reuses the canonical OAI imagery infrastructure rather than
+re-implementing it:
+  • garment refs  -> ``references.build_references`` (canonical SKU→techflat map,
+                     hard-fails on a missing garment — no silent fallback)
+  • catalog facts -> ``catalog_loader.get_product_with_dossier``
+  • the edit call -> ``client.OAIImageClient`` (retry/backoff, gpt-image-2 high)
+  • cost + gate   -> ``cost.CostManifest`` / ``format_manifest`` / ``SpendTracker``
+
+CLI:
+    python -m scripts.oai_render.lookbook plan     --sku lh-004 --scene <scene.png>
+    python -m scripts.oai_render.lookbook generate --sku lh-004 --scene <scene.png> --yes
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Ensure OPENAI_API_KEY is present for config.get_api_key() — the project env
+# loader (root .env + gemini/.env) may not carry it; .env.hf does. config reads
+# the key LAZILY (at OAIImageClient init, in generate_one), so loading .env.hf
+# here at import — before any client is built — is sufficient. The interpreter
+# reads the value; it is never logged.
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(Path(__file__).resolve().parents[2] / ".env.hf", override=False)
+except ImportError:  # pragma: no cover - dotenv optional if key already exported
+    pass
+
+from skyyrose.core.catalog_loader import get_product_with_dossier  # noqa: E402
+from skyyrose.core.dossier_loader import DossierMissingError  # noqa: E402
+
+from . import config, cost, references  # noqa: E402
+from .client import OAIImageClient  # noqa: E402
+
+# Per-collection scene register (the prompt's setting; the actual backdrop image
+# is supplied via --scene). love-hurts = the Beauty-and-the-Beast gothic world;
+# the others default to the brand's Oakland-concrete-luxury register.
+COLLECTION_SCENE: dict[str, str] = {
+    "love-hurts": (
+        "a candlelit gothic cathedral interior with a Beauty-and-the-Beast mood — "
+        "ornate stone arches, stained glass, crimson velvet drapes, an enchanted "
+        "rose under a glass cloche, rose petals scattered on the stone floor, "
+        "dramatic warm candlelight"
+    ),
+    "black-rose": (
+        "a rain-slick West Oakland concrete underpass at night — brutalist pillars, "
+        "silver-rimmed light, wet asphalt reflections, cold monochrome luxury"
+    ),
+    "signature": (
+        "an Oakland rooftop at warm predawn — raw concrete parapet, the Bay Bridge "
+        "glowing amber in the haze, gold-graded cinematic editorial light"
+    ),
+    "kids-capsule": (
+        "an Oakland rooftop at magic-hour dusk facing the downtown skyline — warm "
+        "rose-gold light, Bay Bridge on the horizon, grounded and unhurried"
+    ),
+}
+DEFAULT_SCENE = "an Oakland concrete-luxury editorial setting with dramatic directional light"
+
+
+def _garment_paths(sku: str, collection: str) -> list[Path]:
+    """Canonical front-only garment references for an on-model render.
+
+    Front-only (``include_back=False``) avoids the back-view / multi-panel collage
+    failure mode. Raises ``references.MissingReferenceError`` if no garment source
+    exists — never silently substitutes.
+    """
+    refs = references.build_references(sku, collection, include_back=False)
+    # On-model: feed the garment photo/techflat, and a sport patch only when the
+    # SKU requires it (jerseys). Exclude collection LOGO refs — as a separate edit
+    # input on a worn render the model may treat the branding script as a second
+    # garment; the techflat already carries the branding in situ.
+    needs_patch = references.requires_patch(sku)
+    keep = [
+        r
+        for r in refs
+        if r.path.exists() and (r.kind == "garment" or (r.kind == "patch" and needs_patch))
+    ]
+    if not keep:
+        raise references.MissingReferenceError(f"no usable garment reference for {sku}")
+    return [r.path for r in keep]
+
+
+def _resolve(sku: str, collection: str | None) -> tuple[str, str, str]:
+    """Return (name, collection, scene_desc) from the canonical catalog row.
+
+    ``get_product_with_dossier`` hard-fails (KeyError for an unknown SKU,
+    DossierMissingError for an un-authored dossier) — convert both to
+    MissingReferenceError so ``main`` reports a clean ABORT, never a traceback.
+    """
+    try:
+        row = get_product_with_dossier(sku)
+    except (KeyError, DossierMissingError) as exc:
+        raise references.MissingReferenceError(f"{sku}: {exc}") from exc
+    name = (row.get("name") or sku).strip()
+    coll = (collection or row.get("collection") or "").strip()
+    scene_desc = COLLECTION_SCENE.get(coll, DEFAULT_SCENE)
+    return name, coll, scene_desc
+
+
+def build_prompt(name: str, scene_desc: str) -> str:
+    """Lookbook 'worn, not floating' prompt — garment is the protagonist."""
+    return (
+        f"Full-body editorial fashion photograph of a model wearing this exact "
+        f"{name}, worn naturally with realistic drape, fit, fabric folds and grounded "
+        f"contact shadows. Reproduce the garment's exact design, colors, embroidery "
+        f"and lettering from the reference image — do not invent, recolor or restyle "
+        f"any part of the garment. The model stands in {scene_desc}. The garment is "
+        f"the protagonist of the frame. Cinematic, photographic, ultra-detailed, 8k."
+    )
+
+
+def generate_one(sku: str, scene: Path, collection: str | None, dest: Path) -> bytes:
+    """Render one on-model lookbook image. Returns PNG bytes, writes to dest."""
+    if not scene.exists():
+        raise FileNotFoundError(f"scene image not found: {scene}")
+    name, coll, scene_desc = _resolve(sku, collection)
+    garments = _garment_paths(sku, coll)
+    image_paths = [*garments, scene]  # garments lead (authority); scene = context
+    prompt = build_prompt(name, scene_desc)
+    data = OAIImageClient().edit(prompt=prompt, image_paths=image_paths)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(data)
+    return data
+
+
+def _manifest(skus: list[str]) -> cost.CostManifest:
+    entries = []
+    for sku in skus:
+        name, coll, _ = _resolve(sku, None)
+        # Count the garment refs actually sent to the edit call (not all of
+        # build_references, which may include excluded logo refs) so the manifest
+        # never overstates the API inputs.
+        ref_count = len(_garment_paths(sku, coll))
+        entries.append(cost.ManifestEntry(sku=sku, name=name, n_images=1, ref_count=ref_count))
+    return cost.CostManifest(entries=entries)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="On-model lookbook (gpt-image-2 edit)")
+    ap.add_argument("mode", choices=["plan", "generate"])
+    ap.add_argument("--sku", action="append", required=True, help="SKU(s) to render")
+    ap.add_argument("--scene", type=Path, required=True, help="styled backdrop image")
+    ap.add_argument("--collection", default=None, help="override collection (else from catalog)")
+    ap.add_argument("--out", type=Path, default=config.OUTPUT_DIR / "_lookbook" / "onmodel")
+    ap.add_argument("--yes", action="store_true", help="confirm the paid run (generate)")
+    args = ap.parse_args(argv)
+
+    # Anchor --out inside the canonical output dir — a traversal --out must not
+    # let a write land outside renders/.
+    out_dir = Path(args.out).resolve()
+    if not out_dir.is_relative_to(config.OUTPUT_DIR.resolve()):
+        print(f"ABORT: --out must be inside {config.OUTPUT_DIR}", file=sys.stderr)
+        return 2
+
+    if not args.scene.exists():
+        print(f"ABORT: scene not found: {args.scene}", file=sys.stderr)
+        return 2
+
+    try:
+        manifest = _manifest(args.sku)
+    except references.MissingReferenceError as exc:
+        print(f"ABORT: {exc}", file=sys.stderr)
+        return 2
+
+    print(cost.format_manifest(manifest))
+    if args.mode == "plan":
+        return 0
+
+    cost.enforce_cap(manifest)
+    if not args.yes:
+        print("\nRefusing to spend without --yes (STOP-AND-SHOW gate).", file=sys.stderr)
+        return 3
+    if not config.api_key_present():
+        print(f"ABORT: {config.API_KEY_ENV} not set (add to .env.hf)", file=sys.stderr)
+        return 2
+
+    import openai
+
+    tracker = cost.SpendTracker()
+    failures = 0
+    for sku in args.sku:
+        safe_sku = re.sub(r"[^a-z0-9\-]", "", sku.lower())
+        dest = out_dir / f"{safe_sku}-onmodel.png"
+        if not tracker.can_afford(config.EST_COST_PER_IMAGE_USD):
+            print(f"STOP: spend cap ${tracker.cap_usd:.2f} reached before {sku}", file=sys.stderr)
+            break
+        try:
+            print(f"[{sku}] rendering on-model ...", flush=True)
+            data = generate_one(sku, args.scene, args.collection, dest)
+            tracker.add(config.EST_COST_PER_IMAGE_USD)
+            print(f"[{sku}] [ok] {dest} ({len(data) // 1024} KB)", flush=True)
+        except openai.AuthenticationError:
+            # Never print str(exc) — the OpenAI SDK echoes a partial key in it.
+            print(
+                f"[{sku}] [fail] AuthenticationError: check {config.API_KEY_ENV}", file=sys.stderr
+            )
+            failures += 1
+            break  # every subsequent call fails identically
+        except (references.MissingReferenceError, FileNotFoundError) as exc:
+            print(f"[{sku}] [fail] {type(exc).__name__}: {exc}", file=sys.stderr)
+            failures += 1
+        except Exception as exc:  # noqa: BLE001 — surface, continue the batch
+            failures += 1
+            print(f"[{sku}] [fail] {type(exc).__name__}: {exc}", file=sys.stderr)
+    print(f"\nDone. spent ~${tracker.spent_usd:.2f}, {failures} failed -> {out_dir}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-replicate-models.py
+++ b/scripts/verify-replicate-models.py
@@ -51,8 +51,8 @@ def whoami() -> None:
     try:
         acct = replicate.Client(api_token=token).accounts.current()
         _line("account", f"{acct.username} ({acct.type})")
-    except Exception as exc:  # noqa: BLE001
-        _line("account", f"could not resolve ({type(exc).__name__}: {exc})")
+    except Exception as exc:  # noqa: BLE001 — drop str(exc); SDK error chains can echo the token
+        _line("account", f"could not resolve ({type(exc).__name__})")
     print()
 
 

--- a/scripts/verify-replicate-models.py
+++ b/scripts/verify-replicate-models.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Free Replicate model-provenance verifier (NO predictions = NO spend).
+
+Confirms that the models we depend on actually exist on Replicate and reports
+their provenance, so a model id copied from source code can never be trusted
+blindly:
+
+  • black-forest-labs/flux-1.1-pro-ultra  — the hero-scene engine (must resolve
+    before any paid hero run)
+  • devskyy/skyyrose-lora-v3              — the repo's claimed product LoRA
+    (llm/providers/replicate.py:76), including the pinned version hash
+
+Keys are read at runtime from .env.hf by python-dotenv — never printed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(PROJECT_ROOT / ".env.hf", override=False)
+except Exception as exc:  # pragma: no cover
+    print(f"FATAL: could not load .env.hf ({exc})", file=sys.stderr)
+    raise SystemExit(2)
+
+import replicate  # noqa: E402
+
+# The repo-claimed product LoRA + the exact pinned version (replicate.py:76).
+PRODUCT_LORA = "devskyy/skyyrose-lora-v3"
+PINNED_VERSION = "64dbb859fed83670e7cde81fc161c183bd9d0607fb7028b01bfc0a000ec114b4"
+HERO_ENGINE = "black-forest-labs/flux-1.1-pro-ultra"
+
+
+def _line(label: str, value: object) -> None:
+    print(f"    {label:<16}: {value}")
+
+
+def whoami() -> None:
+    token = os.environ.get("REPLICATE_API_TOKEN", "").strip()
+    print("== Replicate auth ==")
+    if not token:
+        print("    REPLICATE_API_TOKEN: ✗ MISSING")
+        return
+    print("    REPLICATE_API_TOKEN: ✓ present")
+    try:
+        acct = replicate.Client(api_token=token).accounts.current()
+        _line("account", f"{acct.username} ({acct.type})")
+    except Exception as exc:  # noqa: BLE001
+        _line("account", f"could not resolve ({type(exc).__name__}: {exc})")
+    print()
+
+
+def describe_model(ref: str, *, label: str) -> bool:
+    print(f"== {label}: {ref} ==")
+    try:
+        model = replicate.models.get(ref)
+    except Exception as exc:  # noqa: BLE001
+        print(f"    ✗ DOES NOT RESOLVE — {type(exc).__name__}: {exc}\n")
+        return False
+    _line("exists", "✓")
+    _line("owner", model.owner)
+    _line("visibility", model.visibility)
+    _line("run_count", getattr(model, "run_count", "?"))
+    desc = (model.description or "").strip()
+    _line("description", (desc[:90] + "…") if len(desc) > 90 else (desc or "(none)"))
+    _line("github_url", getattr(model, "github_url", None) or "(none)")
+    _line("cover_image", "yes" if getattr(model, "cover_image_url", None) else "no")
+    latest = getattr(model, "latest_version", None)
+    _line("latest_version", latest.id if latest else "(none)")
+    if latest is not None:
+        _line("latest_created", getattr(latest, "created_at", "?"))
+    print()
+    return True
+
+
+def check_pinned_version(ref: str, version_id: str) -> None:
+    print(f"== Pinned version check: {ref}:{version_id[:12]}… ==")
+    try:
+        model = replicate.models.get(ref)
+        version = model.versions.get(version_id)
+    except Exception as exc:  # noqa: BLE001
+        print(f"    ✗ version NOT found — {type(exc).__name__}: {exc}\n")
+        return
+    _line("version_exists", "✓")
+    _line("created_at", getattr(version, "created_at", "?"))
+    schema = getattr(version, "openapi_schema", None) or {}
+    title = schema.get("info", {}).get("title") if isinstance(schema, dict) else None
+    _line("schema_title", title or "(none)")
+    print()
+
+
+def main() -> int:
+    whoami()
+    hero_ok = describe_model(HERO_ENGINE, label="HERO ENGINE")
+    lora_ok = describe_model(PRODUCT_LORA, label="PRODUCT LORA (claimed)")
+    if lora_ok:
+        check_pinned_version(PRODUCT_LORA, PINNED_VERSION)
+
+    print("== VERDICT ==")
+    print(
+        f"    hero engine resolves : {'✓ safe to run paid heroes' if hero_ok else '✗ FIX SLUG before paid run'}"
+    )
+    print(
+        "    product LoRA real    : "
+        + (
+            "✓ model id is NOT hallucinated"
+            if lora_ok
+            else "✗ claimed LoRA does NOT exist under this token"
+        )
+    )
+    return 0 if hero_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skyyrose-suite/plugins/skyyrose-design/skills/prototype/GENERATIVE.md
+++ b/skyyrose-suite/plugins/skyyrose-design/skills/prototype/GENERATIVE.md
@@ -1,0 +1,112 @@
+# Generative Prototype
+
+Produce **several radically different variants of a generated artifact** — image, video, 3D asset, audio, copy, a design comp — present them side-by-side, let the user pick one (or steal bits from each), throw the rest away.
+
+Use this when the question is **"which produced artifact / approach is right?"** and the medium is something *generated* rather than a screen (UI.md) or a state model (LOGIC.md). If the artifact is a web page, that's UI.md. If it's business logic, that's LOGIC.md. Everything else that gets *produced* — a hero image, a lookbook shot, a 3D mesh, a voiceover, a tagline set — lives here.
+
+## When this is the right shape
+
+- "Which way should this hero image / lookbook shot look?"
+- "Show me a few options for this product render before we commit the batch."
+- "Try this on-model shot through a couple of different engines and let me compare."
+- "I want to hear two takes on this voiceover / read three versions of this headline."
+- Any time the user would otherwise pick blindly between approaches they can't see yet.
+
+The variants usually differ along one of these axes — pick whichever the question is really about:
+
+- **Engine / model** — same prompt, different generators (e.g. FASHN try-on vs gpt-image-2 edit vs FLUX Kontext). Best when "what's the right tool" is the open question.
+- **Approach / method** — same engine, structurally different method (text-to-image vs reference-composite vs masked inpaint). Best when the *technique* is unsettled.
+- **Direction / concept** — same engine and method, genuinely different creative directions (not different seeds). Best when the *look* is open.
+
+Differing only by **seed or a single parameter** is not a prototype — it's a re-roll. Variants must disagree about something the user actually has to decide.
+
+## Process
+
+### 1. State the question and pick N
+
+Default to **3 variants**; cap at 5. Write the plan in one line at the top of the prototype location:
+
+> "One Love Hurts on-model look (bomber + joggers, in the gothic scene), generated three ways — FASHN try-on / gpt-image-2 edit / FLUX Kontext — to decide which wears most naturally."
+
+Name the axis explicitly (engine / approach / direction) so the comparison is fair — all three should answer the *same* brief, varying only along that axis.
+
+### 2. Isolate inputs from the throwaway generator
+
+The **inputs** are the bit worth keeping — the real garment files, the approved scene, the verified prompt, the canonical references. Resolve them through the project's canonical sources (catalog, dossiers, visual manifest), not ad-hoc. The generator script around them is throwaway.
+
+Put the prototype in a clearly-marked throwaway location next to where the real pipeline lives — e.g. `renders/.../_prototype/` or `scripts/.../proto-*.py` — with `prototype` in the name. One in-memory/scratch output dir; never write variants into a production asset path.
+
+### 3. COST GATE — before any paid or metered generation
+
+Generative media usually **costs money or compute**. Before generating, STOP-AND-SHOW the exact manifest: engine(s), model id, image count, per-unit cost, total estimate, hard cap, output path. Wait for explicit `y`. A free dry-run / `plan` mode that builds the prompts and prints the manifest **without** calling any API is the correct first run. (This step is what makes a generative prototype safe — never skip it for paid engines.)
+
+### 4. Generate the variants — one command
+
+One runnable command (the project's task runner / `python <path>`), with the same brief fed to each variant and only the chosen axis varying. Mark each output so the variant is obvious: `<look>-<engine>.png`. Keep generation resilient — one variant failing shouldn't kill the others (surface the failure, continue).
+
+### 5. Present one comparable view
+
+The user must judge variants **together**, not one at a time. Produce a single side-by-side artifact in the medium's native form:
+
+- **Images / video frames** — a labelled montage / contact sheet (each tile tagged with its engine/approach), plus the full-res originals.
+- **Audio** — a single playlist / concatenated stems with spoken labels between takes.
+- **Copy** — a single doc, variants stacked with headers.
+
+Send the comparison to the user (surface the files). Respect any platform constraints — e.g. batch image reads, don't retry past a quota.
+
+### 6. Hand it over
+
+Give the user the comparison + the per-variant labels. The useful feedback is usually **"the garment from A but the lighting from C"** — that's the real direction. If they want another axis explored, that's a new round (re-gate cost).
+
+### 7. Capture the answer and clean up
+
+The winning *approach* (and *why*) is the only durable output. Capture it in `NOTES.md` next to the prototype (or a commit/ADR/memory entry), with the question it answered. Then fold the winning engine/approach into the real pipeline and delete the losing variants + the throwaway generator. Keep the resolved inputs (prompts, refs) — they're reusable.
+
+## Worked example — on-model lookbook (do / don't)
+
+**Question:** "Which engine makes the real Love Hurts garments look genuinely *worn* (not floating) on a model in the gothic scene?" Axis = **engine**.
+
+| Step | ✅ Do | ❌ Don't |
+|------|-------|---------|
+| Inputs | Resolve the garment files from the catalog + `data/product-references/`; reuse the approved `love-hurts-remake-v2-masked.png` scene. | Describe the garments in a prompt and let the model invent them. |
+| Variants | Same look + same scene through **3 different engines** — FASHN try-on, gpt-image-2 edit (reference-guided), FLUX Kontext. | Run gpt-image-2 three times with different seeds and call it three variants. |
+| Location | Write to `renders/oai/_lookbook/_prototype/<look>-<engine>.png`. | Write into `assets/.../products/` where it could be mistaken for a real asset. |
+| Cost | `python proto.py plan` (free) → show the manifest (`3 engines × 1 look`, per-unit + total) → wait for `y`. | Fire all three engines immediately because "it's only a couple dollars." |
+| Present | One labelled montage (`engine` tag per tile) + the full-res originals, sent to the user. | Send three bare PNGs across three messages with no labels. |
+| Verdict | "FLUX Kontext wins — garment seats into the light, no floating" → `NOTES.md` → fold that engine into the real pipeline, delete the rest. | Leave all three + the generator in the repo and move on. |
+
+The payoff of the right version: the user says *"the try-on from FASHN but the lighting from Kontext"* — a real, buildable direction you could not have reached by arguing about it in prose.
+
+## Verify before hand-over (authoritative)
+
+Run a check that can return **"no"** — never hand over on assumption. Concrete recipe for image/video variants:
+
+```bash
+cd renders/oai/_lookbook/_prototype
+# 1. every variant exists and DECODES (catches zero-byte / truncated / API-error blobs)
+for f in <look>-*.png; do identify -format '%f %wx%h %m\n' "$f" || echo "FAIL: $f"; done
+# 1b. NOT BLANK — a render can decode fine yet be a uniform/empty image (an engine
+#     that "succeeds" with an all-black/grey frame). stddev≈0 => blank => FAIL.
+for f in <look>-*.png; do echo "$f $(convert "$f" -colorspace Gray -format '%[fx:standard_deviation]' info:)"; done
+# 2. variants are NOT re-rolls — hashes must all differ
+shasum <look>-*.png            # identical hashes => same image => not a prototype
+# 3. THIS prototype's outputs are confined to the throwaway dir (scope to your
+#    own outputs — don't grep all untracked files or you'll false-flag unrelated
+#    pre-existing state). The output dir path must carry a throwaway marker.
+pwd | grep -qE '_prototype|/_lookbook|/scratch|/tmp/' \
+  && echo "clean — outputs in a throwaway location" \
+  || echo "LEAK: prototype is writing outside a throwaway dir"
+```
+
+Note the scoping: check **the files the prototype produced**, not the whole working tree — a repo often has unrelated untracked assets, and flagging those is a false alarm, which erodes trust in the check.
+
+Then confirm by eye (batch the image reads, never retry past quota): each variant answers the stated question and differs along the *named axis* (here: engine), not by accident. Report the result as evidence — "3 files, 3 distinct hashes, all 1536×1024, decoded OK, none in asset paths" — not "looks good." For non-image media: decode/play each file, diff transcripts/waveforms/text to prove the variants differ, confirm the comparison artifact was delivered. Any failure → fix before hand-over.
+
+## Anti-patterns
+
+- **Re-rolls dressed as variants.** Different seed / one tweaked parameter is not a prototype. Variants must disagree about engine, method, or direction.
+- **Skipping the cost gate.** Never fire a paid generator without the STOP-AND-SHOW manifest + `y`. A free `plan`/dry-run first is mandatory.
+- **Writing into production asset paths.** Variants are throwaway — keep them in a `_prototype/` / scratch dir so a stray one can't get treated as a real asset.
+- **Presenting variants one at a time.** Without a side-by-side, every variant looks fine alone; the comparison is the whole point.
+- **Inventing inputs.** The garment, product, scene, or facts must resolve through canonical sources — a prototype that hallucinates the subject answers the wrong question.
+- **Keeping the generator.** When the question's answered, the generator script is deleted; only the verdict and the reusable inputs survive.

--- a/skyyrose-suite/plugins/skyyrose-design/skills/prototype/SKILL.md
+++ b/skyyrose-suite/plugins/skyyrose-design/skills/prototype/SKILL.md
@@ -1,30 +1,54 @@
 ---
 name: prototype
-description: Build a throwaway prototype to flesh out a design before committing to it. Routes between two branches — a runnable terminal app for state/business-logic questions, or several radically different UI variations toggleable from one route. Use when the user wants to prototype, sanity-check a data model or state machine, mock up a UI, explore design options, or says "prototype this", "let me play with it", "try a few designs".
+description: Build a throwaway prototype to answer one question before committing — in ANY domain. Routes between three branches — a runnable terminal app for state/business-logic questions, several radically different UI variations toggleable from one route, or several variant generated artifacts (image, video, 3D, audio, copy) compared side-by-side. Use when the user wants to prototype, sanity-check a data model or state machine, mock up a UI, explore image/render/lookbook directions, compare engines, explore design options, or says "prototype this", "let me play with it", "try a few designs", "show me a couple variations".
 ---
 
 # Prototype
 
-A prototype is **throwaway code that answers a question**. The question decides the shape.
+A prototype is **a throwaway artifact that answers a question**. The invariant is always the same: **N throwaway variants answering one question, presented side-by-side, the winner absorbed and the rest deleted.** Only the *medium* changes with the domain — terminal, browser, image grid, audio reel. There is no domain in which a prototype cannot be produced; if you ever conclude "this isn't prototype-able," you've picked the wrong medium, not hit a real wall.
 
 ## Pick a branch
 
-Identify which question is being answered — from the user's prompt, the surrounding code, or by asking if the user is around:
+Identify which question is being answered — from the user's prompt, the surrounding code/assets, or by asking if the user is around — then pick the medium that fits:
 
-- **"Does this logic / state model feel right?"** → [LOGIC.md](LOGIC.md). Build a tiny interactive terminal app that pushes the state machine through cases that are hard to reason about on paper.
-- **"What should this look like?"** → [UI.md](UI.md). Generate several radically different UI variations on a single route, switchable via a URL search param and a floating bottom bar.
+- **"Does this logic / state model feel right?"** → [LOGIC.md](LOGIC.md). A tiny interactive terminal app that pushes the state machine through cases that are hard to reason about on paper.
+- **"What should this *screen* look like?"** → [UI.md](UI.md). Several radically different UI variations on a single route, switchable via a URL search param and a floating bottom bar.
+- **"Which produced *artifact* / approach is right?"** (image, render, lookbook, video, 3D, audio, copy — anything *generated* rather than a screen or a state model) → [GENERATIVE.md](GENERATIVE.md). Several variant artifacts generated along one axis (engine / method / direction), presented as one side-by-side comparison, with a cost gate before any paid generation.
 
-The two branches produce very different artifacts — getting this wrong wastes the whole prototype. If the question is genuinely ambiguous and the user isn't reachable, default to whichever branch better matches the surrounding code (a backend module → logic; a page or component → UI) and state the assumption at the top of the prototype.
+The three branches produce very different artifacts — getting this wrong wastes the whole prototype. Match the medium to the question, not to habit: a backend module → logic; a page or component → UI; a generated asset → generative.
 
-## Rules that apply to both
+**No matter the domain, a prototype is producible.** If the question fits none of the three cleanly, do not refuse — fall back to the invariant directly: produce N (default 3) throwaway variants of the smallest real version of the artifact, in whatever medium is native to it, present them in one comparable view, capture the verdict, delete the rest. The branch files are worked examples of this one shape, not an exhaustive list of allowed domains.
 
-1. **Throwaway from day one, and clearly marked as such.** Locate the prototype code close to where it will actually be used (next to the module or page it's prototyping for) so context is obvious — but name it so a casual reader can see it's a prototype, not production. For throwaway UI routes, obey whatever routing convention the project already uses; don't invent a new top-level structure.
+If the question is genuinely ambiguous and the user isn't reachable, default to whichever branch best matches what's in front of you (backend module → logic; page/component → UI; image/render/media asset → generative) and state the assumption at the top of the prototype.
+
+## Rules that apply to all branches
+
+1. **Throwaway from day one, and clearly marked as such.** Locate the prototype close to where it will actually be used (next to the module, page, or pipeline it's prototyping for) so context is obvious — but name it so a casual reader can see it's a prototype, not production. For throwaway UI routes, obey whatever routing convention the project already uses; for generated artifacts, write into a clearly-marked `_prototype/` / scratch dir, never a production asset path.
 2. **One command to run.** Whatever the project's existing task runner supports — `pnpm <name>`, `python <path>`, `bun <path>`, etc. The user must be able to start it without thinking.
-3. **No persistence by default.** State lives in memory. Persistence is the thing the prototype is _checking_, not something it should depend on. If the question explicitly involves a database, hit a scratch DB or a local file with a clear "PROTOTYPE — wipe me" name.
-4. **Skip the polish.** No tests, no error handling beyond what makes the prototype _runnable_, no abstractions. The point is to learn something fast and then delete it.
-5. **Surface the state.** After every action (logic) or on every variant switch (UI), print or render the full relevant state so the user can see what changed.
-6. **Delete or absorb when done.** When the prototype has answered its question, either delete it or fold the validated decision into the real code — don't leave it rotting in the repo.
+3. **No persistence by default.** State / outputs live in memory or a scratch location, not production stores. Persistence is the thing the prototype is _checking_, not something it should depend on. If the question explicitly involves a database, hit a scratch DB or a local file with a clear "PROTOTYPE — wipe me" name.
+4. **Gate any real-world cost.** If a branch spends money or metered compute (paid generators, third-party APIs), STOP-AND-SHOW the exact cost manifest and wait for explicit `y` before the spend; a free dry-run / `plan` first is the correct opening move. (Logic/UI prototypes are usually free; generative ones usually aren't.)
+5. **Skip the polish.** No tests, no error handling beyond what makes the prototype _runnable_, no abstractions. The point is to learn something fast and then delete it.
+6. **Surface the result.** After every action (logic), on every variant switch (UI), or as one side-by-side comparison (generative), present the full relevant state/output so the user can see and judge what differs.
+7. **Delete or absorb when done.** When the prototype has answered its question, fold the validated decision into the real code/pipeline and delete the throwaway — don't leave it rotting in the repo.
+
+## Verify before you hand over (authoritative)
+
+A prototype you haven't verified is not done — it's a claim. Before telling the user it's ready, run a check **that can return "no."** Invoke the project's `verification-before-completion` discipline: evidence before assertion, always. A checklist you eyeball is not verification; a command whose output you read is.
+
+Every branch must pass these, with proof you actually ran:
+
+1. **It exists / runs.** Logic → the command launches and the first frame renders. UI → the route loads and returns 200 for each `?variant=`. Generative → every expected output file exists and **decodes** (`identify <file>` / open it), none zero-byte.
+2. **The variants genuinely differ.** UI → each variant renders a structurally different tree (not the same component). Generative → the outputs are not byte-identical re-rolls — `shasum <files>` must show distinct hashes, and on inspection they differ along the stated axis. Logic → each action visibly mutates state.
+3. **It answers the stated question.** Re-read the one-line question from the top of the prototype; confirm the artifact actually lets the user decide it. If it doesn't, the prototype is wrong even if it runs.
+4. **It didn't leak into production.** Outputs/code live in the throwaway location; `git status` / a path check shows nothing written to a real asset path, route, or store.
+5. **Cost gate honored** (paid branches). The STOP-AND-SHOW manifest was shown and `y` received before any spend; no paid call fired during a dry-run.
+
+State the result as evidence ("3 files, distinct hashes, all 1536×1024, decoded OK"), not as "looks good." If any check fails, fix it before handing over — never report a prototype ready on an unverified assumption.
 
 ## When done
 
 The _answer_ is the only thing worth keeping from a prototype. Capture it somewhere durable (commit message, ADR, issue, or a `NOTES.md` next to the prototype) along with the question it was answering. If the user is around, that capture is a quick conversation; if not, leave the placeholder so they (or you, on the next pass) can fill in the verdict before deleting the prototype.
+
+## Worked examples by branch
+
+Each branch file ends with concrete **do / don't** examples and a branch-specific verification recipe — see the *Anti-patterns* and, in [GENERATIVE.md](GENERATIVE.md), the *Worked example* and *Verify before hand-over* sections. Read the matching branch file before building; the examples are the fastest way to avoid the common failure of that medium.


### PR DESCRIPTION
## What

Lands the unique imagery-pipeline work from `feat/mcp-http-surfaces` onto main (the MCP-HTTP commits on that branch were already merged; only these 3 were unique), plus a code-review hardening pass.

- **`scripts/oai_render/lookbook.py`** — on-model lookbook pipeline (gpt-image-2 edit; won an engine comparison vs FASHN and FLUX Kontext). Reuses the canonical OAI render infra; `--yes` STOP-AND-SHOW gate + spend cap.
- **`scripts/gen-hero-previews.py`** / **`gen-lookbook-remake.py`** — collection hero-scene + lookbook remake preview generators (OpenAI + Replicate/FLUX).
- **`scripts/build-lookbook-mask.py`**, **`scripts/verify-replicate-models.py`** — mask builder + Replicate model/auth verifier.
- **`skyyrose-design/skills/prototype/GENERATIVE.md`** (+ SKILL.md) — domain-agnostic generative prototype branch.
- **`llm/providers/replicate.py`** — supporting changes.

## Security / review hardening (in this PR)

- Auth-key leak: drop `str(exc)` on OpenAI/Replicate auth failures (SDK echoes a partial key); print only the env-var name.
- Cost-cap crash: catch `CostCapExceeded` in `lookbook.py` (was an unhandled traceback on >$50 batch).
- SSRF: `gen-hero-previews` fetches Replicate output via `httpx(follow_redirects=False)` (a CDN bounce could evade the host allowlist); `build-lookbook-mask` source guard `is_file()` (rejects pipes/devices/dirs).
- **Cosmetic STOP-AND-SHOW closed:** `gen-hero-previews` and `gen-lookbook-remake` `go` mode printed a `[y/N]` banner only in `plan` mode but dispatched paid generation with just a hard cap. Added a real fail-closed gate: interactive `y/N` on a TTY, `--yes` for automation, **abort** when non-interactive without `--yes` (mirrors the pipeline3d money-gate).

## Keys / secrets

Read at runtime from `.env.hf` via python-dotenv; never printed. No secrets in the diff.

## Test plan

- [x] `python -m py_compile` on all touched Python — OK
- [x] `ruff check` on all touched files — clean
- [x] Gate behavioral test: `gen-hero-previews go </dev/null` → exit 2 + `ABORT: non-interactive`; `plan` → exit 0 (free). Same for `gen-lookbook-remake`.
- [x] No paid API call made during verification (gates fail-closed)
- [ ] CI green (Security Gate may flag the pre-existing GPL/AGPL dep — unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an on‑model lookbook pipeline using `gpt-image-2` edits, plus hero/lookbook preview utilities with real spend gates. Also hardens generative scripts to prevent key leaks, SSRF, and cost‑cap crashes.

- **New Features**
  - `scripts/oai_render/lookbook.py` — on‑model lookbook generator (SKU→techflat refs, scene image input, cost manifest + `--yes` gate).
  - `scripts/gen-hero-previews.py` — 4 collection hero backdrops via `openai` and `replicate`/FLUX; free `plan`, gated `go`; outputs to `renders/oai/_hero_preview/`.
  - `scripts/gen-lookbook-remake.py` + `scripts/build-lookbook-mask.py` — garment‑preserving remake (masked `gpt-image-2` edit) with local rembg mask builder and overlay preview.
  - `scripts/verify-replicate-models.py` — free Replicate model/auth provenance check (no predictions, no spend).
  - `skyyrose-design/skills/prototype/GENERATIVE.md` (+ updated `SKILL.md`) — new generative branch with cost‑gate and verification guidance.
  - `llm/providers/replicate.py` — correct LoRA provenance comment (390→604 images).

- **Bug Fixes**
  - Remove secret echoes on auth failures; print only env var names for OpenAI/Replicate.
  - Real STOP‑AND‑SHOW: interactive y/N for paid runs; `--yes` for automation; abort when non‑interactive without `--yes`.
  - Catch `CostCapExceeded` in lookbook pipeline; enforce spend cap before dispatch.
  - SSRF hardening: Replicate fetch via `httpx` with `follow_redirects=False`; mask builder checks `is_file()` on sources.
  - Keys loaded at runtime from `.env.hf`; never logged.

<sup>Written for commit 008ce65d2199ea7154240d2793152b7fce99d33b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated preview generation for hero scenes using AI image models
  * Introduced garment-preserving mask workflow for enhanced image editing
  * Added on-model lookbook generation capabilities

* **Documentation**
  * Added comprehensive guides for generative prototype workflows and verification best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->