### PR TITLE
fix(docker): bump base image to python:3.12-slim (green Docker Build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN npm run build
 # =============================================================================
 # Stage 2: Python Backend Builder
 # =============================================================================
-FROM python:3.11-slim AS backend-builder
+FROM python:3.12-slim AS backend-builder
 
 # Prevent apt from hanging
 ENV DEBIAN_FRONTEND=noninteractive
@@ -72,7 +72,7 @@ RUN pip install --no-cache-dir --timeout=600 ".[all]"
 # =============================================================================
 # Stage 3: Production Runtime
 # =============================================================================
-FROM python:3.11-slim AS production
+FROM python:3.12-slim AS production
 
 # Prevent apt from hanging
 ENV DEBIAN_FRONTEND=noninteractive
@@ -96,7 +96,7 @@ RUN apt-get update --fix-missing || apt-get update --fix-missing && \
 WORKDIR /app
 
 # Copy Python dependencies from builder
-COPY --from=backend-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=backend-builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=backend-builder /usr/local/bin /usr/local/bin
 
 # Copy Next.js build artifacts

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -8,7 +8,7 @@
 # =============================================================================
 # Stage 1: Python Dependencies Builder
 # =============================================================================
-FROM python:3.11-slim AS builder
+FROM python:3.12-slim AS builder
 
 # Prevent apt from hanging
 ENV DEBIAN_FRONTEND=noninteractive
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --timeout=300 --user -r requirements.txt
 # =============================================================================
 # Stage 2: Production Runtime
 # =============================================================================
-FROM python:3.11-slim AS production
+FROM python:3.12-slim AS production
 
 # Prevent apt from hanging
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Why
After #564 set `requires-python = '>=3.12,<3.15'` and moved CI to Python 3.12, the push-only **🐳 Docker Build** job started failing on main at `Dockerfile:70`:
```
ERROR: Package 'devskyy' requires a different Python: 3.11.15 not in '<3.15,>=3.12'
```
The Dockerfiles still used `python:3.11-slim`. This job is `if: github.event_name == 'push'`, so it's invisible on PRs and only reds main after merge.

## Fix
`python:3.11-slim` → `python:3.12-slim` in `Dockerfile` (backend-builder + production) and `Dockerfile.worker`, plus the hardcoded `python3.11/site-packages` COPY path → `python3.12`.

COPY paths are already correct on main (`frontend/contexts`, `sdk/python/agent_sdk` both exist), so #469's COPY fixes are already superseded — only the Python base needed bumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Docker images to Python 3.12 to match `requires-python >=3.12,<3.15` and fix the push-only Docker Build failing on main. Bumps base images to `python:3.12-slim` and updates the site-packages COPY path.

- Bug Fixes
  - Dockerfile: switch backend-builder and production to `python:3.12-slim`; update COPY to `/usr/local/lib/python3.12/site-packages`.
  - Dockerfile.worker: switch builder and production to `python:3.12-slim`.

<sup>Written for commit cb0a7a0a4a8b0101b4997d77c213cf7c23549b72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python runtime environment from version 3.11 to 3.12 for improved stability and performance across backend and worker services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->