### PR TITLE
fix(ci): mark elite_studio CLIP/DINO tests as integration (deflake main)

### DIFF
--- a/tests/elite_studio/test_clip_alignment.py
+++ b/tests/elite_studio/test_clip_alignment.py
@@ -9,6 +9,12 @@ from PIL import Image, ImageDraw
 
 from skyyrose.elite_studio.quality import clip_alignment
 
+# Network/model-download integration tests — these pull CLIP/DINO weights from
+# HF Hub at runtime. Excluded from the fast gate (CI runs `-m "not slow and not
+# integration"`) so a transient HF outage cannot flake main red; run on demand
+# with `-m integration`.
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture
 def red_circle_image(tmp_path: Path) -> Path:

--- a/tests/elite_studio/test_clip_embedder.py
+++ b/tests/elite_studio/test_clip_embedder.py
@@ -10,6 +10,12 @@ from PIL import Image
 
 from skyyrose.core import clip_embedder
 
+# Network/model-download integration tests — these pull CLIP/DINO weights from
+# HF Hub at runtime. Excluded from the fast gate (CI runs `-m "not slow and not
+# integration"`) so a transient HF outage cannot flake main red; run on demand
+# with `-m integration`.
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture
 def red_image(tmp_path: Path) -> Path:

--- a/tests/elite_studio/test_compositor_gate_integration.py
+++ b/tests/elite_studio/test_compositor_gate_integration.py
@@ -15,6 +15,12 @@ from skyyrose.elite_studio.quality.brand_centroid import (
     save_centroid,
 )
 
+# Network/model-download integration tests — these pull CLIP/DINO weights from
+# HF Hub at runtime. Excluded from the fast gate (CI runs `-m "not slow and not
+# integration"`) so a transient HF outage cannot flake main red; run on demand
+# with `-m integration`.
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture
 def fake_centroid_file(tmp_path: Path) -> Path:

--- a/tests/elite_studio/test_dino_embedder.py
+++ b/tests/elite_studio/test_dino_embedder.py
@@ -15,6 +15,12 @@ from PIL import Image
 
 from skyyrose.core import dino_embedder
 
+# Network/model-download integration tests — these pull CLIP/DINO weights from
+# HF Hub at runtime. Excluded from the fast gate (CI runs `-m "not slow and not
+# integration"`) so a transient HF outage cannot flake main red; run on demand
+# with `-m integration`.
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture
 def red_image(tmp_path: Path) -> Path:

--- a/tests/elite_studio/test_embedding_gate.py
+++ b/tests/elite_studio/test_embedding_gate.py
@@ -11,6 +11,12 @@ from PIL import Image
 from skyyrose.elite_studio.quality import embedding_gate
 from skyyrose.elite_studio.quality.brand_centroid import BrandCentroid
 
+# Network/model-download integration tests — these pull CLIP/DINO weights from
+# HF Hub at runtime. Excluded from the fast gate (CI runs `-m "not slow and not
+# integration"`) so a transient HF outage cannot flake main red; run on demand
+# with `-m integration`.
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture
 def fake_centroid() -> BrandCentroid:


### PR DESCRIPTION
## Why
On the #564 merge commit, `🐍 Python Tests` failed with **15 errors**, all identical:
```
OSError: We couldn't connect to 'https://huggingface.co' to load the files, and couldn't find them in the cached files.
```
All in `tests/elite_studio/test_clip_*`, `test_dino_*`, `test_embedding_gate`, `test_compositor_gate_integration` — tests that download CLIP/DINO weights from HF Hub at runtime. No code regressed; HF Hub was transiently unreachable from the runner. #564's PR run only passed because HF happened to be reachable then.

## Fix
Mark the 5 model-download files `pytestmark = pytest.mark.integration`. The repo already excludes `-m integration` from the fast `Python Tests` gate (`addopts: -m "not slow and not integration"`) and runs integration via separate file globs that don't match `elite_studio/`. So this deselects them from the deterministic gate while keeping them runnable via `-m integration`. No assertions weakened — correct classification of genuine integration tests.

## Verified locally
- `-m "not slow and not integration"` → **0** collected from the 5 files
- `-m integration` → **17** collected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark `elite_studio` CLIP/DINO tests that download weights from Hugging Face Hub as `pytest.mark.integration` to deflake the fast Python Tests gate. They are excluded by `-m "not slow and not integration"` and remain runnable with `-m integration`; no assertions changed.

<sup>Written for commit 7f88fe632e1f151ec95b7b3ff1afc0894693d61c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

