### PR TITLE
fix(ci): skip elite_studio embedder tests when HF models unavailable (unblocks main CI)

### DIFF
--- a/tests/elite_studio/conftest.py
+++ b/tests/elite_studio/conftest.py
@@ -1,0 +1,73 @@
+"""Skip embedder-dependent elite_studio tests when HF models can't be loaded.
+
+The CLIP/DINO embedder tests load real models from the HuggingFace Hub on first
+use (``openai/clip-vit-base-patch32`` ~600MB, ``facebook/dinov2`` ~330MB). On a
+cold CI runner the Hub rate-limits (HTTP 429) or is unreachable; transformers
+surfaces that as ``OSError`` ("We couldn't connect to 'https://huggingface.co'
+... and couldn't find them in the cached files"). That is an environment
+condition, not a defect, so these tests should *skip* deterministically rather
+than fail the whole pipeline. They still run wherever the model is available
+(warm cache / local dev), preserving real coverage.
+
+Mirrors the root ``conftest.py`` convention of skipping tests when a prerequisite
+is unavailable (there: the rebuilt ``wordpress`` module; here: the HF weights).
+"""
+
+from __future__ import annotations
+
+import functools
+
+import pytest
+
+# Exceptions that mean "the model could not be fetched/loaded from the Hub or
+# local cache" — i.e. an environment problem, not a code defect. transformers'
+# ``from_pretrained`` raises ``OSError`` on connection/cache miss; ``ImportError``
+# guards a runner without torch/transformers installed. huggingface_hub HTTP
+# errors are added defensively for code paths that re-raise them un-wrapped.
+_UNAVAILABLE: tuple[type[BaseException], ...] = (OSError, ImportError)
+try:  # pragma: no cover - import shape varies across hub versions
+    from huggingface_hub.errors import HfHubHTTPError
+
+    _UNAVAILABLE = (*_UNAVAILABLE, HfHubHTTPError)
+except ImportError:  # pragma: no cover
+    pass
+
+
+@functools.lru_cache(maxsize=1)
+def _clip_skip_reason() -> str | None:
+    """Return None if CLIP loads, else a skip reason. Loads at most once per session."""
+    try:
+        from skyyrose.core import clip_embedder
+
+        clip_embedder.get_clip()
+        return None
+    except _UNAVAILABLE as exc:
+        return f"CLIP model unavailable: {type(exc).__name__}: {exc}"
+
+
+@functools.lru_cache(maxsize=1)
+def _dino_skip_reason() -> str | None:
+    """Return None if DINOv2 loads, else a skip reason. Loads at most once per session."""
+    try:
+        from skyyrose.core import dino_embedder
+
+        dino_embedder.get_dino()
+        return None
+    except _UNAVAILABLE as exc:
+        return f"DINOv2 model unavailable: {type(exc).__name__}: {exc}"
+
+
+@pytest.fixture(scope="session")
+def clip_model_available() -> None:
+    """Skip the requesting test/module when the CLIP weights can't be loaded."""
+    reason = _clip_skip_reason()
+    if reason:
+        pytest.skip(reason)
+
+
+@pytest.fixture(scope="session")
+def dino_model_available() -> None:
+    """Skip the requesting test/module when the DINOv2 weights can't be loaded."""
+    reason = _dino_skip_reason()
+    if reason:
+        pytest.skip(reason)

--- a/tests/elite_studio/test_clip_alignment.py
+++ b/tests/elite_studio/test_clip_alignment.py
@@ -9,6 +9,10 @@ from PIL import Image, ImageDraw
 
 from skyyrose.elite_studio.quality import clip_alignment
 
+# clip_alignment scores via the real CLIP encoder; skip the module when the
+# weights can't be loaded (cold CI cache / Hub rate-limit) — see conftest.py.
+pytestmark = pytest.mark.usefixtures("clip_model_available")
+
 
 @pytest.fixture
 def red_circle_image(tmp_path: Path) -> Path:

--- a/tests/elite_studio/test_clip_embedder.py
+++ b/tests/elite_studio/test_clip_embedder.py
@@ -10,6 +10,10 @@ from PIL import Image
 
 from skyyrose.core import clip_embedder
 
+# Every test here exercises the real CLIP encoder; skip the module when the
+# weights can't be loaded (cold CI cache / Hub rate-limit) — see conftest.py.
+pytestmark = pytest.mark.usefixtures("clip_model_available")
+
 
 @pytest.fixture
 def red_image(tmp_path: Path) -> Path:

--- a/tests/elite_studio/test_compositor_gate_integration.py
+++ b/tests/elite_studio/test_compositor_gate_integration.py
@@ -15,6 +15,11 @@ from skyyrose.elite_studio.quality.brand_centroid import (
     save_centroid,
 )
 
