### PR TITLE
feat(pipeline): stage_review.py — render→approve bridge (gpt-image-2 aware)

### DIFF
--- a/scripts/stage_review.py
+++ b/scripts/stage_review.py
@@ -111,8 +111,10 @@ def resolve_source_folder(root: Path, sku: str) -> Path:
 
 
 def _render_version(path: Path) -> int:
-    match = _VERSION_RE.search(path.name)
-    return int(match.group(1)) if match else 1
+    # findall + last token: a producer-named "seedream-probe-v2-v3.png" scores as
+    # v3 (its intent), not v2 (which .search would return on the first match).
+    nums = _VERSION_RE.findall(path.name)
+    return int(nums[-1]) if nums else 1
 
 
 def select_render(render_dir: Path, *, override: str | None = None) -> Path:
@@ -126,6 +128,11 @@ def select_render(render_dir: Path, *, override: str | None = None) -> Path:
     if not render_dir.is_dir():
         raise ReviewError(f"no renders/ dir: expected {render_dir}")
     if override:
+        # Confine the override to a plain filename inside render_dir — same
+        # path-traversal philosophy as _validate_sku. Without this, a value like
+        # "../other-sku/renders/wrong.png" would stage the wrong garment for review.
+        if "/" in override or os.sep in override or ".." in override:
+            raise ReviewError(f"--render must be a plain filename, not a path: {override!r}")
         chosen = render_dir / override
         if not chosen.is_file():
             raise ReviewError(f"override render not found: {chosen}")
@@ -159,8 +166,10 @@ def load_skipped(root: Path) -> set[str]:
         data = json.loads(path.read_text(encoding="utf-8"))
         return {entry["sku"] for entry in data.get("skipped", []) if "sku" in entry}
     except (json.JSONDecodeError, AttributeError, TypeError) as exc:
-        _log.warning("could not parse %s (%s) — treating skip list as empty", path, exc)
-        return set()
+        # A present-but-broken skip list is a data error: aborting beats silently
+        # un-skipping out-of-scope accessories into a paid batch. (Absent file is
+        # the expected/empty case handled above.)
+        raise ReviewError(f"malformed skip list {path}: {exc}") from exc
 
 
 def discover_skus(root: Path) -> list[str]:
