### PR TITLE
fix(lint): black-format a2a + exclude a2a from mypy (green lint)

### DIFF
--- a/agents/devskyy-a2a/agents/agent.py
+++ b/agents/devskyy-a2a/agents/agent.py
@@ -103,8 +103,7 @@ def _check_budget(skill: str, max_cost_usd: float | None) -> dict[str, Any] | No
             "skill": skill,
             "estimate_usd": estimate,
             "message": (
-                f"Skill '{skill}' costs ~${estimate:.2f} per call; "
-                "caller must pass max_cost_usd"
+                f"Skill '{skill}' costs ~${estimate:.2f} per call; " "caller must pass max_cost_usd"
             ),
         }
     if max_cost_usd is not None and estimate > max_cost_usd:
@@ -114,9 +113,7 @@ def _check_budget(skill: str, max_cost_usd: float | None) -> dict[str, Any] | No
             "skill": skill,
             "estimate_usd": estimate,
             "max_cost_usd": max_cost_usd,
-            "message": (
-                f"Estimated cost ${estimate:.2f} exceeds cap ${max_cost_usd:.2f}"
-            ),
+            "message": (f"Estimated cost ${estimate:.2f} exceeds cap ${max_cost_usd:.2f}"),
         }
     return None
 
@@ -283,9 +280,7 @@ def product_description(
 
     try:
         agent = CommerceAgent()
-        result = agent.describe_product(
-            sku=sku, audience=audience, max_words=int(max_words)
-        )
+        result = agent.describe_product(sku=sku, audience=audience, max_words=int(max_words))
     except Exception as exc:  # noqa: BLE001
         return {
             "ok": False,
@@ -295,9 +290,7 @@ def product_description(
             "message": str(exc),
         }
 
-    description = (
-        result.get("description", "") if isinstance(result, dict) else str(result)
-    )
+    description = result.get("description", "") if isinstance(result, dict) else str(result)
     if _RETIRED_TAGLINE.lower() in description.lower():
         return {
             "ok": False,

--- a/agents/devskyy-a2a/agents/app_utils/telemetry.py
+++ b/agents/devskyy-a2a/agents/app_utils/telemetry.py
@@ -25,9 +25,7 @@ def setup_telemetry() -> str | None:
     """Configure OpenTelemetry and GenAI telemetry with GCS upload."""
 
     bucket = os.environ.get("LOGS_BUCKET_NAME")
-    capture_content = os.environ.get(
-        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "false"
-    )
+    capture_content = os.environ.get("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "false")
     if bucket and capture_content != "false":
         logging.info(
             "Prompt-response logging enabled - mode: NO_CONTENT (metadata only, no prompts/responses)"
@@ -35,9 +33,7 @@ def setup_telemetry() -> str | None:
         os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "NO_CONTENT"
         os.environ.setdefault("OTEL_INSTRUMENTATION_GENAI_UPLOAD_FORMAT", "jsonl")
         os.environ.setdefault("OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK", "upload")
-        os.environ.setdefault(
-            "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-        )
+        os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental")
         commit_sha = os.environ.get("COMMIT_SHA", "dev")
         os.environ.setdefault(
             "OTEL_RESOURCE_ATTRIBUTES",

--- a/mypy.ini
+++ b/mypy.ini
@@ -41,6 +41,7 @@ exclude = (?x)(
     | claude-context/.*
     | vendor/.*
     | prototypes/.*
+    | agents/devskyy-a2a/.*
   )
 
 # Relaxed mode for non-production code


### PR DESCRIPTION
#475 (a2a) merged code never run through main's linters (account-block era). Post-merge lint job failed:

1. **black** — `agents/devskyy-a2a/agents/{agent,telemetry}.py` unformatted.
2. **mypy** — `agents/devskyy-a2a/agents/app_utils/typing.py` shadows stdlib `typing` (exit 2).

Fix: black-format the 2 files; exclude `agents/devskyy-a2a/` in `mypy.ini` (isolated ADK sub-app w/ own venv per CLAUDE.md, like the already-excluded `skyyrose/`/`sdk/`). Verified locally: ruff/black/isort clean repo-wide, `mypy .` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix lint failures from the a2a merge by black-formatting files and excluding the `agents/devskyy-a2a/` sub-app from `mypy` to restore a green lint run.

- **Bug Fixes**
  - Ran `black` on `agents/devskyy-a2a/agents/agent.py` and `agents/devskyy-a2a/agents/app_utils/telemetry.py`.
  - Updated `mypy.ini` to exclude `agents/devskyy-a2a/.*` (isolated ADK sub-app with its own venv), resolving the `typing` module shadowing error.

<sup>Written for commit 7b722b4679d750815fcfa89ae8c6b39dcccc1f1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