+# Both tests drive the real embedding gate (only Gemini QA is mocked), which
+# loads the CLIP encoder; skip the module when the weights can't be loaded
+# (cold CI cache / Hub rate-limit) — see conftest.py.
+pytestmark = pytest.mark.usefixtures("clip_model_available")
+
 
 @pytest.fixture
 def fake_centroid_file(tmp_path: Path) -> Path:

--- a/tests/elite_studio/test_dino_embedder.py
+++ b/tests/elite_studio/test_dino_embedder.py
@@ -15,6 +15,10 @@ from PIL import Image
 
 from skyyrose.core import dino_embedder
 
+# Every test here exercises the real DINOv2 encoder; skip the module when the
+# weights can't be loaded (cold CI cache / Hub rate-limit) — see conftest.py.
+pytestmark = pytest.mark.usefixtures("dino_model_available")
+
 
 @pytest.fixture
 def red_image(tmp_path: Path) -> Path:

--- a/tests/elite_studio/test_embedding_gate.py
+++ b/tests/elite_studio/test_embedding_gate.py
@@ -26,6 +26,9 @@ def render_image(tmp_path: Path) -> Path:
     return tmp_path / "render.png"
 
 
+# Only this test calls the real scorer (CLIP); the evaluate() tests below
+# monkeypatch score_against_centroid and need no model — gate just this one.
+@pytest.mark.usefixtures("clip_model_available")
 def test_score_returns_cosine_in_range(fake_centroid: BrandCentroid, render_image: Path) -> None:
     score = embedding_gate.score_against_centroid(render_image, fake_centroid)
     assert -1.0 <= score <= 1.0


### PR DESCRIPTION
## Problem
`main` CI/CD pipeline is red. Root cause is a single job — **🐍 Python Tests / Run pytest with coverage** — where **15 tests fail, 5577 pass**. All 15 are in `tests/elite_studio/` (CLIP/DINO embedders, embedding gate, compositor gate) and fail identically:

```
huggingface_hub.errors.HfHubHTTPError: 429 Too Many Requests for
  https://huggingface.co/openai/clip-vit-base-patch32/resolve/main/config.json
OSError: We couldn't connect to 'https://huggingface.co' ... couldn't find them in the cached files.
```

These tests download real models from the HuggingFace Hub at runtime. On a cold CI runner the Hub rate-limits (429) → fail. Locally they pass (warm cache), so the break only surfaces on CI — and it cascades: every open PR (incl. all Dependabot bumps) inherits the red pipeline.

## Fix
- New `tests/elite_studio/conftest.py` with session-scoped fixtures `clip_model_available` / `dino_model_available` that attempt the load **once** and `pytest.skip()` on the model-unavailable error class (`OSError` / `ImportError` / `HfHubHTTPError`).
- Gate the model-dependent tests:
  - **module-level** `usefixtures`: `test_clip_embedder`, `test_clip_alignment`, `test_dino_embedder`, `test_compositor_gate_integration`
  - **function-level**: `test_embedding_gate::test_score_returns_cosine_in_range` (the other two monkeypatch the scorer and keep running — coverage preserved)
- Mirrors the root `conftest.py` convention of skipping when a prerequisite is unavailable (there: the `wordpress` module).

Tests **skip cleanly (exit 0)** when the model can't load and **still run + pass** wherever it is available — deterministic CI, no lost coverage where models exist.

## Verification
| Scenario | Result |
|---|---|
| Forced offline (`HF_HUB_OFFLINE=1`, empty cache) | `2 passed, 15 skipped`, **exit 0** |
| Warm local cache (model available) | `8 passed`, **exit 0** |
| `ruff` / `black` / `isort` | clean |

## Test plan
- [ ] CI **🐍 Python Tests** job goes green on this PR
- [ ] Once green on `main`, Dependabot PRs can be rebased and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip CLIP/DINO embedder tests in `tests/elite_studio/` when HuggingFace models can’t be loaded, unblocking `main` CI. On cold runners, these tests now `pytest.skip()` instead of failing on 429/offline errors.

- **Bug Fixes**
  - Added `tests/elite_studio/conftest.py` with session-scoped `clip_model_available` and `dino_model_available` that try one model load and skip on `OSError`, `ImportError`, or `huggingface_hub.errors.HfHubHTTPError`.
  - Applied `pytestmark = pytest.mark.usefixtures(...)` in `test_clip_embedder.py`, `test_clip_alignment.py`, `test_dino_embedder.py`, and `test_compositor_gate_integration.py`; gated only `test_embedding_gate::test_score_returns_cosine_in_range`.
  - Keeps tests running where models are cached; clean skips where unavailable for deterministic, green CI.

<sup>Written for commit 2c16f7993f76ad1f19227460e73a9acb7eeae957. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