@@ -265,7 +274,9 @@ def stage_one(
 
     try:
         _convert_to_webp(src, dst)
-    except OSError as exc:
+    except Exception as exc:  # noqa: BLE001 — isolate any PIL failure (incl.
+        # DecompressionBombError / ValueError, which are NOT OSError) to this SKU
+        # so one bad image cannot abort a whole --all batch.
         return StageResult(sku, "error", src, dst, f"webp conversion failed: {exc}")
     return StageResult(sku, "staged", src, dst, f"{src.name} -> {rel}")
 
@@ -337,10 +348,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.render and args.all:
         parser.error("--render applies to a single SKU only, not --all")
 
-    if args.all:
-        results = stage_all(root=args.root, force=args.force, dry_run=args.dry_run)
-    else:
-        try:
+    try:
+        if args.all:
+            results = stage_all(root=args.root, force=args.force, dry_run=args.dry_run)
+        else:
             results = [
                 stage_one(
                     args.sku,
@@ -350,9 +361,11 @@ def main(argv: list[str] | None = None) -> int:
                     dry_run=args.dry_run,
                 )
             ]
-        except ReviewError as exc:
-            print(f"error: {exc}", file=sys.stderr)
-            return 1
+    except ReviewError as exc:
+        # Global precondition failures (invalid SKU, malformed skip list) — clean
+        # exit, not a traceback. Per-SKU problems are aggregated as results above.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
 
     if not results:
         print("no SKUs to stage (no product-source folders found)")

--- a/scripts/stage_review.py
+++ b/scripts/stage_review.py
@@ -60,7 +60,7 @@ from skyyrose.core.review import (  # noqa: E402
 # assets/product-source/{sku}__{slug}/renders/seedream-probe*.png
 PRODUCT_SOURCE_REL = "assets/product-source"
 RENDERS_SUBDIR = "renders"
-RENDER_GLOB = "seedream-probe*.png"
+RENDER_GLOB = "*-probe*.png"  # matches openai-probe.png (gpt-image-2) + seedream-probe*.png
 SKIPPED_JSON = "SKIPPED.json"
 WEBP_QUALITY = 92
 # Match the version suffix in seedream-probe-v4-clean.png; bare seedream-probe.png == v1.

--- a/scripts/stage_review.py
+++ b/scripts/stage_review.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""stage-review {sku} | --all — bridge a finished render into the approval queue.
+
+The keystone hand-off in the ghost-mannequin pipeline. The render engine
+(scripts/seedream_ghost_mannequin.py) writes to
+
+    assets/product-source/{sku}__{slug}/renders/seedream-probe*.png
+
+but the approval CLI (scripts/approve_ghost.py -> skyyrose.core.review.approve)
+reads from
+
+    renders/ghost-mannequin/{sku}-ghost-front.webp
+
+Nothing previously bridged the two, so approval errored with "no review file ...
+place file before approving" and the whole render -> approve -> WooCommerce chain
+could not start. This script is that bridge: it selects the chosen render,
+converts PNG -> WEBP, and writes it to the path review.approve() expects.
+
+It does NOT touch approved/ or the catalog CSV — that is approve_ghost.py's job
+(it moves the staged file into approved/ and rewrites front_model_image).
+
+Path constants, the SKU allowlist (a path-traversal defense — the SKU is
+interpolated into a filesystem path), and root detection are imported from
+skyyrose.core.review so there is a single source of truth shared with the
+consumer of these files.
+
+Exit codes:
+    0 — all requested SKUs staged / skipped / not-yet-rendered cleanly (or dry-run)
+    1 — at least one SKU hit a genuine error (ambiguous folder, bad --render, IO)
+    2 — argparse usage error
+
+A SKU that simply has no render yet is reported as "no-render" and does NOT fail
+the batch — render it first, then re-run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skyyrose.core.review import (  # noqa: E402
+    APPROVED_SUBDIR,
+    GHOST_FILENAME_FMT,
+    GHOST_REL,
+    ReviewError,
+    _resolve_root,
+    _validate_sku,
+)
+
+# assets/product-source/{sku}__{slug}/renders/seedream-probe*.png
+PRODUCT_SOURCE_REL = "assets/product-source"
+RENDERS_SUBDIR = "renders"
+RENDER_GLOB = "seedream-probe*.png"
+SKIPPED_JSON = "SKIPPED.json"
+WEBP_QUALITY = 92
+# Match the version suffix in seedream-probe-v4-clean.png; bare seedream-probe.png == v1.
+_VERSION_RE = re.compile(r"-v(\d+)")
+
+_log = logging.getLogger("stage_review")
+
+
+@dataclass(frozen=True)
+class StageResult:
+    """Outcome for one SKU. ``ok`` is False only for genuine failures."""
+
+    sku: str
+    status: str  # staged | would-stage | exists | already-approved | skipped | error
+    src: Path | None
+    dst: Path | None
+    detail: str
+
+    @property
+    def ok(self) -> bool:
+        return self.status != "error"
+
+
+# --------------------------------------------------------------------------- paths
+
+
+def _approved_path(root: Path, sku: str) -> Path:
+    return root / GHOST_REL / APPROVED_SUBDIR / GHOST_FILENAME_FMT.format(sku=sku)
+
+
+def _review_path(root: Path, sku: str) -> Path:
+    return root / GHOST_REL / GHOST_FILENAME_FMT.format(sku=sku)
+
+
+def resolve_source_folder(root: Path, sku: str) -> Path:
+    """Resolve assets/product-source/{sku}__<slug>/ for a SKU (exactly one match)."""
+    base = root / PRODUCT_SOURCE_REL
+    matches = sorted(p for p in base.glob(f"{sku}__*") if p.is_dir())
+    if not matches:
+        raise ReviewError(
+            f"no product-source folder for {sku}: expected {base}/{sku}__<slug>/ "
+            f"— render the SKU first or check the slug"
+        )
+    if len(matches) > 1:
+        names = ", ".join(p.name for p in matches)
+        raise ReviewError(f"ambiguous source folder for {sku}: {len(matches)} matches ({names})")
+    return matches[0]
+
+
+def _render_version(path: Path) -> int:
+    match = _VERSION_RE.search(path.name)
+    return int(match.group(1)) if match else 1
+
+
+def select_render(render_dir: Path, *, override: str | None = None) -> Path:
+    """Pick the render to stage.
+
+    Precedence: explicit ``override`` filename > highest -vN variant > sole file.
+    The version heuristic means a re-rendered ``-v4-clean.png`` supersedes the
+    base ``seedream-probe.png`` (== v1) automatically; pass ``override`` to force
+    a specific file when the heuristic is wrong.
+    """
+    if not render_dir.is_dir():
+        raise ReviewError(f"no renders/ dir: expected {render_dir}")
+    if override:
+        chosen = render_dir / override
+        if not chosen.is_file():
+            raise ReviewError(f"override render not found: {chosen}")
+        return chosen
+    candidates = sorted(p for p in render_dir.glob(RENDER_GLOB) if p.is_file())
+    if not candidates:
+        raise ReviewError(f"no render in {render_dir} matching {RENDER_GLOB!r}")
+    if len(candidates) == 1:
+        return candidates[0]
+    best = max(candidates, key=_render_version)
+    others = ", ".join(p.name for p in candidates if p != best)
+    _log.warning(
+        "%s: %d render variants; auto-selected highest version %s (others: %s) "
+        "— pass --render to override",
+        render_dir.parent.name,
+        len(candidates),
+        best.name,
+        others,
+    )
+    return best
+
+
+def load_skipped(root: Path) -> set[str]:
+    """SKUs in renders/ghost-mannequin/SKIPPED.json — out-of-scope accessories."""
+    import json
+
+    path = root / GHOST_REL / SKIPPED_JSON
+    if not path.is_file():
+        return set()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return {entry["sku"] for entry in data.get("skipped", []) if "sku" in entry}
+    except (json.JSONDecodeError, AttributeError, TypeError) as exc:
+        _log.warning("could not parse %s (%s) — treating skip list as empty", path, exc)
+        return set()
+
+
+def discover_skus(root: Path) -> list[str]:
+    """All SKUs that have a product-source folder, derived from folder names."""
+    base = root / PRODUCT_SOURCE_REL
+    if not base.is_dir():
+        return []
+    skus: set[str] = set()
+    for folder in base.glob("*__*"):
+        if not folder.is_dir():
+            continue
+        sku = folder.name.split("__", 1)[0]
+        try:
+            _validate_sku(sku)
+        except ReviewError:
+            continue
+        skus.add(sku)
+    return sorted(skus)
+
+
+# ----------------------------------------------------------------------- convert
+
+
+def _convert_to_webp(src_png: Path, dst_webp: Path, *, quality: int = WEBP_QUALITY) -> None:
+    """Convert PNG -> WEBP atomically (tmp in target dir + os.replace)."""
+    from PIL import Image
+
+    dst_webp.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=dst_webp.parent, prefix=".tmp_stage_", suffix=".webp")
+    os.close(fd)
+    try:
+        with Image.open(src_png) as im:
+            im.save(tmp, "WEBP", quality=quality, method=6)
+        os.replace(tmp, dst_webp)
+    except BaseException:
+        if os.path.exists(tmp):
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+        raise
+
+
+# -------------------------------------------------------------------------- core
+
+
+def stage_one(
+    sku: str,
+    *,
+    root: Path | str | None = None,
+    render: str | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+    skipped: set[str] | None = None,
+) -> StageResult:
+    """Stage one SKU's render into the review queue. Never raises for expected
+    states (skipped, already-approved, exists) — those are returned as results.
+    Raises ReviewError only for an invalid SKU before any work begins.
+    """
+    _validate_sku(sku)
+    base = _resolve_root(root)
+    if skipped is None:
+        skipped = load_skipped(base)
+
+    if sku in skipped:
+        return StageResult(sku, "skipped", None, None, "in SKIPPED.json (out-of-scope accessory)")
+
+    approved = _approved_path(base, sku)
+    if approved.is_file():
+        return StageResult(
+            sku, "already-approved", None, approved, "already approved; nothing to stage"
+        )
+
+    dst = _review_path(base, sku)
+    try:
+        folder = resolve_source_folder(base, sku)
+    except ReviewError as exc:
+        return StageResult(sku, "error", None, dst, str(exc))
+
+    # "not rendered yet" is a precondition, not a failure: it must not fail a
+    # --all batch where other SKUs are ready. Genuine problems (ambiguous folder,
+    # missing override file) still surface as errors below.
+    render_dir = folder / RENDERS_SUBDIR
+    has_render = render_dir.is_dir() and any(render_dir.glob(RENDER_GLOB))
+    if render is None and not has_render:
+        return StageResult(
+            sku, "no-render", None, dst, "no render yet — run the render pipeline first"
+        )
+    try:
+        src = select_render(render_dir, override=render)
+    except ReviewError as exc:
+        return StageResult(sku, "error", None, dst, str(exc))
+
+    if dst.is_file() and not force:
+        return StageResult(
+            sku, "exists", src, dst, "review file already staged (use --force to overwrite)"
+        )
+
+    rel = dst.relative_to(base)
+    if dry_run:
+        return StageResult(sku, "would-stage", src, dst, f"{src.name} -> {rel}")
+
+    try:
+        _convert_to_webp(src, dst)
+    except OSError as exc:
+        return StageResult(sku, "error", src, dst, f"webp conversion failed: {exc}")
+    return StageResult(sku, "staged", src, dst, f"{src.name} -> {rel}")
+
+
+def stage_all(
+    *,
+    root: Path | str | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> list[StageResult]:
+    """Stage every SKU that has a product-source folder, honoring the skip list."""
+    base = _resolve_root(root)
+    skipped = load_skipped(base)
+    results: list[StageResult] = []
+    for sku in discover_skus(base):
+        results.append(stage_one(sku, root=base, force=force, dry_run=dry_run, skipped=skipped))
+    return results
+
+
+# --------------------------------------------------------------------------- CLI
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="stage-review",
+        description=(
+            "Bridge a finished render into the approval queue: select the render, "
+            "convert PNG->WEBP, write renders/ghost-mannequin/{sku}-ghost-front.webp. "
+            "Run before approve_ghost.py."
+        ),
+    )
+    parser.add_argument("sku", nargs="?", help="Catalog SKU (e.g. br-001). Omit with --all.")
+    parser.add_argument("--all", action="store_true", help="Stage every SKU with a render.")
+    parser.add_argument(
+        "--render", default=None, help="Override render filename (single SKU only)."
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Overwrite an already-staged review file."
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Report actions without writing.")
+    parser.add_argument(
+        "--root", default=None, help="Repo root override (defaults to detected root)."
+    )
+    return parser
+
+
+def _print_result(result: StageResult) -> None:
+    glyph = {
+        "staged": "OK  ",
+        "would-stage": "DRY ",
+        "exists": "skip",
+        "already-approved": "skip",
+        "skipped": "skip",
+        "no-render": "wait",
+        "error": "FAIL",
+    }.get(result.status, "?   ")
+    print(f"  [{glyph}] {result.sku:<9} {result.status:<16} {result.detail}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.all and args.sku:
+        parser.error("pass a single SKU or --all, not both")
+    if not args.all and not args.sku:
+        parser.error("provide a SKU or --all")
+    if args.render and args.all:
+        parser.error("--render applies to a single SKU only, not --all")
+
+    if args.all:
+        results = stage_all(root=args.root, force=args.force, dry_run=args.dry_run)
+    else:
+        try:
+            results = [
+                stage_one(
+                    args.sku,
+                    root=args.root,
+                    render=args.render,
+                    force=args.force,
+                    dry_run=args.dry_run,
+                )
+            ]
+        except ReviewError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+
+    if not results:
+        print("no SKUs to stage (no product-source folders found)")
+        return 0
+
+    print(f"stage-review ({'dry-run' if args.dry_run else 'live'}):")
+    for result in results:
+        _print_result(result)
+
+    staged = sum(1 for r in results if r.status in ("staged", "would-stage"))
+    failed = [r for r in results if r.status == "error"]
+    print(f"\n{staged} staged, {len(results) - staged - len(failed)} skipped, {len(failed)} failed")
+    if failed:
+        for r in failed:
+            print(f"  FAILED {r.sku}: {r.detail}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skyyrose/core/review.py
+++ b/skyyrose/core/review.py
@@ -29,6 +29,11 @@ GHOST_REL = "renders/ghost-mannequin"
 APPROVED_SUBDIR = "approved"
 FRONT_MODEL_COL = "front_model_image"
 GHOST_FILENAME_FMT = "{sku}-ghost-front.webp"
+# Approved ghost renders are copied into the THEME's deployable assets tree so the
+# storefront resolves front_model_image via get_theme_file_uri(). The repo-local
+# renders/ path is NOT shipped by deploy-theme.sh, so it must never be the CSV value.
+THEME_GHOST_REL = "wordpress-theme/skyyrose-flagship/assets/images/products/ghost"
+FRONT_MODEL_VALUE_FMT = "assets/images/products/ghost/{sku}-ghost-front.webp"
 APPROVALS_JSON = "approvals.json"
 REJECTIONS_JSON = "rejections.json"
 
@@ -266,10 +271,17 @@ def approve(sku: str, *, root: Path | str | None = None) -> ApprovalResult:
     row_count_before = len(rows)
     idx = _find_row_index(rows, sku)
 
-    new_front = f"{GHOST_REL}/{APPROVED_SUBDIR}/{GHOST_FILENAME_FMT.format(sku=sku)}"
+    # The CSV value must be a THEME-relative path (get_theme_file_uri-resolvable),
+    # never the repo-local renders/ path, which the theme deploy does not ship.
+    new_front = FRONT_MODEL_VALUE_FMT.format(sku=sku)
+    theme_dst = base / THEME_GHOST_REL / GHOST_FILENAME_FMT.format(sku=sku)
 
     shutil.move(str(src), str(dst))
     try:
+        # Deployable theme copy — what the storefront actually serves. The approved/
+        # original stays put for the WooCommerce uploader to read.
+        theme_dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(dst), str(theme_dst))
         rows[idx] = {**rows[idx], FRONT_MODEL_COL: new_front}
         # Runtime invariant — survives python -O (unlike assert).
         if len(rows) != row_count_before:
@@ -278,6 +290,11 @@ def approve(sku: str, *, root: Path | str | None = None) -> ApprovalResult:
             )
         atomic_csv_write(rows, fieldnames, csv_path)
     except BaseException:
+        if theme_dst.exists():
+            try:
+                theme_dst.unlink()
+            except OSError:
+                pass
         if dst.exists() and not src.exists():
             _safe_rollback_move(src, dst)
         raise

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -108,7 +108,24 @@ class TestApprove:
         root = _make_fake_repo(tmp_path, ["br-001"])
         approve("br-001", root=root)
         row = _row_for(_read_rows(root / CATALOG_REL), "br-001")
-        assert row[FRONT_MODEL_COL] == ("renders/ghost-mannequin/approved/br-001-ghost-front.webp")
+        # Theme-relative path (get_theme_file_uri-resolvable), NOT the repo-local
+        # renders/ path the theme deploy does not ship.
+        assert row[FRONT_MODEL_COL] == "assets/images/products/ghost/br-001-ghost-front.webp"
+
+    def test_copies_approved_render_into_theme_assets(self, tmp_path: Path) -> None:
+        root = _make_fake_repo(tmp_path, ["br-001"])
+        approve("br-001", root=root)
+        theme_copy = (
+            root
+            / "wordpress-theme/skyyrose-flagship/assets/images/products/ghost"
+            / "br-001-ghost-front.webp"
+        )
+        approved = root / GHOST_REL / APPROVED_SUBDIR / "br-001-ghost-front.webp"
+        # Both display paths populated: theme-deployed copy AND the approved/ original
+        # the WooCommerce uploader reads.
+        assert theme_copy.is_file()
+        assert approved.is_file()
+        assert theme_copy.read_bytes() == approved.read_bytes()
 
     def test_preserves_csv_row_count(self, tmp_path: Path) -> None:
         skus = ["br-001", "sg-001", "lh-001"]
@@ -394,7 +411,7 @@ class TestAuditLogFailureModes:
         assert result.sku == "br-001"
         assert (root / GHOST_REL / APPROVED_SUBDIR / "br-001-ghost-front.webp").exists()
         row = _row_for(_read_rows(root / CATALOG_REL), "br-001")
-        assert row[FRONT_MODEL_COL].startswith("renders/ghost-mannequin/approved/")
+        assert row[FRONT_MODEL_COL].startswith("assets/images/products/ghost/")
         # Warning was logged.
         assert any("audit log write failed" in r.message for r in caplog.records)
         # Restore so test isolation holds.

--- a/tests/test_stage_review.py
+++ b/tests/test_stage_review.py
@@ -1,0 +1,345 @@
+"""Tests for scripts/stage_review.py — the render -> review-queue bridge.
+
+Mirrors tests/test_review.py: each test builds an isolated repo skeleton under
+tmp_path and passes root= so nothing touches the real tree. The script is loaded
+via importlib because scripts/ is not an importable package.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+# scripts/ is not a package; put it on the path so the CLI module imports by name
+# (keeps coverage --cov=stage_review straightforward).
+_SCRIPTS_DIR = str(REPO_ROOT / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import stage_review as sr  # noqa: E402
+
+ReviewError = sr.ReviewError
+
+
+# --------------------------------------------------------------------------- fixtures
+
+
+def _png(path: Path, *, color=(10, 20, 30), size=(8, 8)) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", size, color).save(path, "PNG")
+
+
+def _repo(tmp_path: Path) -> Path:
+    (tmp_path / "assets" / "product-source").mkdir(parents=True)
+    (tmp_path / "renders" / "ghost-mannequin").mkdir(parents=True)
+    return tmp_path
+
+
+def _add_sku(tmp_path: Path, sku: str, slug: str, renders=("seedream-probe.png",)) -> Path:
+    render_dir = tmp_path / "assets" / "product-source" / f"{sku}__{slug}" / "renders"
+    for name in renders:
+        _png(render_dir / name)
+    return render_dir
+
+
+def _skipped_json(tmp_path: Path, skus: list[str]) -> None:
+    import json
+
+    path = tmp_path / "renders" / "ghost-mannequin" / "SKIPPED.json"
+    path.write_text(
+        json.dumps({"skipped": [{"sku": s, "name": s, "collection": "x"} for s in skus]}),
+        encoding="utf-8",
+    )
+
+
+def _review_file(tmp_path: Path, sku: str) -> Path:
+    return tmp_path / "renders" / "ghost-mannequin" / f"{sku}-ghost-front.webp"
+
+
+def _approved_file(tmp_path: Path, sku: str) -> Path:
+    return tmp_path / "renders" / "ghost-mannequin" / "approved" / f"{sku}-ghost-front.webp"
+
+
+# ------------------------------------------------------------------------ stage_one
+
+
+@pytest.mark.unit
+def test_stage_one_converts_png_to_webp(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "black-rose-crewneck")
+
+    result = sr.stage_one("br-001", root=repo)
+
+    assert result.status == "staged"
+    dst = _review_file(repo, "br-001")
+    assert dst.is_file()
+    with Image.open(dst) as im:
+        assert im.format == "WEBP"
+
+
+@pytest.mark.unit
+def test_stage_one_is_idempotent_without_force(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "black-rose-crewneck")
+    sr.stage_one("br-001", root=repo)
+
+    second = sr.stage_one("br-001", root=repo)
+    assert second.status == "exists"
+
+
+@pytest.mark.unit
+def test_force_overwrites_existing_review_file(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "black-rose-crewneck")
+    sr.stage_one("br-001", root=repo)
+
+    forced = sr.stage_one("br-001", root=repo, force=True)
+    assert forced.status == "staged"
+
+
+@pytest.mark.unit
+def test_already_approved_short_circuits(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "black-rose-crewneck")
+    approved = _approved_file(repo, "br-001")
+    approved.parent.mkdir(parents=True, exist_ok=True)
+    approved.write_bytes(b"already")
+
+    result = sr.stage_one("br-001", root=repo)
+    assert result.status == "already-approved"
+    assert not _review_file(repo, "br-001").exists()
+
+
+@pytest.mark.unit
+def test_skip_list_honored(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "lh-005", "the-fannie")
+    _skipped_json(repo, ["lh-005"])
+
+    result = sr.stage_one("lh-005", root=repo)
+    assert result.status == "skipped"
+    assert not _review_file(repo, "lh-005").exists()
+
+
+@pytest.mark.unit
+def test_multi_variant_picks_highest_version(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(
+        repo,
+        "lh-004",
+        "love-hurts-bomber-jacket",
+        renders=(
+            "seedream-probe.png",
+            "seedream-probe-v2-hollow.png",
+            "seedream-probe-v3-styleref.png",
+            "seedream-probe-v4-clean.png",
+        ),
+    )
+
+    result = sr.stage_one("lh-004", root=repo)
+    assert result.status == "staged"
+    assert result.src.name == "seedream-probe-v4-clean.png"
+
+
+@pytest.mark.unit
+def test_render_override_selects_named_file(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(
+        repo,
+        "lh-004",
+        "love-hurts-bomber-jacket",
+        renders=("seedream-probe.png", "seedream-probe-v4-clean.png"),
+    )
+
+    result = sr.stage_one("lh-004", root=repo, render="seedream-probe.png")
+    assert result.src.name == "seedream-probe.png"
+
+
+@pytest.mark.unit
+def test_override_missing_file_is_error(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "black-rose-crewneck")
+
+    result = sr.stage_one("br-001", root=repo, render="does-not-exist.png")
+    assert result.status == "error"
+
+
+@pytest.mark.unit
+def test_invalid_sku_raises(tmp_path):
+    repo = _repo(tmp_path)
+    with pytest.raises(ReviewError):
+        sr.stage_one("../etc/passwd", root=repo)
+
+
+@pytest.mark.unit
+def test_no_source_folder_is_error_not_raise(tmp_path):
+    repo = _repo(tmp_path)
+    result = sr.stage_one("br-099", root=repo)
+    assert result.status == "error"
+    assert "no product-source folder" in result.detail
+
+
+@pytest.mark.unit
+def test_dry_run_writes_nothing(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "black-rose-crewneck")
+
+    result = sr.stage_one("br-001", root=repo, dry_run=True)
+    assert result.status == "would-stage"
+    assert not _review_file(repo, "br-001").exists()
+
+
+# ---------------------------------------------------------------------- discovery
+
+
+@pytest.mark.unit
+def test_discover_skus_ignores_non_sku_folders(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "black-rose-crewneck")
+    _add_sku(repo, "kids-001", "kids-colorblock-hoodie")
+    # a non-SKU directory that must be ignored
+    (repo / "assets" / "product-source" / "_style-reference").mkdir(parents=True)
+
+    skus = sr.discover_skus(repo)
+    assert skus == ["br-001", "kids-001"]
+
+
+@pytest.mark.unit
+def test_ambiguous_folder_is_error(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "slug-one")
+    _add_sku(repo, "br-001", "slug-two")
+
+    result = sr.stage_one("br-001", root=repo)
+    assert result.status == "error"
+    assert "ambiguous" in result.detail
+
+
+# ------------------------------------------------------------------------ stage_all
+
+
+@pytest.mark.unit
+def test_stage_all_stages_ready_and_skips_others(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "black-rose-crewneck")
+    _add_sku(repo, "br-002", "black-rose-joggers")
+    _add_sku(repo, "lh-005", "the-fannie")
+    _skipped_json(repo, ["lh-005"])
+    # br-002 already approved -> should short-circuit
+    appr = _approved_file(repo, "br-002")
+    appr.parent.mkdir(parents=True, exist_ok=True)
+    appr.write_bytes(b"x")
+
+    results = {r.sku: r.status for r in sr.stage_all(root=repo)}
+    assert results["br-001"] == "staged"
+    assert results["br-002"] == "already-approved"
+    assert results["lh-005"] == "skipped"
+
+
+# ------------------------------------------------------------------------------ CLI
+
+
+@pytest.mark.unit
+def test_cli_single_sku_live(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "black-rose-crewneck")
+
+    code = sr.main(["br-001", "--root", str(repo)])
+    assert code == 0
+    assert _review_file(repo, "br-001").is_file()
+
+
+@pytest.mark.unit
+def test_cli_all_dry_run(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "black-rose-crewneck")
+
+    code = sr.main(["--all", "--dry-run", "--root", str(repo)])
+    assert code == 0
+    assert not _review_file(repo, "br-001").exists()
+
+
+@pytest.mark.unit
+def test_cli_rejects_sku_and_all_together(tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        sr.main(["br-001", "--all"])
+    assert exc.value.code == 2
+
+
+@pytest.mark.unit
+def test_cli_requires_sku_or_all(tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        sr.main([])
+    assert exc.value.code == 2
+
+
+@pytest.mark.unit
+def test_cli_failure_exit_code(tmp_path):
+    repo = _repo(tmp_path)
+    # SKU valid but no source folder -> failure -> exit 1
+    code = sr.main(["br-099", "--root", str(repo)])
+    assert code == 1
+
+
+@pytest.mark.unit
+def test_load_skipped_tolerates_malformed_json(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "renders" / "ghost-mannequin" / "SKIPPED.json").write_text(
+        "{not json", encoding="utf-8"
+    )
+    assert sr.load_skipped(repo) == set()
+
+
+@pytest.mark.unit
+def test_stage_result_ok_property():
+    assert sr.StageResult("br-001", "staged", None, None, "").ok is True
+    assert sr.StageResult("br-001", "error", None, None, "").ok is False
+
+
+@pytest.mark.unit
+def test_cli_all_no_folders_reports_nothing(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    code = sr.main(["--all", "--root", str(repo)])
+    assert code == 0
+    assert "no SKUs to stage" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_cli_all_reports_per_sku_failure(tmp_path):
+    repo = _repo(tmp_path)
+    # ambiguous: two folders for one SKU -> genuine error -> exit 1
+    _add_sku(repo, "br-001", "slug-a")
+    _add_sku(repo, "br-001", "slug-b")
+    code = sr.main(["--all", "--root", str(repo)])
+    assert code == 1
+
+
+@pytest.mark.unit
+def test_render_override_rejected_with_all(tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        sr.main(["--all", "--render", "x.png"])
+    assert exc.value.code == 2
+
+
+@pytest.mark.unit
+def test_no_render_is_soft_skip_not_error(tmp_path):
+    repo = _repo(tmp_path)
+    # folder present but renders/ empty -> precondition not met, not a failure
+    (repo / "assets" / "product-source" / "br-001__slug" / "renders").mkdir(parents=True)
+    result = sr.stage_one("br-001", root=repo)
+    assert result.status == "no-render"
+    assert not _review_file(repo, "br-001").exists()
+
+
+@pytest.mark.unit
+def test_cli_all_with_unrendered_exits_zero(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "ready")
+    (repo / "assets" / "product-source" / "br-002__pending" / "renders").mkdir(parents=True)
+    code = sr.main(["--all", "--root", str(repo)])
+    assert code == 0  # one staged, one not-yet-rendered — batch still succeeds
+    assert _review_file(repo, "br-001").is_file()

--- a/tests/test_stage_review.py
+++ b/tests/test_stage_review.py
@@ -286,12 +286,52 @@ def test_cli_failure_exit_code(tmp_path):
 
 
 @pytest.mark.unit
-def test_load_skipped_tolerates_malformed_json(tmp_path):
+def test_load_skipped_raises_on_malformed_json(tmp_path):
     repo = _repo(tmp_path)
     (repo / "renders" / "ghost-mannequin" / "SKIPPED.json").write_text(
         "{not json", encoding="utf-8"
     )
-    assert sr.load_skipped(repo) == set()
+    with pytest.raises(ReviewError):
+        sr.load_skipped(repo)
+
+
+@pytest.mark.unit
+def test_malformed_skip_list_aborts_all_run_cleanly(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "slug")
+    (repo / "renders" / "ghost-mannequin" / "SKIPPED.json").write_text("{bad", encoding="utf-8")
+    code = sr.main(["--all", "--root", str(repo)])
+    assert code == 1  # clean error exit, not a traceback
+
+
+@pytest.mark.unit
+def test_render_override_path_escape_rejected(tmp_path):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "slug")
+    result = sr.stage_one("br-001", root=repo, render="../../etc/passwd.png")
+    assert result.status == "error"
+    assert "plain filename" in result.detail
+
+
+@pytest.mark.unit
+def test_render_version_uses_last_token():
+    assert sr._render_version(Path("seedream-probe-v2-v3.png")) == 3
+    assert sr._render_version(Path("seedream-probe.png")) == 1
+    assert sr._render_version(Path("seedream-probe-v4-clean.png")) == 4
+
+
+@pytest.mark.unit
+def test_non_oserror_conversion_failure_is_isolated(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    _add_sku(repo, "br-001", "slug")
+
+    def _boom(*_a, **_k):
+        raise ValueError("simulated PIL ValueError (not an OSError)")
+
+    monkeypatch.setattr(sr, "_convert_to_webp", _boom)
+    result = sr.stage_one("br-001", root=repo)
+    assert result.status == "error"
+    assert "webp conversion failed" in result.detail
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What

Lands the missing render→approval bridge from `worktree-go-live-gap-map`. Without it the render→approve→WC chain errors `no review file … place file before approving`.

- **`scripts/stage_review.py`** (+ `tests/test_stage_review.py`) — CLI that promotes probe PNGs from `assets/product-source/{sku}__{slug}/renders/` into the path `approve_ghost.py` expects. Exception isolation, path-confined override, version-token, fail-closed skip list.
- **`skyyrose/core/review.py`** (+ `tests/test_review.py`) — `approve()` writes the theme-deployable image path, not repo-local `renders/`.
- Glob broadened `seedream-probe*.png` → `*-probe*.png` so it picks up `openai-probe.png` (gpt-image-2) as well as seedream probes.

## Deliberately excluded

- The branch's nano_banana gpt-image-2 migration commit — dropped per the erase-nano-banana directive (superseded by the oai_render pipeline).
- The WC outdated-template-notice commit — already on main (`6eec7b495`).

## Test plan

- [x] `pytest tests/test_stage_review.py tests/test_review.py` — all green
- [x] `ruff check scripts/stage_review.py` — clean
- [ ] CI green (Security Gate may flag the pre-existing GPL/AGPL dep — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `scripts/stage_review.py` to bridge finished renders into the approval queue and unblock the render→approve→WooCommerce flow. Updates `approve()` to write a theme-deployable image path and copy approved renders into the theme assets; includes `gpt-image-2` probe support.

- New Features
  - New CLI (`scripts/stage_review.py`) that promotes probe PNGs from `assets/product-source/{sku}__{slug}/renders/` to `renders/ghost-mannequin/{sku}-ghost-front.webp` with PNG→WEBP conversion; supports `--all`, `--render`, `--force`, `--dry-run`.
  - Auto-selects the highest `-vN` variant; broadened glob to `*-probe*.png` (picks up `openai-probe.png`).
  - Honors `SKIPPED.json`; missing renders are soft skips; isolates per-SKU failures and validates inputs.

- Bug Fixes
  - `approve()` now writes `front_model_image` as `assets/images/products/ghost/{sku}-ghost-front.webp` and copies the approved file to `wordpress-theme/.../assets/images/products/ghost/` so the storefront resolves images correctly.
  - Adds rollback cleanup for the theme copy; retains the `approved/` original for the WooCommerce uploader.

<sup>Written for commit 428ec1cef1188b8f5ccd6545e07a5e61ba2c48f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

