### PR TITLE
ci(docker): raise Docker Build timeout 20→45 min (last green blocker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,7 +631,11 @@ jobs:
   docker-build:
     name: 🐳 Docker Build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # The .[all] backend image pulls the full ML stack (torch+CUDA, transformers,
+    # mineru, chromadb, faiss, sentence-transformers) — a multi-GB image whose
+    # build + GHCR push legitimately exceeds 20 min cold. Deps now resolve (aiofiles
+    # cap); the only remaining failure was this timeout. 45 min fits the real build.
+    timeout-minutes: 45
     needs: [python-tests, frontend-tests, security]
     if: github.event_name == 'push'
 


### PR DESCRIPTION
After #575 (aiofiles cap), Docker's `pip install .[all]` resolves + installs cleanly — log shows `Successfully installed … aiofiles-24.1.0 gradio-6.8.0 fastmcp-3.0.0 torch-2.9.1 mineru-3.4.0 …`. The job then hit the **20-min timeout** at the multi-GB image COPY + GHCR push (`The operation was canceled` @ 20m27s), not a build error.

The `.[all]` backend image bundles the full ML stack (torch+CUDA, transformers, mineru, chromadb, faiss) — cold build+push legitimately needs >20 min. Raise to 45.

Last red on main after #564→#569→#571→#574→#575; everything else green. (Slimming the prod image to drop the ML stack it doesn't need at runtime is a worthwhile separate follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the Docker Build job timeout in CI from 20 to 45 minutes so cold builds and GHCR pushes of the multi-GB `.[all]` backend image can complete (full ML stack: `torch`+CUDA, `transformers`, `mineru`, `chromadb`, `faiss`). After the `aiofiles` cap in #575, `pip install .[all]` completes; the only failure was the 20-minute timeout during image copy/push.

<sup>Written for commit a80040f96e0c7918eb941cb7fc2e0aa15962641a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

