### PR TITLE
fix(deps): cap aiofiles<25 in mcp extra so Docker .[all] resolves

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,11 @@ mcp = [
     "httpx>=0.28.1",
     "aiohttp>=3.12.14",
     "asyncio==3.4.3",
-    "aiofiles==25.1.0",
+    # Capped <25 so .[all] resolves: the rag extra (raganything->mineru->gradio)
+    # requires aiofiles<25.0; base needs >=24.1.0. Neither fastmcp nor the mcp
+    # SDK depend on aiofiles (verified via PyPI requires-dist), so the prior
+    # ==25.1.0 pin was arbitrary and made .[all] unsatisfiable in Docker.
+    "aiofiles>=24.1.0,<25.0",
     "orjson==3.11.7",
     "python-dotenv==1.2.2",
     "structlog==25.5.0",


### PR DESCRIPTION
## Why
After the python:3.12 bump (#574), Docker Build still fails — now `pip install .[all]` hits `ResolutionImpossible`:
```
mcp extra:  aiofiles==25.1.0
rag extra:  raganything -> mineru[core] -> gradio<6,>=5.34 -> aiofiles<25.0
```
`.[all]` includes both rag + mcp → unsatisfiable. CI Python Tests passes only because it installs `.[dev,mcp]` (no gradio chain).

## Fix
Neither `fastmcp==3.0.0` nor `mcp>=1.23.0` depend on aiofiles (verified via PyPI `requires_dist`), so the `==25.1.0` pin was arbitrary. Relax to `>=24.1.0,<25.0` — the intersection of base (`>=24.1.0`) and gradio (`<25.0`). Resolves `.[all]`; MCP stack unaffected.

This is the last Docker Build blocker after #564→#569→#571→#574. Python/Frontend/Three.js/Lint/Security/WP/API-Integration already green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap `aiofiles` to `>=24.1.0,<25.0` in the `mcp` extra so `pip install .[all]` resolves in Docker. This aligns with the `rag` extra via `gradio` (`aiofiles<25.0`) and unblocks the build.

- **Dependencies**
  - Updated `aiofiles` in `mcp` extra from `==25.1.0` to `>=24.1.0,<25.0`.
  - `fastmcp` and `mcp` do not require `aiofiles`, so the previous pin was unnecessary.

<sup>Written for commit c5fbff4b14edf4d92c1ad2e5d1d687fb7c50b23a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

