### PR TITLE
feat: close six high-priority agent gaps (#17660) — fraud, retention, forecasting, personalization, evaluator, observability

### DIFF
--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -2046,6 +2046,136 @@
       "related_bugs": [],
       "occurrences": 1,
       "last_seen": "2026-06-18"
+    },
+    {
+      "id": "bug-146",
+      "timestamp": "2026-06-19",
+      "error_message": "On-model render QC: 3/26 renders defective (br-005 black-not-green, br-012 black-not-green, sg-002 collage inset) + committed CSV front_model_image still on OLD paths while committed SOT/binaries are onmodel (parallel commit b432bcac9 shipped old CSV).",
+      "file": "wordpress-theme/skyyrose-flagship/data/skyyrose-catalog.csv",
+      "root_cause": "Parallel session committed 26 onmodel binaries+SOT+manifest+test with the OLD CSV -> committed CSV<->SOT inconsistency. Separately, gpt-image rendered dark-green garments (br-005 olive hoodie, br-012 green jersey) as pure black, and sg-002 got a corner inset panel; deterministic_checks passed all three (color/inset invisible to dimension+band checks), only the paid Claude vision judge caught them.",
+      "fix": "Working-tree CSV re-wired 23 good SKUs to onmodel; br-005/br-012/sg-002 reverted to prior fallback (ghost/front-model). Regenerated SOT to match; manifest --check + 23 tests green. br-005 CSV color=Black is ALSO wrong (real garment olive-green, founder confirmed). Re-render the 3 (paid, gated) before wiring them. NOT committed (parallel session active).",
+      "tags": [
+        "imagery",
+        "qc",
+        "render-fidelity",
+        "catalog-csv",
+        "sot",
+        "parallel-session",
+        "colorway"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-06-19"
+    },
+    {
+      "id": "bug-147",
+      "timestamp": "2026-06-20T08:30:00Z",
+      "error_message": "main CI red across 58 PRs; loop-till-green blocked by 7 stacked root causes",
+      "file": ".github/workflows/ci.yml, pyproject.toml, Dockerfile, tests/elite_studio/*, mypy.ini, wp template-parts",
+      "root_cause": "Unprotected main hid push-only job failures: (1) langgraph/submodule/lint debt #564; (2) CLIP/DINO tests hard-fail when HF Hub unreachable #569; (3) tracked .env + sanitize_html_class multi-class bug #571; (4) Dockerfile py3.11 vs requires-python>=3.12 #574; (5) mcp extra aiofiles==25.1.0 vs rag->mineru->gradio aiofiles<25 #575; (6) docker-build 20-min timeout too short for ML image #578; (7) #475 a2a unlinted: black drift + typing.py shadows stdlib #580.",
+      "fix": "Sequential fixes merged #564,#569,#571,#574,#575,#578,#580; each verified by reading the actual failed-job log. Final main 7e4e27326 all real gates green incl Docker (31min).",
+      "tags": [
+        "ci",
+        "docker",
+        "dependency-resolution",
+        "lint",
+        "loop-till-green",
+        "pr-consolidation"
+      ],
+      "related_bugs": [
+        "bug-146"
+      ],
+      "occurrences": 1,
+      "last_seen": "2026-06-20T08:30:00Z"
+    },
+    {
+      "id": "bug-148",
+      "timestamp": "2026-06-20T21:35:00Z",
+      "error_message": "Adversarial self-review of the new CopyAdapter content-evaluator found 3 real defects (10 confirmed / 30 raised; 20 refuted by skeptic stage): (1) HIGH _maybe_eval_copy had no try/except \u2014 a Claude judge exception (network/429/no-tool_use) would propagate through generate_content and kill content generation, violating the 'never blocks' soft-signal contract; (2) MED related-products regex matched inside 'unrelated products' -> false hard-fail on clean copy; (3) MED SKU lookbehind missed '( br-001)' (space inside paren) -> false sku_first_naming hard-fail.",
+      "file": "agents/skyyrose_content_agent.py, evaluation/domains/copy.py",
+      "root_cause": "Soft-signal advisory gate written without wrapping the external (paid) judge call in exception handling; deterministic regexes used substring / single-char-lookbehind patterns without word-boundary or whitespace tolerance. All three only misfire under the COPY_EVAL_ENABLED opt-in flag, but each is a real contract/canon violation.",
+      "fix": "(1) Wrapped _maybe_eval_copy body in try/except Exception -> log warning + record content.metadata['copy_eval']={'error':...} + return content unchanged. (2) Added leading word-boundary to the related-products regex. (3) Replaced the lookbehind with _uses_sku_as_handle(): finditer SKU tokens, allow only when nearest non-space char before the token is '('. Each fix landed RED->GREEN with a dedicated test. 103 tests green, ruff/black/mypy clean.",
+      "tags": [
+        "evaluation",
+        "content-evaluator",
+        "soft-signal",
+        "exception-handling",
+        "regex-false-positive",
+        "adversarial-review",
+        "tdd"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-06-20T21:35:00Z"
+    },
+    {
+      "id": "bug-149",
+      "timestamp": "2026-06-20T23:05:00Z",
+      "error_message": "Adversarial self-review of the Tier-1 fleet-observability change (FleetObserver consumer + record_llm_usage emitter) found 4 real defects (37 raised, 33 refuted incl a TOCTOU race correctly refuted because FleetObserver.evaluate has zero awaits = atomic under asyncio): (1) HIGH test gap \u2014 consecutive_failures PAGE escalation (streak >= 2*threshold) untested, a silent PAGE->TICKET regression would pass; (2) LOW circuit-breaker-OPEN path raised before the emitter -> CB-blocked calls produced no telemetry (error_rate/consecutive_failures blind during the CB window); (3) LOW calculate_cost used an f-string logger losing the structured field; (4) LOW _observer test helper missing **overrides annotation.",
+      "file": "llm/router.py, monitoring/fleet_observer.py, core/token_tracker.py, tests/test_fleet_health_consumer.py",
+      "root_cause": "Two-tier severity branch shipped without a test for the upper tier; the circuit-breaker early-return sat above the try/except emitter seam; pre-existing f-string log + a test-helper annotation gap in the edited files.",
+      "fix": "(1) Added test_consecutive_failures_at_double_threshold_is_page + asserted TICKET on the at-threshold test. (2) Added record_llm_usage(success=False, error='circuit_breaker_open') before the CB raise; new test_router_circuit_breaker_open_records_failure (RED->GREEN). (3) logger.warning('unknown_model_cost', model=...). (4) annotated **overrides: float. 45 tests green, ruff/black/mypy clean.",
+      "tags": [
+        "observability",
+        "fleet-observer",
+        "token-tracker",
+        "circuit-breaker",
+        "telemetry",
+        "adversarial-review",
+        "tdd"
+      ],
+      "related_bugs": [
+        "bug-148"
+      ],
+      "occurrences": 1,
+      "last_seen": "2026-06-20T23:05:00Z"
+    },
+    {
+      "id": "bug-150",
+      "timestamp": "2026-06-20T23:55:00Z",
+      "error_message": "Adversarial review of the new deterministic fraud scorer (services/risk/fraud.py) found 16 real defects. Top: (HIGH) never-raises contract broken \u2014 `raw = sum(s.weight for s in signals)` sat OUTSIDE the try/except, so FraudScorer(weights={'x':'str'}).assess(...) raised TypeError; (HIGH) false-positive \u2014 a legit first-time guest sending a $500+ gift internationally stacked country(20)+name(10)+highvalue(10)+firsttime(15)=55 -> HIGH/review, costing real sales; (MEDIUM) mixed naive/aware date_created silently zeroed ALL velocity signals (TypeError caught -> every history row out-of-window); (MEDIUM) raw email/IP/full names leaked into signal detail strings + as_dict; (MEDIUM) markdown pipe-injection in format_assessment; (LOW) NaN total treated as 0-risk; current order counted in its own velocity; guest==None false-positive; stale hardcoded total_tools.",
+      "file": "services/risk/fraud.py, mcp_tools/tools/resources.py",
+      "root_cause": "Green TDD suite proved each rule fires but never exercised calibration (signal stacking across action boundaries), the never-raises guard scope, mixed-tz real-world WooCommerce timestamps, or PII/markdown safety \u2014 blind spots only adversarial review surfaces.",
+      "fix": "Recalibrated weights (country 20->15, first_time->guest_high_value 15->10) so benign intl gift = 45 MEDIUM/approve while AVS/CVV still escalate; moved score sum inside the guarded block + logger.warning on fallback; _parse_dt normalizes naive->UTC; masked email(***@domain)/IP(/24)/redacted names in details; _md_cell escapes pipes/newlines; _to_float rejects NaN/inf; velocity excludes the order's own id; guest only when customer_id explicitly '0'; total_tools computed dynamically from the FastMCP registry. Added 9 regression tests.",
+      "tags": [
+        "fraud",
+        "adversarial-review",
+        "never-raises",
+        "calibration",
+        "pii",
+        "datetime-tz",
+        "tier2-agent-gaps"
+      ],
+      "related_bugs": [
+        "bug-148",
+        "bug-149"
+      ],
+      "occurrences": 1,
+      "last_seen": "2026-06-20T23:55:00Z"
+    },
+    {
+      "id": "bug-151",
+      "timestamp": "2026-06-21T00:35:00Z",
+      "error_message": "Adversarial review of the 3 remaining Tier-2 scorers (retention/forecasting/personalization) found 43 confirmed findings (6 HIGH/13 MED/24 LOW; heavy dedup -> ~16 distinct). Top: (HIGH x3, same root) LOYAL lifecycle stage UNREACHABLE past at_risk_days=90 because recency gates fired before the loyalty frequency check -> a 5-order buyer in a normal 91-180d inter-drop gap was demoted to AT_RISK and routed to win-back (100% false-positive on loyal buyers for SkyyRose's quarterly drop cadence); (HIGH) pre-order products triggered false CRITICAL 'reorder_now' alerts because is_preorder was captured but never consulted in sellout risk; (HIGH) personalization popularity used raw unbounded count -> a bestseller could swamp personalized signals; (MED) forecast window included today (partial day) inflating velocity; forecast_units_30d used self.horizon_days not literal 30; _price used `or` dropping price=0.0; segment_customers/forecast_sales fallbacks called now() per row (non-deterministic batch); _parse_dt dropped datetime objects; (HIGH, verified-but-out-of-scope) orphaned analytics_forecast_sales ToolSpec -> documented canonical surface rather than building dispatch.",
+      "file": "services/lifecycle/retention.py, services/forecasting/demand.py, services/personalization/recommender.py, agents/analytics_agent.py",
+      "root_cause": "Green TDD proved each rule fires in isolation but never tested cross-band interactions (stage-ordering precedence), domain calibration (drop cadence, pre-order semantics), bounded scales (raw-count swamp), batch determinism, or real-world datetime types. Adversarial review with domain context surfaced them.",
+      "fix": "Retention: loyalty check moved before the at_risk recency gate so loyal buyers stay LOYAL through the inter-drop window (degrade only past dormant/churned); churn_risk=0 when frequency<=0; _parse_dt accepts datetime. Forecasting: is_preorder -> SelloutRisk.NONE; window excludes today (recency>=1); forecast_units_30d fixed at literal 30d (removed dead horizon_days ctor param); removed unreachable _trend branch; _parse_dt accepts datetime. Personalization: popularity log1p-scaled; _price uses explicit None; added similarity_k fanout param. analytics_agent: forecast_sales/segment_customers take as_of (single now -> reproducible batch), segment_customers rejects non-rfm methods gracefully, ToolSpec metadata documented. Added 15 regression tests (148 total green).",
+      "tags": [
+        "retention",
+        "forecasting",
+        "personalization",
+        "adversarial-review",
+        "calibration",
+        "lifecycle-staging",
+        "preorder",
+        "determinism",
+        "tier2-agent-gaps"
+      ],
+      "related_bugs": [
+        "bug-150"
+      ],
+      "occurrences": 1,
+      "last_seen": "2026-06-21T00:35:00Z"
     }
   ]
 }

--- a/agents/analytics_agent.py
+++ b/agents/analytics_agent.py
@@ -417,7 +417,14 @@ You are a senior data analyst and business intelligence expert with expertise in
         ]
 
     def _register_tools(self) -> None:
-        """Register analytics tools with the global ToolRegistry for MCP integration."""
+        """Register analytics tool *capability metadata* with the global ToolRegistry.
+
+        These ToolSpecs are descriptive declarations (name/params/tags), not execution
+        handlers — the registry has no dispatch entry for them. Runtime execution happens via
+        this agent's async Python methods (``forecast_sales`` / ``segment_customers``) and the
+        canonical FastMCP tools in ``mcp_tools/tools/resources.py`` (e.g.
+        ``devskyy_demand_forecast`` for the deterministic forecaster).
+        """
         registry = ToolRegistry.get_instance()
 
         analytics_tools = [
@@ -792,9 +799,19 @@ Report Structure:
         )
 
     async def forecast_sales(
-        self, horizon_days: int = 30, granularity: str = "daily"
+        self,
+        horizon_days: int = 30,
+        granularity: str = "daily",
+        product: dict[str, Any] | None = None,
+        as_of: datetime | None = None,
     ) -> dict[str, Any]:
-        """Forecast sales using ML"""
+        """Forecast sales.
+
+        Uses the ML module when available; otherwise falls back to the deterministic
+        velocity/sellout forecaster (``services.forecasting.demand``) over ``product``'s
+        sales history — an always-available, explainable baseline (no "not available" dead end).
+        Pass ``as_of`` for reproducible scoring.
+        """
         if self.ml_module:
             prediction = await self.ml_module.predict(
                 "forecaster", {"horizon": horizon_days, "granularity": granularity}
@@ -806,10 +823,36 @@ Report Structure:
                 "granularity": granularity,
             }
 
-        return {"error": "ML module not available"}
+        if product is not None:
+            from services.forecasting.demand import DemandForecaster
 
-    async def segment_customers(self, method: str = "rfm") -> dict[str, Any]:
-        """Segment customers using clustering"""
+            forecast = DemandForecaster().forecast(product, as_of=as_of)
+            payload = forecast.as_dict()
+            payload["forecast_units_horizon"] = forecast.forecast_units(horizon_days)
+            payload["horizon_days"] = horizon_days
+            payload["granularity"] = granularity
+            payload["method"] = "deterministic_velocity"
+            return payload
+
+        return {
+            "forecast": None,
+            "note": "No ML module and no product sales data provided.",
+            "horizon_days": horizon_days,
+            "granularity": granularity,
+        }
+
+    async def segment_customers(
+        self,
+        method: str = "rfm",
+        customers: list[dict[str, Any]] | None = None,
+        as_of: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Segment customers.
+
+        Uses the ML clusterer when available; otherwise, for the RFM method, falls back to the
+        deterministic lifecycle scorer (``services.lifecycle.retention``) over ``customers``.
+        Pass ``as_of`` for a reproducible batch (otherwise a single ``now`` is used for all rows).
+        """
         if self.ml_module:
             prediction = await self.ml_module.predict("clusterer", {"method": method})
             return {
@@ -818,7 +861,36 @@ Report Structure:
                 "confidence": prediction.confidence,
             }
 
-        return {"error": "ML module not available"}
+        if customers is not None:
+            if method.lower() != "rfm":
+                return {
+                    "segments": [],
+                    "note": f"Deterministic fallback supports only method='rfm'; got '{method}'. "
+                    "Wire ml_module for other clustering methods.",
+                    "method": method,
+                }
+            from services.lifecycle.retention import RetentionScorer
+
+            when = as_of or datetime.now(UTC)  # single timestamp -> reproducible batch
+            scorer = RetentionScorer()
+            assessments = [
+                scorer.assess(c, as_of=when).as_dict() for c in customers if isinstance(c, dict)
+            ]
+            counts: dict[str, int] = {}
+            for a in assessments:
+                counts[a["lifecycle_stage"]] = counts.get(a["lifecycle_stage"], 0) + 1
+            return {
+                "segments": assessments,
+                "segment_counts": counts,
+                "method": method,
+                "engine": "deterministic_rfm",
+            }
+
+        return {
+            "segments": [],
+            "note": "No ML module and no customer data provided.",
+            "method": method,
+        }
 
     async def analyze_ab_test(
         self, experiment_id: str, confidence_level: float = 0.95

--- a/agents/core/sub_agent.py
+++ b/agents/core/sub_agent.py
@@ -27,6 +27,7 @@ from abc import abstractmethod
 from typing import Any
 
 from agents.errors import AgentError, ErrorCategory
+from core.token_tracker import current_agent_id
 
 from .base import CoreAgentType, SelfHealingMixin
 
@@ -154,7 +155,13 @@ class SubAgent(SelfHealingMixin):
             correlation_id=self.correlation_id,
         )
 
-        response = await client.complete(request)
+        # Attribute the LLM call to this agent so the router-level telemetry emitter
+        # (core.token_tracker.record_llm_usage) buckets usage under self.name.
+        token = current_agent_id.set(self.name)
+        try:
+            response = await client.complete(request)
+        finally:
+            current_agent_id.reset(token)
 
         return {
             "success": True,

--- a/agents/skyyrose_content_agent.py
+++ b/agents/skyyrose_content_agent.py
@@ -527,6 +527,9 @@ SEO Rules:
         # Parse structured response
         content = self._parse_gemini_response(response, request)
 
+        # Brand-copy quality gate — soft-signal, opt-in via COPY_EVAL_ENABLED. Never blocks.
+        content = await self._maybe_eval_copy(content, request)
+
         # Record for learning
         self._record_generation(content, request, response)
 
@@ -535,6 +538,71 @@ SEO Rules:
             f"[tokens={content.gemini_tokens_used}]"
         )
 
+        return content
+
+    def _build_copy_brief(self, content: GeneratedContent, request: ContentRequest) -> Any:
+        """Assemble the CopyBrief the evaluator scores against (pure field mapping)."""
+        from evaluation.domains.copy import CopyBrief
+
+        return CopyBrief(
+            collection=content.collection.value if content.collection else None,
+            content_type=request.content_type.value,
+            product_name=request.title or None,
+            brand_voice_context=(self._brand_dna.to_prompt_context() if self._brand_dna else ""),
+            additional_direction=request.additional_direction or "",
+        )
+
+    async def _maybe_eval_copy(
+        self,
+        content: GeneratedContent,
+        request: ContentRequest,
+        *,
+        evaluator: Any = None,
+    ) -> GeneratedContent:
+        """Soft-signal brand-copy quality gate.
+
+        Opt-in via the COPY_EVAL_ENABLED env flag. When enabled, scores the generated
+        body against brand canon with the Claude copy judge and records the verdict in
+        ``content.metadata['copy_eval']``. It NEVER blocks — failing copy is returned
+        unchanged (the judge is uncalibrated; promote to a hard gate only after a
+        calibration run, per evaluation.calibration.decide_mode). ``evaluator`` is a
+        dependency-injection seam for tests; production builds the real judge lazily.
+        """
+        if not os.getenv("COPY_EVAL_ENABLED"):
+            return content
+        if evaluator is None:
+            from evaluation.agents import CopyEvaluator
+            from evaluation.judge import ClaudeJudge, make_client
+
+            judge = ClaudeJudge(client=make_client(), model="claude-sonnet-4-6")
+            evaluator = CopyEvaluator(judge_fn=lambda req: judge.run(**req))
+
+        try:
+            brief = self._build_copy_brief(content, request)
+            verdict = await evaluator.evaluate(subject=content.body_html, ref=brief)
+            logger.info(
+                "%s: copy_eval passed=%s score=%.2f cost=$%.4f tags=%s",
+                self.AGENT_NAME,
+                verdict.passed,
+                verdict.score,
+                verdict.cost_usd,
+                list(verdict.failure_tags),
+            )
+            content.metadata["copy_eval"] = {
+                "passed": verdict.passed,
+                "score": verdict.score,
+                "failure_tags": list(verdict.failure_tags),
+                "reason": verdict.reason,
+                "cost_usd": verdict.cost_usd,
+            }
+        except Exception as exc:  # noqa: BLE001 — advisory gate must never block generation
+            logger.warning(
+                "%s: copy_eval skipped — evaluator raised %s: %s",
+                self.AGENT_NAME,
+                type(exc).__name__,
+                exc,
+            )
+            content.metadata["copy_eval"] = {"error": f"{type(exc).__name__}: {exc}"}
         return content
 
     def _build_generation_messages(self, request: ContentRequest) -> list[Message]:

--- a/core/token_tracker.py
+++ b/core/token_tracker.py
@@ -14,6 +14,7 @@ Integrates with all providers: OpenAI, Anthropic, Google, Mistral, Cohere, Groq.
 
 from __future__ import annotations
 
+import contextvars
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -86,7 +87,7 @@ class TokenUsage:
     def calculate_cost(self) -> float:
         """Calculate USD cost for this usage."""
         if self.model not in PROVIDER_COSTS:
-            logger.warning(f"Unknown model cost: {self.model}")
+            logger.warning("unknown_model_cost", model=self.model)
             return 0.0
 
         costs = PROVIDER_COSTS[self.model]
@@ -288,6 +289,17 @@ class TokenTracker:
 
         return by_agent
 
+    def records(self, since: datetime | None = None) -> list[TokenUsage]:
+        """Return a snapshot copy of recorded usages, optionally filtered by time.
+
+        A copy is returned so consumers (e.g. the fleet observer) can iterate without
+        racing concurrent ``record()`` appends — the backing list is not locked. Use
+        this instead of touching ``_usages`` directly.
+        """
+        if since is None:
+            return list(self._usages)
+        return [u for u in self._usages if u.timestamp >= since]
+
     def clear(self) -> None:
         """Clear all tracked usage (useful for testing)."""
         self._usages.clear()
@@ -304,3 +316,50 @@ def get_token_tracker() -> TokenTracker:
     if _global_tracker is None:
         _global_tracker = TokenTracker()
     return _global_tracker
+
+
+# Per-agent attribution for telemetry across the async call chain. An agent sets this
+# before dispatching an LLM call; the LLM-router emitter reads it when recording usage.
+# ContextVars are task-local, so concurrent agents attribute correctly.
+current_agent_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "current_agent_id", default=None
+)
+
+
+def record_llm_usage(
+    *,
+    provider: str,
+    model: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    total_tokens: int = 0,
+    latency_ms: float = 0.0,
+    success: bool = True,
+    error: str | None = None,
+    task_type: TaskType = TaskType.CHAT,
+    agent_id: str | None = None,
+    correlation_id: str | None = None,
+) -> None:
+    """Record one LLM call into the global tracker, attributed to the current agent.
+
+    ``agent_id`` falls back to the ``current_agent_id`` ContextVar (set by the dispatching
+    agent) when not given. NEVER raises — telemetry must not break the LLM call path.
+    """
+    try:
+        get_token_tracker().record(
+            TokenUsage(
+                provider=provider,
+                model=model,
+                task_type=task_type,
+                agent_id=agent_id if agent_id is not None else current_agent_id.get(),
+                correlation_id=correlation_id,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=total_tokens,
+                latency_ms=latency_ms,
+                success=success,
+                error=error,
+            )
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break the call path
+        logger.warning("record_llm_usage_failed", exc_info=True)

--- a/evaluation/agents.py
+++ b/evaluation/agents.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
+from evaluation.contracts import Verdict
 from evaluation.core import EvaluationCore, JudgeFn
+from evaluation.domains.copy import CopyAdapter
 from evaluation.domains.imagery import ImageryAdapter
 
 
@@ -17,8 +20,31 @@ class RenderFidelityEvaluator:
         self._core = EvaluationCore(judge_fn=judge_fn)
         self._adapter = adapter or ImageryAdapter()
 
-    async def evaluate(self, subject: bytes, ref: Any) -> Any:
+    async def evaluate(self, subject: bytes, ref: Any) -> Verdict:
         return await self._core.score(self._adapter, subject, ref)
 
     def adapter(self) -> ImageryAdapter:
+        return self._adapter
+
+
+class CopyEvaluator:
+    """Copy domain: does generated copy hold the SkyyRose brand line?"""
+
+    job_title = "Brand Copy Evaluator"
+
+    def __init__(self, judge_fn: JudgeFn, adapter: CopyAdapter | None = None) -> None:
+        self._core = EvaluationCore(judge_fn=judge_fn)
+        self._adapter = adapter or CopyAdapter()
+
+    async def evaluate(self, subject: str, ref: Any) -> Verdict:
+        """Single-shot score (deterministic gate -> judge -> verdict)."""
+        return await self._core.score(self._adapter, subject, ref)
+
+    async def gate(
+        self, ref: Any, producer: Callable[[Any], Awaitable[Any]], cap: int = 2
+    ) -> Verdict:
+        """Score-and-revise loop: re-call the producer up to `cap` times on failure."""
+        return await self._core.gate(self._adapter, ref, producer, cap)
+
+    def adapter(self) -> CopyAdapter:
         return self._adapter

--- a/evaluation/domains/copy.py
+++ b/evaluation/domains/copy.py
@@ -1,0 +1,271 @@
+"""Brand Copy Evaluator — copy/content domain adapter.
+
+Scores SkyyRose product/collection/marketing copy against brand canon via forced
+tool-use (text-only Claude judge — no vision). Mirrors the imagery adapter's shape:
+a module-level TOOL dict with a leading chain-of-thought field, fail-closed parsing,
+and deterministic free pre-checks. Subject = copy text (str); ref = CopyBrief.
+
+The revise loop (content's differentiator over imagery) is wired via a `regenerate_fn`
+injected at construction — the same dependency-injection seam EvaluationCore uses for
+`judge_fn`. This keeps the adapter import-free from agents/ (no circular dependency).
+
+Rubric dimensions and the hard-fail vocabulary trace to brand canon — see
+memory/feedback_collection_canon_attribution.md, memory/project_founder_voice.md,
+memory/feedback_product_naming.md, memory/project_brand.md, and docs/brand/.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from evaluation.contracts import Verdict
+
+# Weighted-composite floor. Matches the imagery stage_g QA gate (24/30 = 0.80).
+# Advisory in soft_signal mode; promote to a hard gate only after calibration
+# (calibration.decide_mode requires kappa >= 0.65 against labeled ground truth).
+_PASS_THRESHOLD = 0.80
+
+# Dimension order MUST match the COPY_TOOL required list (minus the non-scored fields).
+_DIMENSIONS: tuple[str, ...] = (
+    "brand_voice_fidelity",
+    "correct_collection_canon",
+    "garment_as_protagonist",
+    "no_urgency_theatre",
+    "no_related_products_push",
+    "name_not_sku_referencing",
+    "canonical_tagline_only",
+    "oakland_anchoring",
+)
+
+# Canon-traced relative priorities (sum to 1.0). Founder-tunable — advisory in v1.
+_WEIGHTS: dict[str, float] = {
+    "brand_voice_fidelity": 0.20,
+    "correct_collection_canon": 0.20,
+    "garment_as_protagonist": 0.15,
+    "no_urgency_theatre": 0.10,
+    "no_related_products_push": 0.10,
+    "name_not_sku_referencing": 0.10,
+    "canonical_tagline_only": 0.10,
+    "oakland_anchoring": 0.05,
+}
+
+# Any of these tags (deterministic or judge-emitted) fails the verdict regardless of score.
+_HARD_FAIL_TAGS: frozenset[str] = frozenset(
+    {
+        "wrong_collection_canon",
+        "retired_tagline_present",
+        "urgency_timer_present",
+        "related_products_push",
+        "sku_first_naming",
+        "cross_collection_quote_mix",
+        "tagline_misuse",
+        "gendered_language",
+        "blue_in_palette_reference",
+        "european_luxury_lineage_reference",
+        "locked_out_visual_reference",
+        "love_hurts_quote_on_black_rose",
+        "black_rose_quote_on_love_hurts",
+    }
+)
+
+# Deterministic free pre-checks (str/regex only — never call the LLM).
+_RETIRED_RE = re.compile(r"where love meets luxury", re.IGNORECASE)
+# SKU tokens (br-001 etc.). Allowed ONLY as a parenthetical backend key right after the
+# name — i.e. the nearest non-space char before the token is "(" (see _uses_sku_as_handle).
+_SKU_TOKEN_RE = re.compile(r"\b(?:br|lh|sg|kc)-\d{3}\b", re.IGNORECASE)
+_URGENCY_RES = [
+    re.compile(r"\bcountdown\b", re.IGNORECASE),
+    re.compile(r"only\s+\d+\s+left", re.IGNORECASE),
+    re.compile(r"selling\s+fast", re.IGNORECASE),
+    re.compile(r"limited[\s-]time", re.IGNORECASE),
+    re.compile(r"buy\s+before", re.IGNORECASE),
+    re.compile(r"\bhurry\b", re.IGNORECASE),
+    re.compile(r"ends\s+(?:tonight|soon|today)", re.IGNORECASE),
+]
+_RELATED_RES = [
+    re.compile(r"you\s+m(?:ay|ight)\s+also\s+like", re.IGNORECASE),
+    re.compile(r"customers\s+also\s+bought", re.IGNORECASE),
+    re.compile(r"\brelated\s+products", re.IGNORECASE),
+    re.compile(r"frequently\s+bought\s+together", re.IGNORECASE),
+]
+
+_RUBRIC_PROMPT = (
+    "Score each dimension 0-5 (5 = fully on-brand). First fill brand_analysis: quote 2-3 "
+    "specific phrases from the copy and note cadence (declarative vs hedging), urgency "
+    "markers, collection attribution, and product/SKU naming.\n"
+    "Dimensions:\n"
+    "- brand_voice_fidelity: declarative founder register, no hedging/apology/mood-board generic.\n"
+    "- correct_collection_canon: collection-locked quotes/taglines stay on their own collection "
+    "(Love Hurts lines never on Black Rose, etc.).\n"
+    "- garment_as_protagonist: the piece is the subject (material/construction/motif), not a "
+    "lifestyle prop ('perfect for the weekend').\n"
+    "- no_urgency_theatre: no countdowns, scarcity nudges, or FOMO CTAs.\n"
+    "- no_related_products_push: no 'you may also like' / 'customers also bought' framing.\n"
+    "- name_not_sku_referencing: products named in full, never by SKU handle.\n"
+    "- canonical_tagline_only: only 'Luxury Grows from Concrete.'; never 'Where Love Meets Luxury'.\n"
+    "- oakland_anchoring: Oakland-first vocabulary ('The Town', 'frisco'), never glossed; "
+    "'Bay Area' in supporting copy is acceptable.\n"
+    "Emit failure_tags from the approved vocabulary for any canon violation; empty if clean."
+)
+
+COPY_TOOL: dict[str, object] = {
+    "name": "copy_qc_verdict",
+    "description": "Score the candidate copy against the SkyyRose brand brief.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "brand_analysis": {
+                "type": "string",
+                "description": "FIRST: quote 2-3 phrases from the copy and note cadence, urgency "
+                "markers, collection attribution, and product/SKU naming BEFORE scoring.",
+            },
+            "brand_voice_fidelity": {"type": "integer", "minimum": 0, "maximum": 5},
+            "correct_collection_canon": {"type": "integer", "minimum": 0, "maximum": 5},
+            "garment_as_protagonist": {"type": "integer", "minimum": 0, "maximum": 5},
+            "no_urgency_theatre": {"type": "integer", "minimum": 0, "maximum": 5},
+            "no_related_products_push": {"type": "integer", "minimum": 0, "maximum": 5},
+            "name_not_sku_referencing": {"type": "integer", "minimum": 0, "maximum": 5},
+            "canonical_tagline_only": {"type": "integer", "minimum": 0, "maximum": 5},
+            "oakland_anchoring": {"type": "integer", "minimum": 0, "maximum": 5},
+            "failure_tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Zero or more tags describing why the copy fails; empty if clean.",
+            },
+            "reason": {"type": "string"},
+        },
+        "required": ["brand_analysis", *(_DIMENSIONS), "failure_tags", "reason"],
+        "additionalProperties": False,
+    },
+}
+
+
+@dataclass(frozen=True)
+class CopyBrief:
+    """Reference brief for a copy evaluation — the data available at the agent seam."""
+
+    collection: str | None
+    content_type: str
+    product_name: str | None
+    brand_voice_context: str = ""
+    additional_direction: str = ""
+
+
+def _clamp_score(value: object) -> int:
+    """Coerce a judge dimension value to an int in [0, 5]; missing/None/garbage -> 0."""
+    try:
+        n = int(value)  # type: ignore[arg-type]  # handles 5, "5", 5.0
+    except (TypeError, ValueError):
+        return 0
+    return max(0, min(5, n))
+
+
+def _uses_sku_as_handle(text: str) -> bool:
+    """True if any SKU token is used as a primary handle (not a parenthetical key).
+
+    A SKU is permitted only as a backend key right after the name, e.g. "Crewneck (br-001)"
+    or "( br-001 )" — i.e. the nearest non-space character before the token is "(".
+    """
+    for match in _SKU_TOKEN_RE.finditer(text):
+        if not text[: match.start()].rstrip().endswith("("):
+            return True
+    return False
+
+
+class CopyAdapter:
+    domain = "copy"
+
+    def __init__(
+        self,
+        regenerate_fn: Callable[[CopyBrief, dict], Awaitable[str]] | None = None,
+        review_state_path: Path | None = None,
+    ) -> None:
+        self._regenerate_fn = regenerate_fn
+        self._review_state = (
+            Path(review_state_path)
+            if review_state_path
+            else (Path(__file__).parent / "copy-review-state.json")
+        )
+
+    def deterministic_checks(self, subject: str, ref: CopyBrief) -> list[str]:
+        text = subject or ""
+        tags: list[str] = []
+        if _RETIRED_RE.search(text):
+            tags.append("retired_tagline_present")
+        if _uses_sku_as_handle(text):
+            tags.append("sku_first_naming")
+        if any(p.search(text) for p in _URGENCY_RES):
+            tags.append("urgency_timer_present")
+        if any(p.search(text) for p in _RELATED_RES):
+            tags.append("related_products_push")
+        return tags
+
+    def build_judge_request(self, subject: str, ref: CopyBrief) -> dict:
+        brief_lines = [
+            "You are a SkyyRose brand-copy evaluator. Score the candidate copy against the brief.",
+            f"Collection: {ref.collection or 'brand-wide (no single collection)'}",
+            f"Content type: {ref.content_type}",
+            f"Product: {ref.product_name or 'n/a'}",
+        ]
+        if ref.brand_voice_context:
+            brief_lines.append(f"Brand voice: {ref.brand_voice_context}")
+        if ref.additional_direction:
+            brief_lines.append(f"Direction: {ref.additional_direction}")
+        prompt = (
+            "\n".join(brief_lines)
+            + "\n\n"
+            + _RUBRIC_PROMPT
+            + "\n\nCandidate copy to evaluate:\n"
+            + (subject or "")
+        )
+        return {
+            "messages": [{"role": "user", "content": [{"type": "text", "text": prompt}]}],
+            "tool": COPY_TOOL,
+        }
+
+    def parse_verdict(self, judge_output: dict, det_failures: list[str]) -> Verdict:
+        raw = {d: _clamp_score(judge_output.get(d)) for d in _DIMENSIONS}
+        judge_tags = tuple(str(t) for t in (judge_output.get("failure_tags") or ()) if t)
+        all_tags = tuple(det_failures) + judge_tags
+        hard_fail = any(t in _HARD_FAIL_TAGS for t in all_tags)
+        composite = sum(_WEIGHTS[d] * raw[d] for d in _DIMENSIONS) / 5.0
+        passed = composite >= _PASS_THRESHOLD and not hard_fail
+        return Verdict(
+            domain="copy",
+            passed=passed,
+            score=composite,
+            gate_results=dict(raw),
+            failure_tags=all_tags,
+            reason=str(judge_output.get("reason", ""))[:300],
+            detail={"brand_analysis": judge_output.get("brand_analysis", "")},
+        )
+
+    async def revise(self, ref: CopyBrief, critique: dict) -> str:
+        if self._regenerate_fn is None:
+            raise NotImplementedError(
+                "CopyAdapter.revise requires a regenerate_fn injected at construction"
+            )
+        return await self._regenerate_fn(ref, critique)
+
+    def load_ground_truth(self) -> list[dict]:
+        if not self._review_state.exists():
+            return []
+        state = json.loads(self._review_state.read_text(encoding="utf-8"))
+        out: list[dict] = []
+        for subject_id, entry in state.items():
+            label_pass = bool(entry.get("approved")) and not bool(entry.get("flagged"))
+            out.append(
+                {
+                    "subject_id": subject_id,
+                    "label_pass": label_pass,
+                    "comment": entry.get("comment", ""),
+                }
+            )
+        return out
+
+
+__all__ = ["COPY_TOOL", "CopyAdapter", "CopyBrief"]

--- a/llm/router.py
+++ b/llm/router.py
@@ -21,6 +21,7 @@ from enum import StrEnum
 from typing import Any
 
 from core.telemetry.tracer import get_tracer
+from core.token_tracker import record_llm_usage
 
 from .base import BaseLLMClient, CompletionResponse, Message, ModelProvider
 from .exceptions import LLMError
@@ -390,6 +391,12 @@ class LLMRouter:
 
         # Enterprise hardening: Check circuit breaker before attempting
         if not self.circuit_breaker.is_available(provider):
+            record_llm_usage(
+                provider=provider.value,
+                model=model or self.configs[provider].default_model,
+                success=False,
+                error="circuit_breaker_open",
+            )
             raise LLMError(
                 f"Provider {provider.value} temporarily unavailable (circuit breaker OPEN)",
                 details={"circuit_breaker_state": self.circuit_breaker.get_status()},
@@ -411,11 +418,26 @@ class LLMRouter:
                 span.set_attribute("llm.input_tokens", response.input_tokens)
                 span.set_attribute("llm.output_tokens", response.output_tokens)
                 span.set_attribute("llm.latency_ms", response.latency_ms)
+                record_llm_usage(
+                    provider=provider.value,
+                    model=response.model,
+                    input_tokens=response.input_tokens,
+                    output_tokens=response.output_tokens,
+                    total_tokens=response.total_tokens,
+                    latency_ms=response.latency_ms,
+                    success=True,
+                )
                 return response
             except Exception as e:
                 # Record failure
                 self.circuit_breaker.record_failure(provider)
                 span.record_exception(e)
+                record_llm_usage(
+                    provider=provider.value,
+                    model=model,
+                    success=False,
+                    error=str(e),
+                )
                 raise
 
     async def complete_with_fallback(

--- a/mcp_tools/tools/resources.py
+++ b/mcp_tools/tools/resources.py
@@ -143,12 +143,17 @@ async def health_check(response_format: ResponseFormat = ResponseFormat.MARKDOWN
         "correlation_tracking": "enabled",
     }
 
-    # MCP Server Info
+    # MCP Server Info. Count tools dynamically from the registry so the value can never
+    # drift out of sync with the actual @mcp.tool registrations (it repeatedly did).
+    try:
+        total_tools = len(mcp._tool_manager.list_tools())
+    except Exception:  # registry shape changed — degrade gracefully rather than crash health
+        total_tools = len(getattr(getattr(mcp, "_tool_manager", None), "_tools", {}) or {})
     health_data["mcp_server"] = {
         "backend": MCP_BACKEND,
         "api_base_url": API_BASE_URL,
         "request_timeout": REQUEST_TIMEOUT,
-        "total_tools": 22,  # 21 + health_check
+        "total_tools": total_tools,
     }
 
     # Overall Health Status
@@ -159,3 +164,257 @@ async def health_check(response_format: ResponseFormat = ResponseFormat.MARKDOWN
     health_data["timestamp"] = time.time()
 
     return _format_response(health_data, response_format, "DevSkyy System Health Check")
+
+
+@mcp.tool(
+    name="devskyy_fleet_health",
+    annotations={
+        "title": "DevSkyy Fleet Health",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,  # Internal diagnostic tool
+        "defer_loading": False,  # Always available for monitoring
+    },
+)
+@secure_tool("fleet_health")
+async def fleet_health(window_seconds: int = 3600) -> str:
+    """Per-agent LLM fleet health and alerts from in-process telemetry.
+
+    Reads the token tracker (core.token_tracker) and reports, over the look-back window,
+    fleet cost/requests plus any alerts: budget overrun, per-agent cost overrun, error
+    rate, p95 latency, consecutive failures (retry-storm proxy), and stale/dead agents.
+
+    Read-only and advisory — it never restarts an agent or mutates any state.
+
+    Args:
+        window_seconds: Look-back window for every check (default 3600 = 1 hour).
+
+    Returns:
+        str: Markdown fleet-health report.
+    """
+    from monitoring.fleet_observer import FleetObserver, format_health_report
+
+    report = FleetObserver(window_seconds=window_seconds).evaluate()
+    return format_health_report(report)
+
+
+@mcp.tool(
+    name="devskyy_fraud_assess",
+    annotations={
+        "title": "DevSkyy Fraud Risk Assessment",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,  # Pure local scoring — no external calls
+        "defer_loading": False,
+    },
+)
+@secure_tool("fraud_assess")
+async def fraud_assess(order_json: str, history_json: str = "") -> str:
+    """Score an order's fraud / chargeback risk from deterministic signals (advisory only).
+
+    Reads industry-standard chargeback predictors — AVS/CVV mismatch, billing↔shipping
+    country mismatch, order velocity, disposable email, new-customer high-value, recipient-
+    name mismatch — and returns a 0-100 score, a risk level, and a recommended action
+    ("approve" / "review" / "hold").
+
+    This is READ-ONLY and ADVISORY. It never cancels, refunds, or writes to WooCommerce —
+    a human (or a STOP-AND-SHOW gated action) acts on the recommendation.
+
+    Args:
+        order_json: A JSON object for the order (WooCommerce order shape: billing, shipping,
+            total, customer_id, customer_ip_address, date_created, optional avs_result /
+            cvv_result / meta_data).
+        history_json: Optional JSON array of the customer's prior orders, used for velocity
+            checks. Empty string disables velocity scoring.
+
+    Returns:
+        str: Markdown risk report followed by a compact JSON line for programmatic callers.
+    """
+    import json
+
+    from services.risk.fraud import FraudScorer, format_assessment
+
+    if len(order_json) > 1_000_000 or len(history_json) > 5_000_000:
+        return "Payload too large — order_json must be <1MB and history_json <5MB."
+
+    try:
+        order = json.loads(order_json) if order_json else {}
+    except (json.JSONDecodeError, TypeError):
+        return "Could not parse order_json — expected a JSON object."
+
+    history = None
+    if history_json:
+        try:
+            parsed = json.loads(history_json)
+            history = parsed if isinstance(parsed, list) else None
+        except (json.JSONDecodeError, TypeError):
+            history = None
+
+    assessment = FraudScorer().assess(order if isinstance(order, dict) else {}, history=history)
+    return f"{format_assessment(assessment)}\n\n```json\n{json.dumps(assessment.as_dict())}\n```"
+
+
+@mcp.tool(
+    name="devskyy_retention_assess",
+    annotations={
+        "title": "DevSkyy Retention / Lifecycle Assessment",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,  # Pure local scoring — no external calls
+        "defer_loading": False,
+    },
+)
+@secure_tool("retention_assess")
+async def retention_assess(customer_json: str, as_of: str = "") -> str:
+    """Score a customer's RFM, lifecycle stage, and churn risk (advisory only).
+
+    Computes Recency / Frequency / Monetary from the customer's order history, assigns a
+    lifecycle stage (NEW / ACTIVE / LOYAL / AT_RISK / DORMANT / CHURNED), a 0-100 churn-risk
+    score, a recommended next action, and a SUGGESTED Klaviyo segment to enroll into.
+
+    This is READ-ONLY and ADVISORY. It NEVER calls the Klaviyo API or enrolls anyone — a
+    human (or a STOP-AND-SHOW gated action) performs the actual send.
+
+    Args:
+        customer_json: A JSON object for the customer. Either ``{"orders": [{"date_created",
+            "total"}, ...]}`` or precomputed ``{"last_order_date", "order_count",
+            "total_spent"}``. May include ``id``.
+        as_of: Optional ISO-8601 timestamp to score against (default: now). Pass it for
+            reproducible scoring.
+
+    Returns:
+        str: Markdown lifecycle report followed by a compact JSON line.
+    """
+    import json
+    from datetime import datetime
+
+    from services.lifecycle.retention import RetentionScorer, format_assessment
+
+    if len(customer_json) > 5_000_000:
+        return "Payload too large — customer_json must be <5MB."
+
+    try:
+        customer = json.loads(customer_json) if customer_json else {}
+    except (json.JSONDecodeError, TypeError):
+        return "Could not parse customer_json — expected a JSON object."
+
+    when = None
+    if as_of:
+        try:
+            when = datetime.fromisoformat(as_of.strip().replace("Z", "+00:00"))
+        except ValueError:
+            when = None
+
+    assessment = RetentionScorer().assess(
+        customer if isinstance(customer, dict) else {}, as_of=when
+    )
+    return f"{format_assessment(assessment)}\n\n```json\n{json.dumps(assessment.as_dict())}\n```"
+
+
+@mcp.tool(
+    name="devskyy_demand_forecast",
+    annotations={
+        "title": "DevSkyy Demand / Sellout Forecast",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,  # Pure local scoring — no external calls
+        "defer_loading": False,
+    },
+)
+@secure_tool("demand_forecast")
+async def demand_forecast(product_json: str, horizon_days: int = 30) -> str:
+    """Forecast a product's demand velocity, trend, and sellout risk (advisory only).
+
+    Computes units/day over a trailing window, the trend vs the prior window
+    (ACCELERATING / STEADY / DECLINING), days-to-sellout against inventory, and a reorder
+    recommendation. The key signal for SkyyRose's pre-order / limited-run drops: will this
+    sell out before production lead time?
+
+    READ-ONLY and ADVISORY — it never changes inventory or places a reorder.
+
+    Args:
+        product_json: A JSON object: ``{"sku", "sales": [{"date", "units"}, ...],
+            "inventory" (or "stock_quantity"), "is_preorder"}``.
+        horizon_days: Projection horizon for the unit forecast (default 30).
+
+    Returns:
+        str: Markdown forecast followed by a compact JSON line.
+    """
+    import json
+
+    from services.forecasting.demand import DemandForecaster, format_forecast
+
+    if len(product_json) > 5_000_000:
+        return "Payload too large — product_json must be <5MB."
+
+    try:
+        product = json.loads(product_json) if product_json else {}
+    except (json.JSONDecodeError, TypeError):
+        return "Could not parse product_json — expected a JSON object."
+
+    forecast = DemandForecaster().forecast(product if isinstance(product, dict) else {})
+    payload = forecast.as_dict()
+    payload["forecast_units_horizon"] = forecast.forecast_units(horizon_days)
+    return f"{format_forecast(forecast)}\n\n```json\n{json.dumps(payload)}\n```"
+
+
+@mcp.tool(
+    name="devskyy_recommend",
+    annotations={
+        "title": "DevSkyy Per-User Recommendations",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,  # Pure local scoring — no external calls
+        "defer_loading": False,
+    },
+)
+@secure_tool("recommend")
+async def recommend(user_json: str, catalog_json: str, top_n: int = 10) -> str:
+    """Rank the catalog for one user (content-based + co-purchase, advisory only).
+
+    Personalizes ordering by the user's purchase profile (collection affinity, shared tags,
+    price tier) and optional co-purchase data, falling back to global popularity for
+    cold-start users. READ-ONLY — it suggests an order, it changes nothing.
+
+    Args:
+        user_json: A JSON object: ``{"id", "purchased": [item_id | {"id"/"sku", ...}, ...]}``.
+        catalog_json: A JSON array of product dicts: ``{"id"/"sku", "collection", "price",
+            "tags", "popularity"}``. May include a top-level ``co_purchase`` map if wrapped as
+            ``{"catalog": [...], "co_purchase": {...}}``.
+        top_n: Number of recommendations to return (default 10).
+
+    Returns:
+        str: Markdown recommendation table followed by a compact JSON line.
+    """
+    import json
+
+    from services.personalization.recommender import Recommender, format_recommendations
+
+    if len(user_json) > 1_000_000 or len(catalog_json) > 10_000_000:
+        return "Payload too large — user_json <1MB, catalog_json <10MB."
+
+    try:
+        user = json.loads(user_json) if user_json else {}
+        parsed = json.loads(catalog_json) if catalog_json else []
+    except (json.JSONDecodeError, TypeError):
+        return "Could not parse user_json/catalog_json."
+
+    co_purchase = None
+    if isinstance(parsed, dict):
+        catalog = parsed.get("catalog", [])
+        cp = parsed.get("co_purchase")
+        co_purchase = cp if isinstance(cp, dict) else None
+    else:
+        catalog = parsed
+
+    rs = Recommender(top_n=max(1, top_n)).recommend(
+        user if isinstance(user, dict) else {},
+        catalog if isinstance(catalog, list) else [],
+        co_purchase=co_purchase,
+    )
+    return f"{format_recommendations(rs)}\n\n```json\n{json.dumps(rs.as_dict())}\n```"

--- a/monitoring/fleet_observer.py
+++ b/monitoring/fleet_observer.py
@@ -1,0 +1,244 @@
+"""Fleet-health observability consumer.
+
+Closes the observability gap: core/token_tracker.py records per-agent LLM telemetry but had
+zero consumers. FleetObserver reads that telemetry over a look-back window and emits alerts
+when an agent or the fleet breaches a threshold.
+
+ALERT + RECOMMEND ONLY. evaluate() is pure-read: it never restarts an agent, clears the
+tracker, or calls any write API. Callers (an MCP tool, a cron) surface the report; all
+remediation is human-initiated. Mirrors evaluation/observer.py's philosophy.
+
+AlertSeverity is a local copy of evaluation.contracts.Severity (identical values) on purpose:
+monitoring/ must not depend on the evaluation/ (QC) package — that would invert the dependency
+direction and risk circular imports. Four lines is cheaper than a coupling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import IntEnum
+
+from core.token_tracker import TokenUsage, get_token_tracker
+
+
+class AlertSeverity(IntEnum):
+    """Alert routing: DASHBOARD (info), TICKET (actionable), PAGE (blocking)."""
+
+    DASHBOARD = 1
+    TICKET = 2
+    PAGE = 3
+
+
+@dataclass(frozen=True)
+class FleetAlert:
+    rule: str
+    agent_id: str | None  # None = fleet-wide
+    severity: AlertSeverity
+    message: str
+    value: float
+    threshold: float
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    snapshot_at: datetime
+    window_seconds: int
+    alerts: tuple[FleetAlert, ...]
+    per_agent: dict[str, dict]
+    fleet_cost_usd: float
+    fleet_requests: int
+
+
+def _p95(values: list[float]) -> float:
+    """95th percentile via nearest-rank (floor-biased for small N — fine for alerting)."""
+    ordered = sorted(values)
+    idx = min(int(0.95 * len(ordered)), len(ordered) - 1)
+    return ordered[idx]
+
+
+def _max_consecutive_failures(recs: list[TokenUsage]) -> int:
+    """Longest run of consecutive failed calls, ordered by timestamp (retry-storm proxy)."""
+    streak = best = 0
+    for usage in sorted(recs, key=lambda u: u.timestamp):
+        if usage.success:
+            streak = 0
+        else:
+            streak += 1
+            best = max(best, streak)
+    return best
+
+
+class FleetObserver:
+    """Reads the token tracker and reports fleet/agent health alerts (read-only)."""
+
+    def __init__(
+        self,
+        *,
+        budget_usd: float = 10.0,  # fleet-wide cost cap per window
+        cost_per_agent_usd: float = 2.0,  # per-agent cost cap per window
+        error_rate_pct: float = 10.0,  # % of an agent's calls that failed
+        p95_latency_ms: float = 5000.0,  # p95 latency gate
+        stale_agent_secs: int = 300,  # no activity for N seconds
+        consecutive_failures: int = 3,  # retry-storm proxy
+        window_seconds: int = 3600,  # look-back window for every check
+    ) -> None:
+        self.budget_usd = budget_usd
+        self.cost_per_agent_usd = cost_per_agent_usd
+        self.error_rate_pct = error_rate_pct
+        self.p95_latency_ms = p95_latency_ms
+        self.stale_agent_secs = stale_agent_secs
+        self.consecutive_failures = consecutive_failures
+        self.window_seconds = window_seconds
+
+    def evaluate(self) -> HealthReport:
+        tracker = get_token_tracker()
+        now = datetime.now(UTC)
+        since = now - timedelta(seconds=self.window_seconds)
+
+        by_agent = tracker.get_usage_by_agent(since=since)
+        fleet_cost = tracker.get_total_cost(since=since)
+        fleet_requests = sum(agg["requests"] for agg in by_agent.values())
+
+        records_by_agent: dict[str, list[TokenUsage]] = {}
+        for usage in tracker.records(since=since):
+            records_by_agent.setdefault(usage.agent_id or "unknown", []).append(usage)
+
+        alerts: list[FleetAlert] = []
+        if fleet_cost > self.budget_usd:
+            alerts.append(
+                FleetAlert(
+                    rule="budget_overrun",
+                    agent_id=None,
+                    severity=AlertSeverity.TICKET,
+                    message=f"Fleet cost ${fleet_cost:.4f} exceeds ${self.budget_usd:.4f}",
+                    value=fleet_cost,
+                    threshold=self.budget_usd,
+                )
+            )
+        for agent_id, agg in by_agent.items():
+            alerts.extend(
+                self._agent_alerts(agent_id, agg, records_by_agent.get(agent_id, []), now)
+            )
+
+        return HealthReport(
+            snapshot_at=now,
+            window_seconds=self.window_seconds,
+            alerts=tuple(alerts),
+            per_agent=dict(by_agent),
+            fleet_cost_usd=fleet_cost,
+            fleet_requests=fleet_requests,
+        )
+
+    def _agent_alerts(
+        self, agent_id: str, agg: dict, recs: list[TokenUsage], now: datetime
+    ) -> list[FleetAlert]:
+        alerts: list[FleetAlert] = []
+
+        if agg["cost_usd"] > self.cost_per_agent_usd:
+            alerts.append(
+                FleetAlert(
+                    "agent_cost_overrun",
+                    agent_id,
+                    AlertSeverity.TICKET,
+                    f"{agent_id} cost ${agg['cost_usd']:.4f} exceeds "
+                    f"${self.cost_per_agent_usd:.4f}",
+                    agg["cost_usd"],
+                    self.cost_per_agent_usd,
+                )
+            )
+
+        if not recs:
+            return alerts
+
+        errors = sum(1 for u in recs if not u.success)
+        rate = 100.0 * errors / len(recs)
+        if rate > self.error_rate_pct:
+            alerts.append(
+                FleetAlert(
+                    "error_rate",
+                    agent_id,
+                    AlertSeverity.PAGE if rate > 50.0 else AlertSeverity.TICKET,
+                    f"{agent_id} error rate {rate:.1f}% exceeds {self.error_rate_pct:.1f}%",
+                    rate,
+                    self.error_rate_pct,
+                )
+            )
+
+        p95 = _p95([u.latency_ms for u in recs])
+        if p95 > self.p95_latency_ms:
+            alerts.append(
+                FleetAlert(
+                    "p95_latency",
+                    agent_id,
+                    AlertSeverity.TICKET,
+                    f"{agent_id} p95 latency {p95:.0f}ms exceeds {self.p95_latency_ms:.0f}ms",
+                    p95,
+                    self.p95_latency_ms,
+                )
+            )
+
+        streak = _max_consecutive_failures(recs)
+        if streak >= self.consecutive_failures:
+            alerts.append(
+                FleetAlert(
+                    "consecutive_failures",
+                    agent_id,
+                    (
+                        AlertSeverity.PAGE
+                        if streak >= 2 * self.consecutive_failures
+                        else AlertSeverity.TICKET
+                    ),
+                    f"{agent_id} had {streak} consecutive failures "
+                    f"(threshold {self.consecutive_failures})",
+                    float(streak),
+                    float(self.consecutive_failures),
+                )
+            )
+
+        age_secs = (now - max(u.timestamp for u in recs)).total_seconds()
+        if age_secs > self.stale_agent_secs:
+            alerts.append(
+                FleetAlert(
+                    "stale_agent",
+                    agent_id,
+                    AlertSeverity.DASHBOARD,
+                    f"{agent_id} last seen {age_secs:.0f}s ago "
+                    f"(threshold {self.stale_agent_secs}s)",
+                    age_secs,
+                    float(self.stale_agent_secs),
+                )
+            )
+
+        return alerts
+
+
+def format_health_report(report: HealthReport) -> str:
+    """Render a HealthReport as a markdown summary (used by the MCP fleet-health tool)."""
+    lines = [
+        f"## Fleet Health ({report.snapshot_at.strftime('%Y-%m-%d %H:%M:%S UTC')})",
+        f"Window: {report.window_seconds}s | Cost: ${report.fleet_cost_usd:.4f} | "
+        f"Requests: {report.fleet_requests}",
+        "",
+    ]
+    if not report.alerts:
+        lines.append("**No alerts. All agents within thresholds.**")
+        return "\n".join(lines)
+
+    lines.append("| Severity | Rule | Agent | Value | Threshold | Message |")
+    lines.append("|----------|------|-------|-------|-----------|---------|")
+    for alert in sorted(report.alerts, key=lambda a: -int(a.severity)):
+        lines.append(
+            f"| {alert.severity.name} | {alert.rule} | {alert.agent_id or 'fleet'} | "
+            f"{alert.value:.2f} | {alert.threshold:.2f} | {alert.message} |"
+        )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "AlertSeverity",
+    "FleetAlert",
+    "FleetObserver",
+    "HealthReport",
+    "format_health_report",
+]

--- a/services/forecasting/__init__.py
+++ b/services/forecasting/__init__.py
@@ -1,0 +1,25 @@
+"""Demand-forecasting services (deterministic, advisory-only).
+
+Exposes a velocity/sellout forecaster that replaces the ``forecast_sales`` stub (which fell
+through to "not available") with a real, explainable model: trailing-window velocity, trend
+direction, days-to-sellout, and a reorder recommendation. No ML training required; an ML
+time-series model is a later upgrade behind the same interface.
+"""
+
+from __future__ import annotations
+
+from services.forecasting.demand import (
+    DemandForecast,
+    DemandForecaster,
+    SelloutRisk,
+    Trend,
+    format_forecast,
+)
+
+__all__ = [
+    "DemandForecast",
+    "DemandForecaster",
+    "SelloutRisk",
+    "Trend",
+    "format_forecast",
+]

--- a/services/forecasting/demand.py
+++ b/services/forecasting/demand.py
@@ -1,0 +1,295 @@
+"""Deterministic demand / sellout forecaster (advisory only).
+
+Closes agent gap #3 (Drop/Demand Forecasting). The previous ``analytics_agent.forecast_sales``
+fell through to "not available", and ``algorithm_agent._predict_demand`` was a pure-LLM guess.
+This is a real, explainable baseline:
+
+- **Velocity**: units sold per day over a trailing window.
+- **Trend**: recent window vs the prior window (ACCELERATING / STEADY / DECLINING).
+- **Sellout**: days-to-sellout = inventory / velocity, mapped to a risk band against the
+  production lead time — the key signal for SkyyRose's pre-order/limited-run model ("will this
+  drop sell out before we can restock?").
+- **Reorder**: a recommended action derived from the sellout band.
+
+Design (mirrors ``services/risk/fraud.py`` / ``services/lifecycle/retention.py``):
+deterministic given ``as_of``, never-raises, advisory-only, founder-tunable. An ML time-series
+model (ARIMA/Prophet) is a future upgrade behind this same interface.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import IntEnum, StrEnum
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# Public types
+# --------------------------------------------------------------------------- #
+
+
+class Trend(StrEnum):
+    ACCELERATING = "accelerating"
+    STEADY = "steady"
+    DECLINING = "declining"
+    NO_DATA = "no_data"
+
+
+class SelloutRisk(IntEnum):
+    NONE = 0  # no inventory data or nothing selling
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+    CRITICAL = 4  # sells out before the next restock can arrive
+
+
+@dataclass(frozen=True)
+class DemandForecast:
+    """Forecast for one product. Immutable, JSON-serializable."""
+
+    sku: str | None
+    daily_velocity: float  # units/day over the trailing window
+    trend: Trend
+    forecast_units_30d: int
+    days_to_sellout: float | None
+    sellout_risk: SelloutRisk
+    recommended_action: str
+    is_preorder: bool
+
+    def forecast_units(self, horizon_days: int) -> int:
+        """Projected units sold over ``horizon_days`` at the current velocity."""
+        return int(round(self.daily_velocity * max(0, horizon_days)))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "sku": self.sku,
+            "daily_velocity": self.daily_velocity,
+            "trend": self.trend.name,
+            "forecast_units_30d": self.forecast_units_30d,
+            "days_to_sellout": self.days_to_sellout,
+            "sellout_risk": self.sellout_risk.name,
+            "recommended_action": self.recommended_action,
+            "is_preorder": self.is_preorder,
+        }
+
+
+_ACTION_BY_RISK: dict[SelloutRisk, str] = {
+    SelloutRisk.NONE: "no_action",
+    SelloutRisk.LOW: "no_action",
+    SelloutRisk.MEDIUM: "monitor",
+    SelloutRisk.HIGH: "reorder_soon",
+    SelloutRisk.CRITICAL: "reorder_now",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Defensive helpers (never raise)
+# --------------------------------------------------------------------------- #
+
+
+def _to_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        result = float(value)
+    elif isinstance(value, str):
+        try:
+            result = float(value.strip())
+        except (ValueError, AttributeError):
+            return None
+    else:
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    if not isinstance(value, str):
+        return None
+    raw = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def _units(entry: dict) -> float:
+    val = _to_float(entry.get("units"))
+    if val is None:
+        val = _to_float(entry.get("quantity"))
+    return val if val is not None and val >= 0 else 0.0
+
+
+def _entry_date(entry: dict) -> datetime | None:
+    return _parse_dt(entry.get("date")) or _parse_dt(entry.get("date_created"))
+
+
+# --------------------------------------------------------------------------- #
+# Forecaster
+# --------------------------------------------------------------------------- #
+
+
+class DemandForecaster:
+    """Forecast demand and sellout risk from a product's sales history (read-only, advisory)."""
+
+    def __init__(
+        self,
+        *,
+        window_days: int = 14,
+        baseline_days: int | None = None,  # prior window length for trend; defaults to window
+        lead_time_days: int = 14,  # production/restock lead time
+        sellout_horizon_days: int = 30,
+        accel_ratio: float = 1.15,
+        decline_ratio: float = 0.85,
+    ) -> None:
+        self.window_days = max(1, window_days)
+        self.baseline_days = max(
+            1, baseline_days if baseline_days is not None else self.window_days
+        )
+        self.lead_time_days = lead_time_days
+        self.sellout_horizon_days = sellout_horizon_days
+        self.accel_ratio = accel_ratio
+        self.decline_ratio = decline_ratio
+
+    def forecast(self, product: dict[str, Any], *, as_of: datetime | None = None) -> DemandForecast:
+        """Return a :class:`DemandForecast` for ``product``. Never raises."""
+        now = as_of or datetime.now(UTC)
+        if not isinstance(product, dict):
+            return self._empty(None, False)
+
+        sku = product.get("sku")
+        sku_str = str(sku) if sku is not None else None
+        is_preorder = bool(product.get("is_preorder", False))
+
+        try:
+            recent_units, prior_units = self._windowed_units(product, now)
+        except Exception:
+            return self._empty(sku_str, is_preorder)
+
+        velocity = recent_units / self.window_days
+        prior_velocity = prior_units / self.baseline_days
+        trend = self._trend(recent_units, prior_units, velocity, prior_velocity)
+
+        inventory = self._inventory(product)
+        days_to_sellout = (
+            (inventory / velocity) if (inventory is not None and velocity > 0) else None
+        )
+        risk = self._sellout_risk(days_to_sellout)
+        if is_preorder:
+            # Pre-orders are made-to-order: strong demand is a GOOD signal, not a reorder
+            # emergency. Suppress the sellout alarm so the advisory stays signal, not noise.
+            risk = SelloutRisk.NONE
+
+        return DemandForecast(
+            sku=sku_str,
+            daily_velocity=round(velocity, 4),
+            trend=trend,
+            forecast_units_30d=int(round(velocity * 30)),
+            days_to_sellout=round(days_to_sellout, 2) if days_to_sellout is not None else None,
+            sellout_risk=risk,
+            recommended_action=_ACTION_BY_RISK[risk],
+            is_preorder=is_preorder,
+        )
+
+    def _empty(self, sku: str | None, is_preorder: bool) -> DemandForecast:
+        return DemandForecast(
+            sku=sku,
+            daily_velocity=0.0,
+            trend=Trend.NO_DATA,
+            forecast_units_30d=0,
+            days_to_sellout=None,
+            sellout_risk=SelloutRisk.NONE,
+            recommended_action=_ACTION_BY_RISK[SelloutRisk.NONE],
+            is_preorder=is_preorder,
+        )
+
+    # -- internals --------------------------------------------------------- #
+
+    def _windowed_units(self, product: dict, now: datetime) -> tuple[float, float]:
+        sales = product.get("sales")
+        if not isinstance(sales, list):
+            return 0.0, 0.0
+        recent = prior = 0.0
+        recent_edge = self.window_days
+        prior_edge = self.window_days + self.baseline_days
+        today = now.date()
+        for entry in sales:
+            if not isinstance(entry, dict):
+                continue
+            dt = _entry_date(entry)
+            if dt is None:
+                continue
+            recency = (today - dt.date()).days
+            if recency < 1:
+                continue  # today is a partial day (and future rows) — exclude from the rate
+            units = _units(entry)
+            if recency <= recent_edge:
+                recent += units
+            elif recency <= prior_edge:
+                prior += units
+        return recent, prior
+
+    def _trend(
+        self, recent_units: float, prior_units: float, velocity: float, prior_velocity: float
+    ) -> Trend:
+        if recent_units == 0 and prior_units == 0:
+            return Trend.NO_DATA
+        if prior_velocity == 0:
+            # Reachable only when recent_units > 0 (the both-zero case returned above),
+            # so velocity > 0 here — new demand against an empty prior window.
+            return Trend.ACCELERATING
+        if velocity >= prior_velocity * self.accel_ratio:
+            return Trend.ACCELERATING
+        if velocity <= prior_velocity * self.decline_ratio:
+            return Trend.DECLINING
+        return Trend.STEADY
+
+    @staticmethod
+    def _inventory(product: dict) -> float | None:
+        inv = _to_float(product.get("inventory"))
+        if inv is None:
+            inv = _to_float(product.get("stock_quantity"))
+        return inv if inv is not None and inv >= 0 else None
+
+    def _sellout_risk(self, days_to_sellout: float | None) -> SelloutRisk:
+        if days_to_sellout is None:
+            return SelloutRisk.NONE
+        if days_to_sellout <= self.lead_time_days:
+            return SelloutRisk.CRITICAL
+        if days_to_sellout <= self.sellout_horizon_days:
+            return SelloutRisk.HIGH
+        if days_to_sellout <= 2 * self.sellout_horizon_days:
+            return SelloutRisk.MEDIUM
+        return SelloutRisk.LOW
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+
+
+def format_forecast(forecast: DemandForecast) -> str:
+    """Render a :class:`DemandForecast` as a markdown summary."""
+    sellout = "n/a" if forecast.days_to_sellout is None else f"{forecast.days_to_sellout:.1f}d"
+    preorder = " (pre-order)" if forecast.is_preorder else ""
+    return "\n".join(
+        [
+            f"## Demand Forecast — {forecast.sku or 'n/a'}{preorder}",
+            f"Velocity: **{forecast.daily_velocity:.2f}/day** | Trend: **{forecast.trend.name}** | "
+            f"30d projection: **{forecast.forecast_units_30d} units**",
+            f"Days to sellout: **{sellout}** | Sellout risk: **{forecast.sellout_risk.name}** | "
+            f"Action: **{forecast.recommended_action}**",
+        ]
+    )
+
+
+__all__ = [
+    "DemandForecast",
+    "DemandForecaster",
+    "SelloutRisk",
+    "Trend",
+    "format_forecast",
+]

--- a/services/lifecycle/__init__.py
+++ b/services/lifecycle/__init__.py
@@ -1,0 +1,22 @@
+"""Customer-lifecycle services (deterministic, advisory-only).
+
+Exposes the RFM + lifecycle-stage + churn-risk scorer that unifies the previously
+fragmented churn/retention logic scattered across the SDK domain agents. Pure compute:
+it suggests a Klaviyo segment/flow, it never sends.
+"""
+
+from __future__ import annotations
+
+from services.lifecycle.retention import (
+    LifecycleStage,
+    RetentionAssessment,
+    RetentionScorer,
+    format_assessment,
+)
+
+__all__ = [
+    "LifecycleStage",
+    "RetentionAssessment",
+    "RetentionScorer",
+    "format_assessment",
+]

--- a/services/lifecycle/retention.py
+++ b/services/lifecycle/retention.py
@@ -1,0 +1,310 @@
+"""Deterministic customer-lifecycle / retention scorer (advisory only).
+
+Closes agent gap #5 (Customer Lifecycle / Retention), which was fragmented across thin
+LLM wrappers: ``agents/claude_sdk/domain_agents/customer_intelligence.py`` (``churn_predict``
+capability string), ``community.py`` (retention/win-back prose), ``analytics_agent`` segment
+stub, and an ``mcp_tools/tools/advanced.py`` re-engagement workflow. None computed anything.
+
+This is the missing deterministic core they can all call. It scores a customer with the
+canonical **RFM** model (Recency, Frequency, Monetary), assigns a lifecycle stage, computes a
+churn-risk score, and recommends a next action + a Klaviyo segment to enroll into.
+
+Design (mirrors ``services/risk/fraud.py`` and ``monitoring/fleet_observer.py``):
+- **Deterministic** given ``as_of`` (defaults to now only when the caller omits it).
+- **Never raises.** Every field read is defensive; a malformed customer yields a safe
+  ``NEW`` / ``churn_risk == 0`` assessment.
+- **Advisory.** It returns a *suggested* Klaviyo segment/flow name. It NEVER calls the Klaviyo
+  API or enrolls anyone — a human (or a STOP-AND-SHOW gated action) does the actual send.
+- **Founder-tunable.** Every window and threshold is a constructor argument.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# Public types
+# --------------------------------------------------------------------------- #
+
+
+class LifecycleStage(StrEnum):
+    """Where a customer sits in their relationship with the brand."""
+
+    NEW = "new"
+    ACTIVE = "active"
+    LOYAL = "loyal"
+    AT_RISK = "at_risk"
+    DORMANT = "dormant"
+    CHURNED = "churned"
+
+
+@dataclass(frozen=True)
+class RetentionAssessment:
+    """RFM + lifecycle verdict for one customer. Immutable, JSON-serializable."""
+
+    customer_id: str | None
+    recency_days: int | None  # None when the customer has never ordered
+    frequency: int
+    monetary: float
+    rfm: str  # "R-F-M", each 1-5, e.g. "5-3-4"
+    lifecycle_stage: LifecycleStage
+    churn_risk: int  # 0-100
+    recommended_action: str
+    suggested_klaviyo_segment: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "customer_id": self.customer_id,
+            "recency_days": self.recency_days,
+            "frequency": self.frequency,
+            "monetary": self.monetary,
+            "rfm": self.rfm,
+            "lifecycle_stage": self.lifecycle_stage.name,
+            "churn_risk": self.churn_risk,
+            "recommended_action": self.recommended_action,
+            "suggested_klaviyo_segment": self.suggested_klaviyo_segment,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Defaults (founder-tunable via the constructor)
+# --------------------------------------------------------------------------- #
+
+# Recency days -> R score. Each tuple is (max_days_inclusive, score). First match wins.
+_RECENCY_BANDS: tuple[tuple[int, int], ...] = ((30, 5), (60, 4), (120, 3), (240, 2))
+# Frequency (order count) -> F score. (min_orders_inclusive, score). First match wins.
+_FREQUENCY_BANDS: tuple[tuple[int, int], ...] = ((10, 5), (6, 4), (3, 3), (2, 2))
+# Monetary (total spent) -> M score. (min_spend_inclusive, score). First match wins.
+_MONETARY_BANDS: tuple[tuple[float, int], ...] = ((1000.0, 5), (500.0, 4), (250.0, 3), (100.0, 2))
+
+_ACTION_BY_STAGE: dict[LifecycleStage, str] = {
+    LifecycleStage.NEW: "welcome_nurture",
+    LifecycleStage.ACTIVE: "cross_sell",
+    LifecycleStage.LOYAL: "vip_reward",
+    LifecycleStage.AT_RISK: "reengagement_offer",
+    LifecycleStage.DORMANT: "winback_offer",
+    LifecycleStage.CHURNED: "winback_last_attempt",
+}
+
+_KLAVIYO_SEGMENT_BY_STAGE: dict[LifecycleStage, str] = {
+    LifecycleStage.NEW: "New / Welcome",
+    LifecycleStage.ACTIVE: "Active Buyers",
+    LifecycleStage.LOYAL: "VIP / Loyal",
+    LifecycleStage.AT_RISK: "At-Risk (re-engage)",
+    LifecycleStage.DORMANT: "Dormant (win-back)",
+    LifecycleStage.CHURNED: "Churned (last-touch)",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Defensive helpers (never raise)
+# --------------------------------------------------------------------------- #
+
+
+def _to_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        result = float(value)
+    elif isinstance(value, str):
+        try:
+            result = float(value.strip())
+        except (ValueError, AttributeError):
+            return None
+    else:
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    if not isinstance(value, str):
+        return None
+    raw = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def _band(value: float, bands: tuple[tuple[float, int], ...], *, ascending: bool) -> int:
+    """Map a value to a 1-5 score. ``ascending`` bands are 'value >= edge'; otherwise '<='."""
+    for edge, score in bands:
+        if (value >= edge) if ascending else (value <= edge):
+            return score
+    return 1
+
+
+# --------------------------------------------------------------------------- #
+# Scorer
+# --------------------------------------------------------------------------- #
+
+
+class RetentionScorer:
+    """Score a customer's RFM, lifecycle stage, and churn risk (read-only, advisory)."""
+
+    def __init__(
+        self,
+        *,
+        at_risk_days: int = 90,
+        dormant_days: int = 180,
+        churned_days: int = 365,
+        loyal_min_orders: int = 4,
+        loyalty_weight: int = 4,  # churn-risk discount per repeat order (capped at 5 orders)
+    ) -> None:
+        self.at_risk_days = at_risk_days
+        self.dormant_days = dormant_days
+        self.churned_days = churned_days
+        self.loyal_min_orders = loyal_min_orders
+        self.loyalty_weight = loyalty_weight
+
+    # -- pure mappings ----------------------------------------------------- #
+
+    @staticmethod
+    def action_for(stage: LifecycleStage) -> str:
+        return _ACTION_BY_STAGE.get(stage, "reengagement_offer")
+
+    @staticmethod
+    def klaviyo_segment_for(stage: LifecycleStage) -> str:
+        return _KLAVIYO_SEGMENT_BY_STAGE.get(stage, "At-Risk (re-engage)")
+
+    # -- entry point ------------------------------------------------------- #
+
+    def assess(
+        self, customer: dict[str, Any], *, as_of: datetime | None = None
+    ) -> RetentionAssessment:
+        """Return a :class:`RetentionAssessment` for ``customer``. Never raises."""
+        now = as_of or datetime.now(UTC)
+        if not isinstance(customer, dict):
+            return self._empty(None)
+
+        cid = customer.get("id")
+        cid_str = str(cid) if cid is not None else None
+
+        try:
+            recency_days, frequency, monetary = self._rfm_inputs(customer, now)
+        except Exception:  # defense-in-depth — never break a marketing batch
+            return self._empty(cid_str)
+
+        r_score = (
+            _band(recency_days, _RECENCY_BANDS, ascending=False) if recency_days is not None else 1
+        )
+        f_score = _band(float(frequency), _FREQUENCY_BANDS, ascending=True)
+        m_score = _band(monetary, _MONETARY_BANDS, ascending=True)
+        rfm = f"{r_score}-{f_score}-{m_score}"
+
+        stage = self._stage(frequency, recency_days)
+        churn = self._churn_risk(recency_days, frequency)
+
+        return RetentionAssessment(
+            customer_id=cid_str,
+            recency_days=recency_days,
+            frequency=frequency,
+            monetary=round(monetary, 2),
+            rfm=rfm,
+            lifecycle_stage=stage,
+            churn_risk=churn,
+            recommended_action=self.action_for(stage),
+            suggested_klaviyo_segment=self.klaviyo_segment_for(stage),
+        )
+
+    def _empty(self, cid: str | None) -> RetentionAssessment:
+        return RetentionAssessment(
+            customer_id=cid,
+            recency_days=None,
+            frequency=0,
+            monetary=0.0,
+            rfm="1-1-1",
+            lifecycle_stage=LifecycleStage.NEW,
+            churn_risk=0,
+            recommended_action=self.action_for(LifecycleStage.NEW),
+            suggested_klaviyo_segment=self.klaviyo_segment_for(LifecycleStage.NEW),
+        )
+
+    # -- RFM extraction ---------------------------------------------------- #
+
+    def _rfm_inputs(self, customer: dict, now: datetime) -> tuple[int | None, int, float]:
+        """Return (recency_days, frequency, monetary) from an orders list or precomputed fields."""
+        orders = customer.get("orders")
+        if isinstance(orders, list):
+            dicts = [o for o in orders if isinstance(o, dict)]
+            frequency = len(dicts)
+            monetary = sum(v for v in (_to_float(o.get("total")) for o in dicts) if v is not None)
+            dates = [d for d in (_parse_dt(o.get("date_created")) for o in dicts) if d is not None]
+            recency = self._recency(max(dates), now) if dates else None
+            return recency, frequency, monetary
+
+        # Precomputed-field fallback.
+        frequency = int(_to_float(customer.get("order_count")) or 0)
+        monetary = _to_float(customer.get("total_spent")) or 0.0
+        last = _parse_dt(customer.get("last_order_date"))
+        recency = self._recency(last, now) if last else None
+        return recency, frequency, monetary
+
+    @staticmethod
+    def _recency(last: datetime, now: datetime) -> int:
+        # Day-granularity diff via .date() avoids naive/aware subtraction errors.
+        return max(0, (now.date() - last.date()).days)
+
+    # -- stage + churn ----------------------------------------------------- #
+
+    def _stage(self, frequency: int, recency_days: int | None) -> LifecycleStage:
+        if frequency <= 0 or recency_days is None:
+            return LifecycleStage.NEW
+        if recency_days > self.churned_days:
+            return LifecycleStage.CHURNED
+        if recency_days > self.dormant_days:
+            return LifecycleStage.DORMANT
+        # Loyalty protects against the at-risk gate through the normal inter-drop window:
+        # a repeat buyer (>= loyal_min_orders) in a 91-180d quiet period between drops is
+        # LOYAL, not AT_RISK. churn_risk still rises with recency as the secondary signal.
+        if frequency >= self.loyal_min_orders:
+            return LifecycleStage.LOYAL
+        if recency_days > self.at_risk_days:
+            return LifecycleStage.AT_RISK
+        if frequency >= 2:
+            return LifecycleStage.ACTIVE
+        return LifecycleStage.NEW
+
+    def _churn_risk(self, recency_days: int | None, frequency: int) -> int:
+        if recency_days is None or self.churned_days <= 0 or frequency <= 0:
+            return 0
+        ratio = min(recency_days / self.churned_days, 1.0)
+        base = round(100 * ratio)
+        discount = min(frequency, 5) * self.loyalty_weight
+        return max(0, min(100, base - discount))
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+
+
+def format_assessment(assessment: RetentionAssessment) -> str:
+    """Render a :class:`RetentionAssessment` as a markdown summary."""
+    recency = "never" if assessment.recency_days is None else f"{assessment.recency_days}d ago"
+    return "\n".join(
+        [
+            f"## Retention — customer {assessment.customer_id or 'n/a'}",
+            f"Stage: **{assessment.lifecycle_stage.name}** | Churn risk: "
+            f"**{assessment.churn_risk}/100** | RFM: **{assessment.rfm}**",
+            f"Last order: {recency} | Orders: {assessment.frequency} | "
+            f"Spent: ${assessment.monetary:.2f}",
+            f"Action: **{assessment.recommended_action}** | Klaviyo segment: "
+            f"**{assessment.suggested_klaviyo_segment}**",
+        ]
+    )
+
+
+__all__ = [
+    "LifecycleStage",
+    "RetentionAssessment",
+    "RetentionScorer",
+    "format_assessment",
+]

--- a/services/personalization/__init__.py
+++ b/services/personalization/__init__.py
@@ -1,0 +1,27 @@
+"""Personalization services (deterministic, advisory-only).
+
+Exposes a per-user catalog reranker. It replaces the global, identical-for-everyone ranking
+in ``algorithm_agent.score_products`` with content-based + co-purchase personalization, and
+falls back to global popularity for cold-start users. An embedding/Pinecone backend is an
+optional injected port — the no-LLM, no-network path ships by default.
+"""
+
+from __future__ import annotations
+
+from services.personalization.recommender import (
+    Recommendation,
+    RecommendationSet,
+    Recommender,
+    SimilarityBackend,
+    Strategy,
+    format_recommendations,
+)
+
+__all__ = [
+    "Recommendation",
+    "RecommendationSet",
+    "Recommender",
+    "SimilarityBackend",
+    "Strategy",
+    "format_recommendations",
+]

--- a/services/personalization/recommender.py
+++ b/services/personalization/recommender.py
@@ -1,0 +1,336 @@
+"""Deterministic per-user product recommender (advisory only).
+
+Closes agent gap #6 (Personalization / Recommendation). ``algorithm_agent.score_products``
+ranked the catalog GLOBALLY — the same list for every user. This adds real personalization:
+
+- **Content-based**: score each candidate by how well it matches the user's purchase profile
+  (collection affinity, shared tags, price-tier proximity).
+- **Co-purchase**: boost items frequently bought together with what the user owns (item-item).
+- **Popularity cold-start**: a user with no usable history falls back to global popularity —
+  a strict superset of the old global ranking.
+- **Optional similarity port**: an embedding backend (e.g. the Pinecone ``skyyrose-catalog``
+  index) can be injected via ``similarity_backend``; it is blended in when present. The
+  default path uses NO LLM and NO network.
+
+Design (mirrors the other services/ scorers): deterministic, never-raises, advisory,
+founder-tunable weights, stable tie-break (by score then id).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+
+
+class SimilarityBackend(Protocol):
+    """Optional embedding/vector-similarity port. The Pinecone adapter implements this."""
+
+    def similar(self, item_id: str, k: int) -> list[tuple[str, float]]:
+        """Return up to ``k`` (item_id, similarity_score) pairs most similar to ``item_id``."""
+        ...
+
+
+class Strategy(StrEnum):
+    PERSONALIZED = "personalized"
+    POPULARITY_COLD_START = "popularity_cold_start"
+
+
+@dataclass(frozen=True)
+class Recommendation:
+    item_id: str
+    score: float
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RecommendationSet:
+    user_id: str | None
+    strategy: Strategy
+    items: tuple[Recommendation, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "user_id": self.user_id,
+            "strategy": self.strategy.name,
+            "recommendations": [
+                {"item_id": r.item_id, "score": r.score, "reasons": list(r.reasons)}
+                for r in self.items
+            ],
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Defensive normalizers (never raise)
+# --------------------------------------------------------------------------- #
+
+
+def _to_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        result = float(value)
+    elif isinstance(value, str):
+        try:
+            result = float(value.strip())
+        except (ValueError, AttributeError):
+            return None
+    else:
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _item_id(item: Any) -> str:
+    if isinstance(item, dict):
+        return str(item.get("id") or item.get("sku") or "").strip()
+    if isinstance(item, str):
+        return item.strip()
+    return ""
+
+
+def _collection(item: dict) -> str:
+    return str(item.get("collection") or "").strip().lower()
+
+
+def _price(item: dict) -> float | None:
+    # Explicit None check — a price of 0.0 is a real value, not a reason to fall through.
+    price = _to_float(item.get("price"))
+    return price if price is not None else _to_float(item.get("regular_price"))
+
+
+def _tags(item: dict) -> set[str]:
+    raw = item.get("tags")
+    out: set[str] = set()
+    if isinstance(raw, list):
+        for t in raw:
+            if isinstance(t, str):
+                out.add(t.strip().lower())
+            elif isinstance(t, dict):
+                name = t.get("name") or t.get("slug")
+                if name:
+                    out.add(str(name).strip().lower())
+    return out
+
+
+def _popularity(item: dict) -> float:
+    val = _to_float(item.get("popularity"))
+    if val is None:
+        val = _to_float(item.get("total_sales"))
+    return val if val is not None and val >= 0 else 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Recommender
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class _Profile:
+    collections: frozenset[str]
+    tags: frozenset[str]
+    avg_price: float | None
+    owned_ids: frozenset[str]
+
+    @property
+    def empty(self) -> bool:
+        return not (self.collections or self.tags or self.avg_price)
+
+
+class Recommender:
+    """Rank a catalog for one user (read-only, advisory)."""
+
+    def __init__(
+        self,
+        *,
+        top_n: int = 10,
+        collection_match_weight: float = 10.0,
+        tag_overlap_weight: float = 3.0,
+        price_proximity_weight: float = 5.0,
+        copurchase_weight: float = 0.5,
+        popularity_weight: float = 0.1,
+        similarity_weight: float = 8.0,
+        similarity_k: int = 50,  # fanout per owned item when a similarity backend is wired
+    ) -> None:
+        self.top_n = top_n
+        self.similarity_k = max(1, similarity_k)
+        self.collection_match_weight = collection_match_weight
+        self.tag_overlap_weight = tag_overlap_weight
+        self.price_proximity_weight = price_proximity_weight
+        self.copurchase_weight = copurchase_weight
+        self.popularity_weight = popularity_weight
+        self.similarity_weight = similarity_weight
+
+    def recommend(
+        self,
+        user: dict[str, Any],
+        catalog: list[dict[str, Any]],
+        *,
+        co_purchase: dict[str, dict[str, Any]] | None = None,
+        similarity_backend: SimilarityBackend | None = None,
+    ) -> RecommendationSet:
+        """Return a ranked :class:`RecommendationSet` for ``user``. Never raises."""
+        user_dict = user if isinstance(user, dict) else {}
+        uid = user_dict.get("id")
+        uid_str = str(uid) if uid is not None else None
+
+        try:
+            return self._recommend(uid_str, user_dict, catalog, co_purchase, similarity_backend)
+        except Exception:  # defense-in-depth — recommendations must never break a page render
+            return RecommendationSet(uid_str, Strategy.POPULARITY_COLD_START, ())
+
+    def _recommend(
+        self,
+        uid: str | None,
+        user: dict,
+        catalog: Any,
+        co_purchase: dict[str, dict[str, Any]] | None,
+        backend: SimilarityBackend | None,
+    ) -> RecommendationSet:
+        items = [c for c in catalog if isinstance(c, dict)] if isinstance(catalog, list) else []
+        by_id = {_item_id(c): c for c in items if _item_id(c)}
+
+        profile = self._build_profile(user, by_id)
+        strategy = Strategy.POPULARITY_COLD_START if profile.empty else Strategy.PERSONALIZED
+        co = co_purchase if isinstance(co_purchase, dict) else {}
+
+        # Precompute similarity contributions per candidate from the user's owned items.
+        sim_scores = self._similarity_scores(profile.owned_ids, backend) if backend else {}
+
+        scored: list[Recommendation] = []
+        for c in items:
+            cid = _item_id(c)
+            if not cid or cid in profile.owned_ids:
+                continue
+            score, reasons = self._score(c, cid, profile, co, sim_scores)
+            scored.append(
+                Recommendation(item_id=cid, score=round(score, 4), reasons=tuple(reasons))
+            )
+
+        # Stable, deterministic ordering: score desc, then id asc.
+        scored.sort(key=lambda r: (-r.score, r.item_id))
+        return RecommendationSet(uid, strategy, tuple(scored[: self.top_n]))
+
+    def _build_profile(self, user: dict, by_id: dict[str, dict]) -> _Profile:
+        purchased = user.get("purchased")
+        owned_ids: set[str] = set()
+        profile_items: list[dict] = []
+        if isinstance(purchased, list):
+            for entry in purchased:
+                pid = _item_id(entry)
+                if pid:
+                    owned_ids.add(pid)
+                source = by_id.get(pid) or (entry if isinstance(entry, dict) else None)
+                if source is not None:
+                    profile_items.append(source)
+
+        collections = {_collection(i) for i in profile_items if _collection(i)}
+        tags: set[str] = set()
+        for i in profile_items:
+            tags |= _tags(i)
+        prices = [p for p in (_price(i) for i in profile_items) if p is not None and p > 0]
+        avg_price = (sum(prices) / len(prices)) if prices else None
+
+        return _Profile(
+            collections=frozenset(collections),
+            tags=frozenset(tags),
+            avg_price=avg_price,
+            owned_ids=frozenset(owned_ids),
+        )
+
+    def _similarity_scores(
+        self, owned_ids: frozenset[str], backend: SimilarityBackend
+    ) -> dict[str, float]:
+        out: dict[str, float] = {}
+        for oid in owned_ids:
+            try:
+                pairs = backend.similar(oid, self.similarity_k)
+            except Exception:
+                continue
+            for cand_id, sim in pairs or []:
+                val = _to_float(sim)
+                if val is not None:
+                    out[str(cand_id)] = out.get(str(cand_id), 0.0) + val
+        return out
+
+    def _score(
+        self,
+        item: dict,
+        cid: str,
+        profile: _Profile,
+        co: dict[str, dict[str, Any]],
+        sim_scores: dict[str, float],
+    ) -> tuple[float, list[str]]:
+        score = 0.0
+        reasons: list[str] = []
+
+        if not profile.empty:
+            if _collection(item) and _collection(item) in profile.collections:
+                score += self.collection_match_weight
+                reasons.append(f"same collection: {item.get('collection')}")
+
+            shared = _tags(item) & profile.tags
+            if shared:
+                score += self.tag_overlap_weight * len(shared)
+                reasons.append(f"shares tag: {', '.join(sorted(shared))}")
+
+            price = _price(item)
+            if profile.avg_price and price is not None:
+                closeness = max(0.0, 1.0 - abs(price - profile.avg_price) / profile.avg_price)
+                if closeness > 0:
+                    score += self.price_proximity_weight * closeness
+                    reasons.append("matches your price range")
+
+            co_count = sum(
+                _to_float((co.get(oid) or {}).get(cid)) or 0.0 for oid in profile.owned_ids
+            )
+            if co_count > 0:
+                score += self.copurchase_weight * co_count
+                reasons.append("frequently bought together")
+
+            sim = sim_scores.get(cid, 0.0)
+            if sim > 0:
+                score += self.similarity_weight * sim
+                reasons.append("similar to items you bought")
+
+        pop = _popularity(item)
+        if pop > 0:
+            # log-scale so a runaway bestseller can't swamp personalized signals; monotonic,
+            # so cold-start popularity ordering is preserved.
+            score += self.popularity_weight * math.log1p(pop)
+            if profile.empty:
+                reasons.append("popular")
+
+        return score, reasons
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+
+
+def format_recommendations(rs: RecommendationSet) -> str:
+    """Render a :class:`RecommendationSet` as a markdown summary."""
+    lines = [
+        f"## Recommendations — user {rs.user_id or 'n/a'} ({rs.strategy.name})",
+        "",
+    ]
+    if not rs.items:
+        lines.append("No recommendations available.")
+        return "\n".join(lines)
+    lines.append("| # | Item | Score | Why |")
+    lines.append("|---|------|-------|-----|")
+    for i, r in enumerate(rs.items, 1):
+        why = "; ".join(r.reasons) if r.reasons else "—"
+        lines.append(f"| {i} | {r.item_id} | {r.score:.2f} | {why} |")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "Recommendation",
+    "RecommendationSet",
+    "Recommender",
+    "SimilarityBackend",
+    "Strategy",
+    "format_recommendations",
+]

--- a/services/risk/__init__.py
+++ b/services/risk/__init__.py
@@ -1,0 +1,23 @@
+"""Risk-scoring services (deterministic, advisory-only).
+
+Currently exposes the fraud/chargeback risk scorer. Every module here is pure and
+never-raises: it scores and recommends, it never mutates an order or calls a write API.
+"""
+
+from __future__ import annotations
+
+from services.risk.fraud import (
+    FraudAssessment,
+    FraudScorer,
+    RiskLevel,
+    RiskSignal,
+    format_assessment,
+)
+
+__all__ = [
+    "FraudAssessment",
+    "FraudScorer",
+    "RiskLevel",
+    "RiskSignal",
+    "format_assessment",
+]

--- a/services/risk/fraud.py
+++ b/services/risk/fraud.py
@@ -1,0 +1,483 @@
+"""Deterministic fraud / chargeback risk scorer (advisory only).
+
+Closes agent gap #4 (Fraud/Chargeback), which previously existed only as a prompt
+bullet in ``agents/commerce_agent.py`` and ``agents/support_agent.py`` — no implementation.
+
+Design (mirrors ``monitoring/fleet_observer.py``):
+- **Pure + deterministic.** Same order in → same assessment out. No LLM, no network, no clock
+  except an explicit fallback when an order omits its own ``date_created`` for velocity.
+- **Never raises.** Every field read is defensive; the scoring body is fully guarded so a
+  malformed order yields a safe ``score == 0`` assessment rather than an exception.
+- **Advisory.** It returns a score, a level, and a recommended action ("approve" / "review" /
+  "hold"). It NEVER cancels, refunds, or writes to WooCommerce. A human (or a STOP-AND-SHOW
+  gated action) acts on the recommendation.
+- **Founder-tunable.** Every threshold and the disposable-domain list are constructor args.
+- **PII-careful.** Signal details mask email/IP and omit full customer names; the assessment
+  payload is internal-only but still avoids embedding raw PII.
+
+Signals are industry-standard chargeback predictors: AVS/CVV mismatch, billing↔shipping
+country mismatch, order velocity, disposable email, guest high-value, recipient-name mismatch.
+Weights sum, clamp to 100, and map to a level band.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import IntEnum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- #
+# Public types
+# --------------------------------------------------------------------------- #
+
+
+class RiskLevel(IntEnum):
+    """Ordered risk bands. Higher = more likely fraudulent."""
+
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+    CRITICAL = 4
+
+
+@dataclass(frozen=True)
+class RiskSignal:
+    """One triggered rule and the points it contributed."""
+
+    rule: str
+    weight: int
+    detail: str
+
+
+@dataclass(frozen=True)
+class FraudAssessment:
+    """The verdict for a single order. Immutable, JSON-serializable via ``as_dict``."""
+
+    order_id: str | None
+    score: int  # 0-100
+    level: RiskLevel
+    signals: tuple[RiskSignal, ...]
+    recommended_action: str  # "approve" | "review" | "hold"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "order_id": self.order_id,
+            "score": self.score,
+            "level": self.level.name,
+            "recommended_action": self.recommended_action,
+            "signals": [
+                {"rule": s.rule, "weight": s.weight, "detail": s.detail} for s in self.signals
+            ],
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Defaults
+# --------------------------------------------------------------------------- #
+
+# Per-rule point weights. Summed, then clamped to 100. Calibrated so that a benign
+# international gift (country mismatch + name mismatch + guest + high value) lands at 45
+# (MEDIUM/approve), while any gateway-verified signal (AVS/CVV) pushes to HIGH/CRITICAL.
+_WEIGHTS: dict[str, int] = {
+    "cvv_failure": 35,
+    "avs_mismatch": 30,
+    "disposable_email": 30,
+    "velocity_email": 25,
+    "velocity_ip": 20,
+    "billing_shipping_country_mismatch": 15,
+    "guest_high_value": 10,
+    "high_value_order": 10,
+    "mismatched_recipient_name": 10,
+    "address_mismatch": 8,
+    "email_gibberish": 8,
+}
+
+# Score band edges → level. Kept module-level so ``level_for`` is a pure staticmethod.
+_LEVEL_BANDS: tuple[tuple[int, RiskLevel], ...] = (
+    (80, RiskLevel.CRITICAL),
+    (50, RiskLevel.HIGH),
+    (20, RiskLevel.MEDIUM),
+    (0, RiskLevel.LOW),
+)
+
+_ACTION_BY_LEVEL: dict[RiskLevel, str] = {
+    RiskLevel.LOW: "approve",
+    RiskLevel.MEDIUM: "approve",
+    RiskLevel.HIGH: "review",
+    RiskLevel.CRITICAL: "hold",
+}
+
+# Throwaway-email providers. Conservative, well-known set; founder can extend per-instance.
+_DEFAULT_DISPOSABLE_DOMAINS: frozenset[str] = frozenset(
+    {
+        "mailinator.com",
+        "guerrillamail.com",
+        "10minutemail.com",
+        "trashmail.com",
+        "yopmail.com",
+        "temp-mail.org",
+        "tempmail.com",
+        "getnada.com",
+        "throwawaymail.com",
+        "sharklasers.com",
+        "maildrop.cc",
+        "dispostable.com",
+        "fakeinbox.com",
+        "mailnesia.com",
+        "mintemail.com",
+    }
+)
+
+_GIBBERISH_MIN_LEN = 8
+
+
+# --------------------------------------------------------------------------- #
+# Defensive field helpers (never raise)
+# --------------------------------------------------------------------------- #
+
+
+def _section(order: dict, key: str) -> dict:
+    """Return ``order[key]`` if it is a dict, else an empty dict."""
+    value = order.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _to_float(value: Any) -> float | None:
+    """Parse a money-ish value to a finite float, or None when not parseable/non-finite."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        result = float(value)
+    elif isinstance(value, str):
+        try:
+            result = float(value.strip())
+        except (ValueError, AttributeError):
+            return None
+    else:
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    """Parse an ISO-8601 timestamp defensively. Naive timestamps are normalized to UTC so
+    aware/naive subtraction never raises (real WooCommerce mixes +00:00 and bare timestamps)."""
+    if not isinstance(value, str):
+        return None
+    raw = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def _email_domain(email: Any) -> str:
+    if not isinstance(email, str) or "@" not in email:
+        return ""
+    return email.rsplit("@", 1)[-1].strip().lower()
+
+
+def _email_local(email: Any) -> str:
+    if not isinstance(email, str) or "@" not in email:
+        return ""
+    return email.rsplit("@", 1)[0].strip().lower()
+
+
+def _mask_email(email: str) -> str:
+    """Mask an email for logging: keep the domain, redact the local-part."""
+    domain = _email_domain(email)
+    return f"***@{domain}" if domain else "***"
+
+
+def _mask_ip(ip: str) -> str:
+    """Mask an IP for logging: keep the /24 prefix for IPv4, else fully redact."""
+    octets = ip.split(".")
+    if len(octets) == 4 and all(o.isdigit() for o in octets):
+        return f"{octets[0]}.{octets[1]}.{octets[2]}.x"
+    return "***"
+
+
+def _full_name(section: dict) -> str:
+    first = str(section.get("first_name") or "").strip().lower()
+    last = str(section.get("last_name") or "").strip().lower()
+    return f"{first} {last}".strip()
+
+
+def _scan_meta(order: dict, needle: str) -> str | None:
+    """Search ``meta_data`` (WooCommerce list-of-{key,value}) for a key containing ``needle``."""
+    meta = order.get("meta_data")
+    if not isinstance(meta, list):
+        return None
+    for item in meta:
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("key", "")).lower()
+        if needle in key:
+            value = item.get("value")
+            return str(value) if value is not None else None
+    return None
+
+
+# AVS/CVV result codes that indicate a mismatch / failure (lowercased).
+_AVS_BAD = {"n", "no_match", "nomatch", "mismatch", "fail", "failed"}
+_CVV_BAD = {"n", "no_match", "nomatch", "fail", "failed", "mismatch"}
+
+
+def _looks_gibberish(local: str) -> bool:
+    """Heuristic: long local-part that is mostly digits reads as machine-generated."""
+    if len(local) < _GIBBERISH_MIN_LEN:
+        return False
+    digits = sum(c.isdigit() for c in local)
+    return digits / len(local) >= 0.5
+
+
+_WS = re.compile(r"\s+")
+
+
+def _norm_addr(section: dict) -> str:
+    parts = [
+        str(section.get("address_1") or ""),
+        str(section.get("postcode") or ""),
+        str(section.get("city") or ""),
+    ]
+    return _WS.sub(" ", " ".join(parts)).strip().lower()
+
+
+def _md_cell(value: Any) -> str:
+    """Escape a value for a GitHub-flavored-Markdown table cell (no pipe/newline breakout)."""
+    return str(value).replace("|", "\\|").replace("\n", " ").replace("\r", " ")
+
+
+# --------------------------------------------------------------------------- #
+# Scorer
+# --------------------------------------------------------------------------- #
+
+
+class FraudScorer:
+    """Score an order's fraud/chargeback risk from deterministic signals (read-only)."""
+
+    def __init__(
+        self,
+        *,
+        high_value_threshold: float = 500.0,
+        mid_value_threshold: float = 250.0,
+        velocity_count: int = 3,
+        velocity_window_hours: int = 24,
+        extra_disposable_domains: tuple[str, ...] = (),
+        weights: dict[str, int] | None = None,
+    ) -> None:
+        self.high_value_threshold = high_value_threshold
+        self.mid_value_threshold = mid_value_threshold
+        self.velocity_count = velocity_count
+        self.velocity_window_hours = velocity_window_hours
+        self.disposable_domains = _DEFAULT_DISPOSABLE_DOMAINS | {
+            d.lower() for d in extra_disposable_domains
+        }
+        self.weights = {**_WEIGHTS, **(weights or {})}
+
+    # -- level / action mapping (pure) ------------------------------------- #
+
+    @staticmethod
+    def level_for(score: int) -> RiskLevel:
+        for edge, level in _LEVEL_BANDS:
+            if score >= edge:
+                return level
+        return RiskLevel.LOW
+
+    @staticmethod
+    def action_for(level: RiskLevel) -> str:
+        return _ACTION_BY_LEVEL.get(level, "review")
+
+    # -- main entry point -------------------------------------------------- #
+
+    def assess(
+        self, order: dict[str, Any], history: list[dict[str, Any]] | None = None
+    ) -> FraudAssessment:
+        """Return a :class:`FraudAssessment` for ``order``. Never raises."""
+        if not isinstance(order, dict):
+            return FraudAssessment(None, 0, RiskLevel.LOW, (), "approve")
+
+        order_id = order.get("id")
+        order_id_str = str(order_id) if order_id is not None else None
+
+        try:
+            signals = self._signals(order, history or [])
+            raw = sum(int(s.weight) for s in signals)
+        except Exception as exc:  # defense-in-depth: a buggy rule must not break checkout review
+            logger.warning("fraud assess fell back to score=0 (order_id=%s): %s", order_id_str, exc)
+            signals, raw = (), 0
+
+        score = max(0, min(100, raw))
+        level = self.level_for(score)
+        return FraudAssessment(
+            order_id=order_id_str,
+            score=score,
+            level=level,
+            signals=signals,
+            recommended_action=self.action_for(level),
+        )
+
+    # -- rules ------------------------------------------------------------- #
+
+    def _signals(self, order: dict, history: list[dict]) -> tuple[RiskSignal, ...]:
+        billing = _section(order, "billing")
+        shipping = _section(order, "shipping")
+        out: list[RiskSignal] = []
+
+        def add(rule: str, detail: str) -> None:
+            out.append(RiskSignal(rule=rule, weight=self.weights.get(rule, 0), detail=detail))
+
+        # --- payment-gateway signals --------------------------------------
+        if self._cvv_failed(order):
+            add("cvv_failure", "CVV/CVC check did not pass")
+        if self._avs_mismatch(order):
+            add("avs_mismatch", "Address Verification System reported a mismatch")
+
+        # --- email signals -------------------------------------------------
+        email = billing.get("email")
+        domain = _email_domain(email)
+        if domain and domain in self.disposable_domains:
+            add("disposable_email", f"Disposable email domain: {domain}")
+        elif _looks_gibberish(_email_local(email)):
+            add("email_gibberish", "Email local-part looks machine-generated")
+
+        # --- velocity ------------------------------------------------------
+        self._velocity_signals(order, billing, history, add)
+
+        # --- geography -----------------------------------------------------
+        bill_country = str(billing.get("country") or "").strip().upper()
+        ship_country = str(shipping.get("country") or "").strip().upper()
+        countries_mismatch = bool(bill_country and ship_country and bill_country != ship_country)
+        if countries_mismatch:
+            add(
+                "billing_shipping_country_mismatch",
+                f"Billing {bill_country} != shipping {ship_country}",
+            )
+        elif bill_country and ship_country:
+            # Same country but different street/zip/city.
+            bill_addr = _norm_addr(billing)
+            ship_addr = _norm_addr(shipping)
+            if bill_addr and ship_addr and bill_addr != ship_addr:
+                add("address_mismatch", "Billing and shipping addresses differ")
+
+        # --- recipient name (redacted — names are PII) --------------------
+        bill_name = _full_name(billing)
+        ship_name = _full_name(shipping)
+        if bill_name and ship_name and bill_name != ship_name:
+            add("mismatched_recipient_name", "Billing name does not match shipping name")
+
+        # --- order value ---------------------------------------------------
+        total = _to_float(order.get("total"))
+        # Guest only when the gateway explicitly says customer_id == 0. A missing/None id is
+        # "unknown", not "guest" — avoids false-positives on partial webhook payloads.
+        is_guest = str(order.get("customer_id", "")).strip() == "0"
+        if total is not None:
+            if total >= self.high_value_threshold:
+                add(
+                    "high_value_order",
+                    f"Order total {total:.2f} >= {self.high_value_threshold:.2f}",
+                )
+            if is_guest and total >= self.mid_value_threshold:
+                add(
+                    "guest_high_value",
+                    f"Guest checkout with total {total:.2f} >= {self.mid_value_threshold:.2f}",
+                )
+
+        return tuple(out)
+
+    def _cvv_failed(self, order: dict) -> bool:
+        value = order.get("cvv_result")
+        if value is None:
+            value = _scan_meta(order, "cvv")
+        return isinstance(value, str) and value.strip().lower() in _CVV_BAD
+
+    def _avs_mismatch(self, order: dict) -> bool:
+        value = order.get("avs_result")
+        if value is None:
+            value = _scan_meta(order, "avs")
+        return isinstance(value, str) and value.strip().lower() in _AVS_BAD
+
+    def _velocity_signals(self, order, billing, history, add) -> None:
+        if not history:
+            return
+        ref = _parse_dt(order.get("date_created"))
+        window = timedelta(hours=self.velocity_window_hours)
+        current_id = order.get("id")
+
+        def eligible(hist: dict) -> bool:
+            if not isinstance(hist, dict):
+                return False
+            if current_id is not None and hist.get("id") == current_id:
+                return False  # never count the order against itself
+            if ref is None:
+                return True  # no reference time → count all provided history
+            ts = _parse_dt(hist.get("date_created"))
+            return ts is not None and timedelta(0) <= (ref - ts) <= window
+
+        window_phrase = "in window" if ref is not None else "(no order timestamp — all counted)"
+        order_email = str(billing.get("email") or "").strip().lower()
+        order_ip = str(order.get("customer_ip_address") or "").strip()
+
+        if order_email:
+            same_email = sum(
+                1
+                for h in history
+                if eligible(h)
+                and str(_section(h, "billing").get("email") or "").strip().lower() == order_email
+            )
+            if same_email >= self.velocity_count:
+                add(
+                    "velocity_email",
+                    f"{same_email} prior orders from {_mask_email(order_email)} {window_phrase}",
+                )
+
+        if order_ip:
+            same_ip = sum(
+                1
+                for h in history
+                if eligible(h) and str(h.get("customer_ip_address") or "").strip() == order_ip
+            )
+            if same_ip >= self.velocity_count:
+                add(
+                    "velocity_ip",
+                    f"{same_ip} prior orders from IP {_mask_ip(order_ip)} {window_phrase}",
+                )
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+
+
+def format_assessment(assessment: FraudAssessment) -> str:
+    """Render a :class:`FraudAssessment` as a markdown summary (for the MCP tool / logs)."""
+    lines = [
+        f"## Fraud Risk — order {assessment.order_id or 'n/a'}",
+        f"Score: **{assessment.score}/100** | Level: **{assessment.level.name}** | "
+        f"Action: **{assessment.recommended_action}**",
+        "",
+    ]
+    if not assessment.signals:
+        lines.append("No risk signals triggered.")
+        return "\n".join(lines)
+
+    lines.append("| Rule | Weight | Detail |")
+    lines.append("|------|--------|--------|")
+    for s in sorted(assessment.signals, key=lambda x: -x.weight):
+        lines.append(f"| {_md_cell(s.rule)} | {_md_cell(s.weight)} | {_md_cell(s.detail)} |")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "FraudAssessment",
+    "FraudScorer",
+    "RiskLevel",
+    "RiskSignal",
+    "format_assessment",
+]

--- a/tasks/todo-tier2-agent-gaps.md
+++ b/tasks/todo-tier2-agent-gaps.md
@@ -1,0 +1,41 @@
+# Tier-2 Agent Gaps — Net-New Build (ticket #17660)
+
+Verified state: `project_agent_gaps_verified_2026_06_20`. ROI order, founder-directed.
+Architecture: deterministic AI-free core (`services/`), advisory/read-only, fail-closed,
+never-raises, founder-tunable thresholds. Mirrors `monitoring/fleet_observer.py`. Any LLM/
+embedding sits behind a narrow injected port; the no-LLM path ships by default. NO live
+WC/Klaviyo writes (advisory payloads only).
+
+## Gap 4 — Fraud / Chargeback risk (ABSENT → BUILT ✅)
+- [x] `services/risk/fraud.py` — `FraudScorer` (11 weighted signals → score/level/action)
+- [x] `tests/services/test_fraud_risk.py` — 53 tests
+- [x] MCP `devskyy_fraud_assess`
+- [x] Adversarial review (16 confirmed → all 15 actionable fixed; 1 accepted) — bug-150
+
+## Gap 5 — Customer Lifecycle / Retention (fragmented → UNIFIED ✅)
+- [x] `services/lifecycle/retention.py` — RFM + lifecycle-stage + churn-risk scorer
+- [x] `tests/services/test_retention.py` — 34 tests
+- [x] MCP `devskyy_retention_assess`; wired `analytics_agent.segment_customers` RFM fallback
+- [x] Review fixed: LOYAL reachable through inter-drop window; churn=0 when no purchases; datetime parse
+
+## Gap 3 — Drop / Demand Forecasting (stub → REAL ✅)
+- [x] `services/forecasting/demand.py` — velocity/trend/sellout forecaster
+- [x] `tests/services/test_demand_forecast.py` — 31 tests
+- [x] Wired `analytics_agent.forecast_sales` → deterministic fallback (no more "not available")
+- [x] MCP `devskyy_demand_forecast`; `tests/agents/test_analytics_forecast_wiring.py` — 8 tests
+- [x] Review fixed: pre-order suppresses CRITICAL; today excluded from velocity; 30d projection fixed
+
+## Gap 6 — Personalization / Recommendation (ABSENT → BUILT ✅)
+- [x] `services/personalization/recommender.py` — per-user reranker (content + co-purchase
+      + popularity cold-start; optional `SimilarityBackend` port for Pinecone)
+- [x] `tests/services/test_recommender.py` — 28 tests
+- [x] MCP `devskyy_recommend`
+- [x] Review fixed: popularity log-scaled (no swamp); price=0 not dropped; similarity_k fanout
+
+## Status — COMPLETE
+148 new tests green · 228 core-agents regression green · ruff/black/mypy clean on all new code ·
+4 new MCP tools registered (56 total, count now dynamic) · NOT committed (matches Tier-1).
+Two adversarial reviews run: fraud (16 findings → bug-150), Tier-2 trio (43 findings → bug-151).
+Founder decides commit. Deferred-by-design (founder-tunable, accepted): churn/stage as
+complementary signals; co-purchase raw count; `.name` enum serialization; ML/Pinecone upgrades
+behind the injected ports.

--- a/tests/agents/test_analytics_forecast_wiring.py
+++ b/tests/agents/test_analytics_forecast_wiring.py
@@ -1,0 +1,106 @@
+"""Wiring tests: analytics_agent forecast/segment now fall back to the deterministic cores
+instead of returning the old ``{"error": "ML module not available"}`` dead end.
+
+The agent is constructed via ``__new__`` to bypass heavy LLM/config init — these tests target
+only the fallback branches, which depend solely on ``self.ml_module`` being None.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agents.analytics_agent import AnalyticsAgent
+
+NOW = datetime.now(UTC)
+
+
+def _agent_without_ml() -> AnalyticsAgent:
+    inst = AnalyticsAgent.__new__(AnalyticsAgent)
+    inst.ml_module = None  # type: ignore[attr-defined]
+    return inst
+
+
+@pytest.mark.asyncio
+async def test_forecast_sales_uses_deterministic_fallback():
+    sales = [
+        {"date": (NOW - timedelta(days=d)).date().isoformat(), "units": 2} for d in range(1, 15)
+    ]
+    product = {"sku": "br-001", "sales": sales, "inventory": 20}
+    res = await _agent_without_ml().forecast_sales(product=product)
+
+    assert res["method"] == "deterministic_velocity"
+    assert res["sku"] == "br-001"
+    assert res["daily_velocity"] > 0
+    assert "sellout_risk" in res
+    assert "error" not in res
+
+
+@pytest.mark.asyncio
+async def test_forecast_sales_no_data_is_graceful_not_error():
+    res = await _agent_without_ml().forecast_sales()
+    assert res["forecast"] is None
+    assert "note" in res
+    assert "error" not in res
+
+
+@pytest.mark.asyncio
+async def test_segment_customers_uses_deterministic_rfm():
+    customers = [
+        {
+            "id": 1,
+            "orders": [
+                {"date_created": (NOW - timedelta(days=400)).date().isoformat(), "total": "120"}
+            ],
+        },
+        {
+            "id": 2,
+            "orders": [
+                {"date_created": (NOW - timedelta(days=5)).date().isoformat(), "total": "300"}
+            ],
+        },
+    ]
+    res = await _agent_without_ml().segment_customers(customers=customers)
+    assert res["engine"] == "deterministic_rfm"
+    assert len(res["segments"]) == 2
+    assert sum(res["segment_counts"].values()) == 2
+    assert "error" not in res
+
+
+@pytest.mark.asyncio
+async def test_segment_customers_no_data_is_graceful():
+    res = await _agent_without_ml().segment_customers()
+    assert res["segments"] == []
+    assert "note" in res
+    assert "error" not in res
+
+
+@pytest.mark.asyncio
+async def test_segment_customers_deterministic_with_as_of():
+    customers = [
+        {"id": 1, "orders": [{"date_created": "2026-03-01T00:00:00", "total": "120"}]},
+    ]
+    a = await _agent_without_ml().segment_customers(customers=customers, as_of=NOW)
+    b = await _agent_without_ml().segment_customers(customers=customers, as_of=NOW)
+    assert a == b
+
+
+@pytest.mark.asyncio
+async def test_segment_customers_rejects_non_rfm_method():
+    customers = [{"id": 1, "orders": []}]
+    res = await _agent_without_ml().segment_customers(method="behavioral", customers=customers)
+    assert res["segments"] == []
+    assert "note" in res
+    assert "error" not in res
+
+
+@pytest.mark.asyncio
+async def test_forecast_sales_deterministic_with_as_of():
+    sales = [
+        {"date": (NOW - timedelta(days=d)).date().isoformat(), "units": 2} for d in range(1, 15)
+    ]
+    product = {"sku": "br-001", "sales": sales, "inventory": 20}
+    a = await _agent_without_ml().forecast_sales(product=product, as_of=NOW)
+    b = await _agent_without_ml().forecast_sales(product=product, as_of=NOW)
+    assert a == b

--- a/tests/agents/test_copy_eval_wiring.py
+++ b/tests/agents/test_copy_eval_wiring.py
@@ -1,0 +1,120 @@
+"""Wiring tests for the opt-in copy-quality gate in SkyyRoseContentAgent.
+
+The gate is soft-signal and OFF by default (COPY_EVAL_ENABLED). These tests cover the
+seam without any live LLM: brief construction maps brand fields, the gate is a no-op when
+disabled, and when enabled it records the verdict into content.metadata and never blocks.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agents.skyyrose_content_agent import (
+    BrandDNA,
+    ContentRequest,
+    ContentType,
+    GeneratedContent,
+    SkyyRoseContentAgent,
+)
+from evaluation.contracts import Verdict
+from orchestration.brand_context import Collection
+
+
+@pytest.fixture
+def agent() -> SkyyRoseContentAgent:
+    with patch("agents.skyyrose_content_agent.BrandContextInjector") as mock_injector:
+        mock_injector.return_value = MagicMock()
+        a = SkyyRoseContentAgent()
+    a._brand_dna = BrandDNA()
+    return a
+
+
+@pytest.fixture
+def request_obj() -> ContentRequest:
+    return ContentRequest(
+        content_type=ContentType.COLLECTION_PAGE,
+        collection=Collection.BLACK_ROSE,
+        title="Black Rose Crewneck",
+        additional_direction="armor, not lifestyle",
+    )
+
+
+def _content() -> GeneratedContent:
+    return GeneratedContent(
+        content_type=ContentType.COLLECTION_PAGE,
+        collection=Collection.BLACK_ROSE,
+        title="Black Rose Crewneck",
+        body_html="<p>Luxury Grows from Concrete. The Black Rose Crewneck is armor.</p>",
+    )
+
+
+def test_build_copy_brief_maps_brand_fields(agent, request_obj):
+    brief = agent._build_copy_brief(_content(), request_obj)
+    assert brief.collection == Collection.BLACK_ROSE.value
+    assert brief.content_type == request_obj.content_type.value
+    assert brief.product_name == request_obj.title
+    assert brief.additional_direction == "armor, not lifestyle"
+    assert "SKYYROSE" in brief.brand_voice_context  # pulled from BrandDNA.to_prompt_context()
+
+
+@pytest.mark.asyncio
+async def test_maybe_eval_copy_disabled_is_noop(agent, request_obj, monkeypatch):
+    monkeypatch.delenv("COPY_EVAL_ENABLED", raising=False)
+
+    class _Boom:
+        async def evaluate(self, **_):
+            raise AssertionError("evaluator must not run when COPY_EVAL_ENABLED is unset")
+
+    content = _content()
+    out = await agent._maybe_eval_copy(content, request_obj, evaluator=_Boom())
+
+    assert out is content
+    assert "copy_eval" not in content.metadata
+
+
+@pytest.mark.asyncio
+async def test_maybe_eval_copy_enabled_records_verdict_and_never_blocks(
+    agent, request_obj, monkeypatch
+):
+    monkeypatch.setenv("COPY_EVAL_ENABLED", "1")
+
+    class _Fake:
+        async def evaluate(self, *, subject, ref):
+            assert "armor" in subject  # the body_html is what gets judged
+            return Verdict(
+                domain="copy",
+                passed=False,
+                score=0.42,
+                gate_results={},
+                failure_tags=("voice_drift",),
+                reason="too hedged",
+                cost_usd=0.004,
+            )
+
+    content = _content()
+    out = await agent._maybe_eval_copy(content, request_obj, evaluator=_Fake())
+
+    assert out is content  # soft-signal: failing copy is still returned, never blocked
+    record = content.metadata["copy_eval"]
+    assert record["passed"] is False
+    assert record["score"] == 0.42
+    assert record["failure_tags"] == ["voice_drift"]
+    assert record["cost_usd"] == 0.004
+
+
+@pytest.mark.asyncio
+async def test_maybe_eval_copy_judge_exception_does_not_block(agent, request_obj, monkeypatch):
+    """A crashing judge must NOT abort generation — soft-signal records the error and returns."""
+    monkeypatch.setenv("COPY_EVAL_ENABLED", "1")
+
+    class _Boom:
+        async def evaluate(self, *, subject, ref):
+            raise RuntimeError("judge unreachable")
+
+    content = _content()
+    out = await agent._maybe_eval_copy(content, request_obj, evaluator=_Boom())
+
+    assert out is content  # never blocks, even when the evaluator crashes
+    assert "error" in content.metadata["copy_eval"]

--- a/tests/quality/test_copy_adapter.py
+++ b/tests/quality/test_copy_adapter.py
@@ -1,0 +1,250 @@
+"""CopyAdapter unit tests — the copy/content domain adapter for the evaluation core.
+
+Mirrors tests/quality/test_imagery_adapter.py style: inline helpers, constructor-injected
+fake judge, tmp_path for file I/O, no conftest. The adapter scores SkyyRose copy against
+brand canon (voice, collection-canon attribution, no urgency theatre, name-not-SKU, etc.).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from evaluation.adapter import DomainAdapter
+from evaluation.domains.copy import _DIMENSIONS, COPY_TOOL, CopyAdapter, CopyBrief
+
+
+def _brief(
+    collection: str | None = None,
+    content_type: str = "product_description",
+    product_name: str | None = "Black Rose Crewneck",
+) -> CopyBrief:
+    return CopyBrief(
+        collection=collection,
+        content_type=content_type,
+        product_name=product_name,
+        brand_voice_context="Declarative fragments. Refusal as posture. No hedging.",
+        additional_direction="",
+    )
+
+
+def _good_output(**overrides) -> dict:
+    out = {
+        "brand_analysis": "The copy opens with a declarative fragment, no hedging.",
+        "brand_voice_fidelity": 5,
+        "correct_collection_canon": 5,
+        "garment_as_protagonist": 5,
+        "no_urgency_theatre": 5,
+        "no_related_products_push": 5,
+        "name_not_sku_referencing": 5,
+        "canonical_tagline_only": 5,
+        "oakland_anchoring": 5,
+        "failure_tags": [],
+        "reason": "clean",
+    }
+    out.update(overrides)
+    return out
+
+
+# --- tool schema ---------------------------------------------------------------
+
+
+def test_copy_tool_schema_has_brand_analysis_first_and_eight_dimensions():
+    props = COPY_TOOL["input_schema"]["properties"]
+    assert list(props.keys())[0] == "brand_analysis"
+    for dim in _DIMENSIONS:
+        assert dim in props
+    assert len(_DIMENSIONS) == 8
+
+
+def test_copy_tool_required_and_additional_properties_closed():
+    schema = COPY_TOOL["input_schema"]
+    assert COPY_TOOL["name"] == "copy_qc_verdict"
+    assert schema["additionalProperties"] is False
+    required = set(schema["required"])
+    assert {"brand_analysis", "failure_tags", "reason"} <= required
+    assert set(_DIMENSIONS) <= required
+
+
+# --- deterministic checks (free, no LLM) ---------------------------------------
+
+
+def test_deterministic_check_retired_tagline():
+    tags = CopyAdapter().deterministic_checks("Where Love Meets Luxury is our promise.", _brief())
+    assert "retired_tagline_present" in tags
+
+
+def test_deterministic_check_urgency_markers():
+    tags = CopyAdapter().deterministic_checks("Only 3 left! Buy before selling fast.", _brief())
+    assert "urgency_timer_present" in tags
+
+
+def test_deterministic_check_sku_first_naming():
+    tags = CopyAdapter().deterministic_checks("br-001 is now available to shop.", _brief())
+    assert "sku_first_naming" in tags
+
+
+def test_deterministic_check_sku_parenthetical_is_allowed():
+    """A SKU as a parenthetical backend key right after the name is permitted."""
+    clean = "The Black Rose Crewneck (br-001) is armor."
+    assert CopyAdapter().deterministic_checks(clean, _brief()) == []
+
+
+def test_deterministic_check_related_products_push():
+    tags = CopyAdapter().deterministic_checks("You may also like the Black Rose Bomber.", _brief())
+    assert "related_products_push" in tags
+
+
+def test_deterministic_checks_clean_copy_returns_empty_list():
+    clean = "Luxury Grows from Concrete. The Black Rose Crewneck is armor."
+    assert CopyAdapter().deterministic_checks(clean, _brief()) == []
+
+
+def test_deterministic_check_unrelated_products_not_flagged():
+    """'unrelated products' must NOT trip the related-products substring match."""
+    text = "Browse unrelated products from our sister lineup."
+    assert "related_products_push" not in CopyAdapter().deterministic_checks(text, _brief())
+
+
+def test_deterministic_check_sku_parenthetical_with_spaces_allowed():
+    """A SKU in a spaced parenthetical, e.g. '( br-001 )', is still a backend key."""
+    clean = "The Black Rose Crewneck ( br-001 ) is armor."
+    assert CopyAdapter().deterministic_checks(clean, _brief()) == []
+
+
+# --- parse_verdict -------------------------------------------------------------
+
+
+def test_parse_verdict_all_perfect_scores_passes():
+    v = CopyAdapter().parse_verdict(_good_output(), [])
+    assert v.passed is True
+    assert v.score == 1.0
+    assert v.domain == "copy"
+    assert dict(v.gate_results) == dict.fromkeys(_DIMENSIONS, 5)
+
+
+def test_parse_verdict_oakland_zero_still_passes():
+    """Dropping only the 0.05-weight dimension to 0 → composite 0.95, still passes."""
+    v = CopyAdapter().parse_verdict(_good_output(oakland_anchoring=0), [])
+    assert v.passed is True
+    assert round(v.score, 2) == 0.95
+
+
+def test_parse_verdict_weighted_score_below_threshold_fails():
+    """Two 0.20-weight dimensions at 0 → composite 0.60, below the 0.80 floor."""
+    v = CopyAdapter().parse_verdict(
+        _good_output(brand_voice_fidelity=0, correct_collection_canon=0), []
+    )
+    assert v.passed is False
+    assert round(v.score, 2) == 0.60
+
+
+def test_parse_verdict_hard_fail_tag_overrides_high_score():
+    """A hard-fail tag fails the verdict even when every dimension scores 5."""
+    out = _good_output(failure_tags=["retired_tagline_present"])
+    v = CopyAdapter().parse_verdict(out, [])
+    assert v.passed is False
+    assert "retired_tagline_present" in v.failure_tags
+
+
+def test_parse_verdict_missing_dimension_is_zero():
+    out = _good_output(correct_collection_canon=0)
+    del out["brand_voice_fidelity"]
+    v = CopyAdapter().parse_verdict(out, [])
+    assert v.gate_results["brand_voice_fidelity"] == 0
+    assert v.passed is False  # 0+0 on the two 0.20 dims drags composite to 0.60
+
+
+def test_parse_verdict_detail_contains_brand_analysis():
+    out = _good_output(brand_analysis="The copy opens with a declarative fragment.")
+    v = CopyAdapter().parse_verdict(out, [])
+    assert v.detail["brand_analysis"].startswith("The copy opens")
+
+
+def test_parse_verdict_does_not_set_cost_or_attempts():
+    """Core stamps cost_usd/attempts via replace(); the adapter leaves them at defaults."""
+    v = CopyAdapter().parse_verdict(_good_output(), [])
+    assert v.cost_usd == 0.0
+    assert v.attempts == 0
+
+
+def test_parse_verdict_carries_deterministic_failures():
+    v = CopyAdapter().parse_verdict(_good_output(), ["sku_first_naming"])
+    assert "sku_first_naming" in v.failure_tags
+    assert v.passed is False
+
+
+# --- build_judge_request -------------------------------------------------------
+
+
+def test_build_judge_request_structure():
+    req = CopyAdapter().build_judge_request("Black Rose Crewneck.", _brief(collection="black_rose"))
+    assert req["tool"]["name"] == "copy_qc_verdict"
+    msg = req["messages"][0]
+    assert msg["role"] == "user"
+    assert msg["content"][0]["type"] == "text"
+
+
+def test_build_judge_request_embeds_subject_and_collection():
+    subject = "Luxury Grows from Concrete."
+    req = CopyAdapter().build_judge_request(subject, _brief(collection="black_rose"))
+    text = req["messages"][0]["content"][0]["text"]
+    assert subject in text
+    assert "black_rose" in text
+
+
+# --- revise (regenerate_fn injection seam) -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revise_calls_regenerate_fn_with_ref_and_critique():
+    captured = {}
+
+    async def regenerate_fn(ref, critique):
+        captured["ref"] = ref
+        captured["critique"] = critique
+        return "revised copy"
+
+    adapter = CopyAdapter(regenerate_fn=regenerate_fn)
+    critique = {"failure_tags": ("voice_drift",), "reason": "hedging", "detail": {}}
+    result = await adapter.revise(_brief(), critique)
+
+    assert result == "revised copy"
+    assert captured["critique"] == critique
+
+
+@pytest.mark.asyncio
+async def test_revise_without_regenerate_fn_raises():
+    with pytest.raises(NotImplementedError):
+        await CopyAdapter().revise(_brief(), {"failure_tags": (), "reason": "", "detail": {}})
+
+
+# --- load_ground_truth ---------------------------------------------------------
+
+
+def test_load_ground_truth_from_json_file(tmp_path):
+    state = {
+        "hero-copy-v1": {"approved": True, "flagged": False, "comment": "clean"},
+        "pdp-v2": {"approved": True, "flagged": True, "comment": "urgency theatre"},
+    }
+    f = tmp_path / "copy-review-state.json"
+    f.write_text(json.dumps(state), encoding="utf-8")
+
+    gt = {row["subject_id"]: row for row in CopyAdapter(review_state_path=f).load_ground_truth()}
+
+    assert gt["hero-copy-v1"]["label_pass"] is True
+    assert gt["pdp-v2"]["label_pass"] is False  # flagged overrides approved
+
+
+def test_load_ground_truth_empty_when_file_missing(tmp_path):
+    missing = tmp_path / "nope.json"
+    assert CopyAdapter(review_state_path=missing).load_ground_truth() == []
+
+
+# --- protocol conformance ------------------------------------------------------
+
+
+def test_copy_adapter_satisfies_domain_adapter_protocol():
+    assert isinstance(CopyAdapter(), DomainAdapter)
+    assert CopyAdapter().domain == "copy"

--- a/tests/quality/test_copy_evaluator_e2e.py
+++ b/tests/quality/test_copy_evaluator_e2e.py
@@ -1,0 +1,125 @@
+"""End-to-end: CopyEvaluator -> EvaluationCore -> judge -> Verdict.
+
+Mirrors tests/quality/test_render_fidelity_e2e.py. Four scenarios:
+1. Deterministic hard-fail (retired tagline) — blocks the paid judge entirely.
+2. Clean copy — full pass-through to a fake judge, verdict passes.
+3. gate() revise loop — first judge call fails, regenerate, second passes (attempts=1).
+4. gate() cap — judge never passes, attempts caps at the configured limit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from evaluation.agents import CopyEvaluator
+from evaluation.domains.copy import CopyAdapter, CopyBrief
+
+
+def _brief(collection: str | None = "black_rose") -> CopyBrief:
+    return CopyBrief(
+        collection=collection,
+        content_type="product_description",
+        product_name="Black Rose Crewneck",
+        brand_voice_context="Declarative fragments. Refusal as posture.",
+        additional_direction="",
+    )
+
+
+def _good_output(**overrides) -> dict:
+    out = {
+        "brand_analysis": "Declarative, no hedging, garment named.",
+        "brand_voice_fidelity": 5,
+        "correct_collection_canon": 5,
+        "garment_as_protagonist": 5,
+        "no_urgency_theatre": 5,
+        "no_related_products_push": 5,
+        "name_not_sku_referencing": 5,
+        "canonical_tagline_only": 5,
+        "oakland_anchoring": 5,
+        "failure_tags": [],
+        "reason": "clean",
+    }
+    out.update(overrides)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_deterministic_hard_fail_blocks_judge():
+    """Retired tagline trips the deterministic gate; the paid judge is never invoked."""
+    called = {"judge": False}
+
+    def judge(req):
+        called["judge"] = True
+        return ({}, 0.0)
+
+    agent = CopyEvaluator(judge_fn=judge)
+    v = await agent.evaluate(subject="Where Love Meets Luxury.", ref=_brief())
+
+    assert v.passed is False
+    assert "retired_tagline_present" in v.failure_tags
+    assert called["judge"] is False
+
+
+@pytest.mark.asyncio
+async def test_clean_copy_passes_through_judge():
+    """No deterministic failures -> judge called -> verdict passes with score 1.0."""
+
+    def judge(req):
+        return (_good_output(brand_analysis="navy crewneck, declarative voice"), 0.012)
+
+    agent = CopyEvaluator(judge_fn=judge)
+    v = await agent.evaluate(
+        subject="Luxury Grows from Concrete. The Black Rose Crewneck is armor.",
+        ref=_brief(),
+    )
+
+    assert v.passed is True
+    assert v.score == 1.0
+    assert v.cost_usd == 0.012
+    assert v.detail["brand_analysis"].startswith("navy")
+
+
+@pytest.mark.asyncio
+async def test_gate_revises_once_then_passes():
+    """First score fails on voice; revise regenerates; second score passes (attempts=1)."""
+    calls = {"judge": 0, "regen": 0}
+
+    def judge(req):
+        calls["judge"] += 1
+        if calls["judge"] == 1:
+            return (_good_output(brand_voice_fidelity=1, correct_collection_canon=1), 0.004)
+        return (_good_output(), 0.004)
+
+    async def regenerate_fn(ref, critique):
+        calls["regen"] += 1
+        return "Luxury Grows from Concrete. The Black Rose Crewneck is armor."
+
+    async def producer(ref):
+        return "Initial draft, weak voice."
+
+    agent = CopyEvaluator(judge_fn=judge, adapter=CopyAdapter(regenerate_fn=regenerate_fn))
+    v = await agent.gate(ref=_brief(), producer=producer, cap=2)
+
+    assert v.passed is True
+    assert v.attempts == 1
+    assert calls["regen"] == 1
+
+
+@pytest.mark.asyncio
+async def test_gate_caps_revisions_when_never_passes():
+    """Judge never passes -> attempts caps at `cap` and the verdict stays failed."""
+
+    def judge(req):
+        return (_good_output(brand_voice_fidelity=0, correct_collection_canon=0), 0.004)
+
+    async def regenerate_fn(ref, critique):
+        return "still weak draft"
+
+    async def producer(ref):
+        return "weak draft"
+
+    agent = CopyEvaluator(judge_fn=judge, adapter=CopyAdapter(regenerate_fn=regenerate_fn))
+    v = await agent.gate(ref=_brief(), producer=producer, cap=2)
+
+    assert v.passed is False
+    assert v.attempts == 2

--- a/tests/services/test_demand_forecast.py
+++ b/tests/services/test_demand_forecast.py
@@ -1,0 +1,257 @@
+"""Tests for services.forecasting.demand — deterministic velocity/sellout forecaster.
+
+Contract: deterministic given ``as_of``, never-raises, advisory.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from services.forecasting.demand import (
+    DemandForecast,
+    DemandForecaster,
+    SelloutRisk,
+    Trend,
+    format_forecast,
+)
+
+AS_OF = datetime(2026, 6, 20, 12, 0, tzinfo=UTC)
+
+
+def _daily(units_per_day, start_day, end_day):
+    """Sale entries for each day in [start_day, end_day] before AS_OF."""
+    out = []
+    for d in range(start_day, end_day + 1):
+        date = (AS_OF - timedelta(days=d)).date().isoformat()
+        out.append({"date": date, "units": units_per_day})
+    return out
+
+
+def _product(sales, **fields):
+    p = {"sku": "br-001", "sales": sales}
+    p.update(fields)
+    return p
+
+
+# --------------------------------------------------------------------------- #
+# Velocity + trend
+# --------------------------------------------------------------------------- #
+
+
+def test_steady_velocity_and_trend():
+    sales = _daily(2, 1, 28)  # 2/day for 28 days
+    f = DemandForecaster().forecast(_product(sales), as_of=AS_OF)
+    assert isinstance(f, DemandForecast)
+    assert f.daily_velocity == pytest.approx(2.0)
+    assert f.trend is Trend.STEADY
+    assert f.forecast_units_30d == 60
+
+
+def test_accelerating_trend():
+    sales = _daily(4, 1, 14) + _daily(2, 15, 28)  # recent hotter than prior
+    f = DemandForecaster().forecast(_product(sales), as_of=AS_OF)
+    assert f.trend is Trend.ACCELERATING
+    assert f.daily_velocity == pytest.approx(4.0)
+
+
+def test_declining_trend():
+    sales = _daily(1, 1, 14) + _daily(3, 15, 28)
+    f = DemandForecaster().forecast(_product(sales), as_of=AS_OF)
+    assert f.trend is Trend.DECLINING
+
+
+def test_no_sales_is_no_data():
+    f = DemandForecaster().forecast(_product([]), as_of=AS_OF)
+    assert f.trend is Trend.NO_DATA
+    assert f.daily_velocity == 0.0
+    assert f.sellout_risk is SelloutRisk.NONE
+    assert f.recommended_action == "no_action"
+    assert f.days_to_sellout is None
+
+
+# --------------------------------------------------------------------------- #
+# Sellout + reorder
+# --------------------------------------------------------------------------- #
+
+
+def test_days_to_sellout_computed():
+    sales = _daily(2, 1, 28)  # velocity 2/day
+    f = DemandForecaster().forecast(_product(sales, inventory=20), as_of=AS_OF)
+    assert f.days_to_sellout == pytest.approx(10.0)
+
+
+def test_sellout_critical_when_below_lead_time():
+    sales = _daily(2, 1, 28)  # 2/day -> 20 units sells out in 10d < 14d lead time
+    f = DemandForecaster(lead_time_days=14).forecast(_product(sales, inventory=20), as_of=AS_OF)
+    assert f.sellout_risk is SelloutRisk.CRITICAL
+    assert f.recommended_action == "reorder_now"
+
+
+def test_sellout_low_when_plenty_of_stock():
+    sales = _daily(1, 1, 28)  # 1/day, 1000 units -> 1000 days
+    f = DemandForecaster().forecast(_product(sales, inventory=1000), as_of=AS_OF)
+    assert f.sellout_risk is SelloutRisk.LOW
+    assert f.recommended_action == "no_action"
+
+
+def test_inventory_from_stock_quantity_field():
+    sales = _daily(2, 1, 28)
+    f = DemandForecaster(lead_time_days=14).forecast(
+        _product(sales, stock_quantity=20), as_of=AS_OF
+    )
+    assert f.days_to_sellout == pytest.approx(10.0)
+
+
+def test_units_from_quantity_and_date_created_aliases():
+    sales = [
+        {"date_created": (AS_OF - timedelta(days=d)).date().isoformat(), "quantity": 2}
+        for d in range(1, 29)
+    ]
+    f = DemandForecaster().forecast(_product(sales), as_of=AS_OF)
+    assert f.daily_velocity == pytest.approx(2.0)
+
+
+# --------------------------------------------------------------------------- #
+# Robustness
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {},
+        {"sales": None},
+        {"sales": "nope"},
+        {"sales": [None, "x", {"date": "garbage", "units": "x"}]},
+        {"sales": [{"units": 5}]},  # no date
+        {"sales": _daily(2, 1, 28), "inventory": "nope"},
+        {"sales": _daily(2, 1, 28), "inventory": -5},
+    ],
+)
+def test_never_raises_on_garbage(bad):
+    f = DemandForecaster().forecast(bad, as_of=AS_OF)
+    assert isinstance(f, DemandForecast)
+    assert f.daily_velocity >= 0.0
+
+
+def test_none_product_does_not_raise():
+    f = DemandForecaster().forecast(None, as_of=AS_OF)  # type: ignore[arg-type]
+    assert f.trend is Trend.NO_DATA
+
+
+def test_zero_velocity_no_division_error():
+    f = DemandForecaster().forecast(_product([], inventory=50), as_of=AS_OF)
+    assert f.days_to_sellout is None
+    assert f.sellout_risk is SelloutRisk.NONE
+
+
+# --------------------------------------------------------------------------- #
+# Determinism + immutability + serialization
+# --------------------------------------------------------------------------- #
+
+
+def test_deterministic():
+    p = _product(_daily(2, 1, 28), inventory=20)
+    assert DemandForecaster().forecast(p, as_of=AS_OF) == DemandForecaster().forecast(
+        p, as_of=AS_OF
+    )
+
+
+def test_frozen():
+    f = DemandForecaster().forecast(_product([]), as_of=AS_OF)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        f.daily_velocity = 9.0  # type: ignore[misc]
+
+
+def test_as_dict_json_safe():
+    import json
+
+    f = DemandForecaster(lead_time_days=14).forecast(
+        _product(_daily(2, 1, 28), inventory=20), as_of=AS_OF
+    )
+    payload = f.as_dict()
+    json.dumps(payload)
+    assert payload["sku"] == "br-001"
+    assert payload["trend"] == f.trend.name
+    assert payload["sellout_risk"] == f.sellout_risk.name
+    assert payload["recommended_action"] == f.recommended_action
+
+
+def test_forecast_units_method_arbitrary_horizon():
+    f = DemandForecaster().forecast(_product(_daily(2, 1, 28)), as_of=AS_OF)
+    assert f.forecast_units(7) == 14
+    assert f.forecast_units(0) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Tunability + preorder
+# --------------------------------------------------------------------------- #
+
+
+def test_window_tunable():
+    # 5/day only in the last 3 days, nothing before.
+    sales = _daily(5, 1, 3)
+    wide = DemandForecaster(window_days=28).forecast(_product(sales), as_of=AS_OF)
+    narrow = DemandForecaster(window_days=3).forecast(_product(sales), as_of=AS_OF)
+    assert narrow.daily_velocity > wide.daily_velocity
+
+
+def test_preorder_flag_surfaced():
+    f = DemandForecaster().forecast(
+        _product(_daily(3, 1, 14), is_preorder=True, inventory=80), as_of=AS_OF
+    )
+    assert f.is_preorder is True
+
+
+def test_format_renders_markdown():
+    f = DemandForecaster(lead_time_days=14).forecast(
+        _product(_daily(2, 1, 28), inventory=20), as_of=AS_OF
+    )
+    text = format_forecast(f)
+    assert "Demand Forecast" in text
+    assert "br-001" in text
+
+
+# --------------------------------------------------------------------------- #
+# Regression: adversarial-review fixes
+# --------------------------------------------------------------------------- #
+
+
+def test_preorder_suppresses_critical_sellout():
+    """Pre-orders are made-to-order — fast sell-through is good, not a reorder emergency."""
+    f = DemandForecaster(lead_time_days=14).forecast(
+        _product(_daily(2, 1, 28), inventory=2, is_preorder=True), as_of=AS_OF
+    )
+    assert f.is_preorder is True
+    assert f.sellout_risk is SelloutRisk.NONE
+    assert f.recommended_action == "no_action"
+
+
+def test_today_partial_day_excluded_from_velocity():
+    # Only today (recency 0) has sales → excluded → velocity 0, NO_DATA.
+    sales = [{"date": AS_OF.date().isoformat(), "units": 50}]
+    f = DemandForecaster().forecast(_product(sales), as_of=AS_OF)
+    assert f.daily_velocity == 0.0
+    assert f.trend is Trend.NO_DATA
+
+
+def test_forecast_units_30d_is_always_30_days():
+    f = DemandForecaster(window_days=7).forecast(_product(_daily(2, 1, 28)), as_of=AS_OF)
+    assert f.forecast_units_30d == f.forecast_units(30)
+    assert f.forecast_units_30d == 60  # velocity 2/day * 30
+
+
+def test_zero_inventory_active_velocity_is_critical():
+    f = DemandForecaster(lead_time_days=14).forecast(
+        _product(_daily(2, 1, 28), inventory=0), as_of=AS_OF
+    )
+    assert f.days_to_sellout == 0.0
+    assert f.sellout_risk is SelloutRisk.CRITICAL
+
+
+def test_parse_dt_accepts_datetime_objects():
+    sales = [{"date": AS_OF - timedelta(days=d), "units": 2} for d in range(1, 15)]
+    f = DemandForecaster().forecast(_product(sales), as_of=AS_OF)
+    assert f.daily_velocity == pytest.approx(2.0)

--- a/tests/services/test_fraud_risk.py
+++ b/tests/services/test_fraud_risk.py
@@ -1,0 +1,440 @@
+"""Tests for services.risk.fraud — deterministic fraud/chargeback risk scorer.
+
+Contract: pure, deterministic, never-raises, advisory-only. No LLM, no network.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from services.risk.fraud import (
+    FraudAssessment,
+    FraudScorer,
+    RiskLevel,
+    RiskSignal,
+    format_assessment,
+)
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+def _clean_order(**overrides) -> dict:
+    """A low-risk, fully-matched domestic order."""
+    order = {
+        "id": 1001,
+        "total": "120.00",
+        "currency": "USD",
+        "customer_id": 42,
+        "customer_ip_address": "73.15.4.9",
+        "date_created": "2026-06-20T10:00:00",
+        "billing": {
+            "first_name": "Corey",
+            "last_name": "Foster",
+            "email": "corey@example.com",
+            "country": "US",
+            "city": "Oakland",
+            "postcode": "94601",
+            "address_1": "1 Telegraph Ave",
+        },
+        "shipping": {
+            "first_name": "Corey",
+            "last_name": "Foster",
+            "country": "US",
+            "city": "Oakland",
+            "postcode": "94601",
+            "address_1": "1 Telegraph Ave",
+        },
+        "line_items": [{"quantity": 1, "name": "Black Rose Bomber"}],
+        "payment_method": "stripe",
+    }
+    order.update(overrides)
+    return order
+
+
+# --------------------------------------------------------------------------- #
+# Clean baseline
+# --------------------------------------------------------------------------- #
+
+
+def test_clean_order_is_low_risk_approve():
+    a = FraudScorer().assess(_clean_order())
+    assert isinstance(a, FraudAssessment)
+    assert a.score == 0
+    assert a.level is RiskLevel.LOW
+    assert a.recommended_action == "approve"
+    assert a.signals == ()
+    assert a.order_id == "1001"
+
+
+# --------------------------------------------------------------------------- #
+# Individual rules each fire
+# --------------------------------------------------------------------------- #
+
+
+def _rules(a: FraudAssessment) -> set[str]:
+    return {s.rule for s in a.signals}
+
+
+def test_country_mismatch_fires():
+    order = _clean_order()
+    order["shipping"] = {**order["shipping"], "country": "NG"}
+    a = FraudScorer().assess(order)
+    assert "billing_shipping_country_mismatch" in _rules(a)
+    assert a.score > 0
+
+
+def test_disposable_email_fires():
+    order = _clean_order()
+    order["billing"] = {**order["billing"], "email": "burner@mailinator.com"}
+    a = FraudScorer().assess(order)
+    assert "disposable_email" in _rules(a)
+
+
+def test_avs_mismatch_fires():
+    a = FraudScorer().assess(_clean_order(avs_result="N"))
+    assert "avs_mismatch" in _rules(a)
+
+
+def test_cvv_failure_fires():
+    a = FraudScorer().assess(_clean_order(cvv_result="N"))
+    assert "cvv_failure" in _rules(a)
+
+
+def test_avs_cvv_read_from_meta_data():
+    order = _clean_order(
+        meta_data=[
+            {"key": "_stripe_avs_result", "value": "N"},
+            {"key": "cvv_check", "value": "fail"},
+        ]
+    )
+    a = FraudScorer().assess(order)
+    assert "avs_mismatch" in _rules(a)
+    assert "cvv_failure" in _rules(a)
+
+
+def test_high_value_order_fires():
+    a = FraudScorer(high_value_threshold=100.0).assess(_clean_order(total="900.00"))
+    assert "high_value_order" in _rules(a)
+
+
+def test_guest_high_value_fires():
+    order = _clean_order(customer_id=0, total="400.00")
+    a = FraudScorer(mid_value_threshold=250.0).assess(order)
+    assert "guest_high_value" in _rules(a)
+
+
+def test_billing_name_mismatch_fires():
+    order = _clean_order()
+    order["shipping"] = {**order["shipping"], "first_name": "Someone", "last_name": "Else"}
+    a = FraudScorer().assess(order)
+    assert "mismatched_recipient_name" in _rules(a)
+
+
+def test_velocity_email_fires_from_history():
+    order = _clean_order()
+    email = order["billing"]["email"]
+    history = [
+        {"billing": {"email": email}, "date_created": "2026-06-20T09:30:00"},
+        {"billing": {"email": email}, "date_created": "2026-06-20T08:00:00"},
+        {"billing": {"email": email}, "date_created": "2026-06-20T07:00:00"},
+    ]
+    a = FraudScorer(velocity_count=3).assess(order, history=history)
+    assert "velocity_email" in _rules(a)
+
+
+def test_velocity_ip_fires_from_history():
+    order = _clean_order()
+    ip = order["customer_ip_address"]
+    history = [
+        {"customer_ip_address": ip, "date_created": "2026-06-20T09:30:00"},
+        {"customer_ip_address": ip, "date_created": "2026-06-20T08:00:00"},
+        {"customer_ip_address": ip, "date_created": "2026-06-20T07:00:00"},
+    ]
+    a = FraudScorer(velocity_count=3).assess(order, history=history)
+    assert "velocity_ip" in _rules(a)
+
+
+def test_email_gibberish_fires():
+    order = _clean_order()
+    # 8-char local part, mostly digits → machine-generated heuristic.
+    order["billing"] = {**order["billing"], "email": "8829471x@example.com"}
+    a = FraudScorer().assess(order)
+    assert "email_gibberish" in _rules(a)
+
+
+def test_address_mismatch_same_country_fires():
+    order = _clean_order()
+    order["shipping"] = {
+        **order["shipping"],
+        "address_1": "999 Somewhere Else Blvd",
+        "postcode": "10001",
+        "city": "New York",
+    }
+    a = FraudScorer().assess(order)
+    assert "address_mismatch" in _rules(a)
+    assert "billing_shipping_country_mismatch" not in _rules(a)  # same country
+
+
+def test_numeric_total_accepted():
+    a = FraudScorer(high_value_threshold=100.0).assess(_clean_order(total=900.0))
+    assert "high_value_order" in _rules(a)
+
+
+def test_velocity_ignores_orders_outside_window():
+    order = _clean_order()
+    email = order["billing"]["email"]
+    # All three are >24h before the order → must NOT trip a 24h window.
+    history = [
+        {"billing": {"email": email}, "date_created": "2026-06-18T09:30:00"},
+        {"billing": {"email": email}, "date_created": "2026-06-17T08:00:00"},
+        {"billing": {"email": email}, "date_created": "2026-06-16T07:00:00"},
+    ]
+    a = FraudScorer(velocity_count=3, velocity_window_hours=24).assess(order, history=history)
+    assert "velocity_email" not in _rules(a)
+
+
+# --------------------------------------------------------------------------- #
+# Score / level / action mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_score_is_clamped_to_100():
+    order = _clean_order(customer_id=0, total="5000.00", avs_result="N", cvv_result="N")
+    order["billing"] = {**order["billing"], "email": "x@guerrillamail.com"}
+    order["shipping"] = {**order["shipping"], "country": "NG", "first_name": "Z", "last_name": "Q"}
+    a = FraudScorer(high_value_threshold=100.0, mid_value_threshold=100.0).assess(order)
+    assert a.score == 100
+    assert a.level is RiskLevel.CRITICAL
+    assert a.recommended_action == "hold"
+
+
+@pytest.mark.parametrize(
+    "score,level,action",
+    [
+        (0, RiskLevel.LOW, "approve"),
+        (19, RiskLevel.LOW, "approve"),
+        (20, RiskLevel.MEDIUM, "approve"),
+        (49, RiskLevel.MEDIUM, "approve"),
+        (50, RiskLevel.HIGH, "review"),
+        (79, RiskLevel.HIGH, "review"),
+        (80, RiskLevel.CRITICAL, "hold"),
+        (100, RiskLevel.CRITICAL, "hold"),
+    ],
+)
+def test_level_and_action_thresholds(score, level, action):
+    assert FraudScorer.level_for(score) is level
+    assert FraudScorer.action_for(level) == action
+
+
+# --------------------------------------------------------------------------- #
+# Robustness — never raises
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {},
+        {"billing": None, "shipping": None},
+        {"total": "not-a-number"},
+        {"total": None},
+        {"billing": {"email": None}},
+        {"date_created": "garbage"},
+        {"line_items": "nope"},
+        {"meta_data": "nope"},
+    ],
+)
+def test_never_raises_on_garbage(bad):
+    a = FraudScorer().assess(bad)  # must not raise
+    assert isinstance(a, FraudAssessment)
+    assert 0 <= a.score <= 100
+
+
+def test_none_order_does_not_raise():
+    a = FraudScorer().assess(None)  # type: ignore[arg-type]
+    assert isinstance(a, FraudAssessment)
+    assert a.score == 0
+
+
+def test_none_history_is_fine():
+    a = FraudScorer().assess(_clean_order(), history=None)
+    assert a.signals == ()
+
+
+# --------------------------------------------------------------------------- #
+# Determinism + immutability
+# --------------------------------------------------------------------------- #
+
+
+def test_deterministic_same_input_same_output():
+    order = _clean_order(total="900.00", avs_result="N")
+    a1 = FraudScorer(high_value_threshold=100.0).assess(order)
+    a2 = FraudScorer(high_value_threshold=100.0).assess(order)
+    assert a1 == a2
+
+
+def test_assessment_is_frozen():
+    a = FraudScorer().assess(_clean_order())
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        a.score = 99  # type: ignore[misc]
+
+
+def test_signal_is_frozen():
+    s = RiskSignal(rule="x", weight=1, detail="d")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        s.weight = 2  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# Tunability
+# --------------------------------------------------------------------------- #
+
+
+def test_threshold_tunable_changes_outcome():
+    order = _clean_order(total="300.00")
+    assert "high_value_order" not in _rules(FraudScorer(high_value_threshold=500.0).assess(order))
+    assert "high_value_order" in _rules(FraudScorer(high_value_threshold=200.0).assess(order))
+
+
+def test_custom_disposable_domain():
+    order = _clean_order()
+    order["billing"] = {**order["billing"], "email": "a@evil.test"}
+    scorer = FraudScorer(extra_disposable_domains=("evil.test",))
+    assert "disposable_email" in _rules(scorer.assess(order))
+
+
+# --------------------------------------------------------------------------- #
+# Serialization / reporting
+# --------------------------------------------------------------------------- #
+
+
+def test_as_dict_is_json_safe():
+    import json
+
+    a = FraudScorer(high_value_threshold=100.0).assess(_clean_order(total="900.00"))
+    payload = a.as_dict()
+    json.dumps(payload)  # must not raise
+    assert payload["score"] == a.score
+    assert payload["level"] == a.level.name
+    assert payload["recommended_action"] == a.recommended_action
+    assert isinstance(payload["signals"], list)
+
+
+def test_format_assessment_renders_markdown():
+    a = FraudScorer(high_value_threshold=100.0).assess(_clean_order(total="900.00"))
+    text = format_assessment(a)
+    assert isinstance(text, str)
+    assert "Fraud Risk" in text
+    assert str(a.score) in text
+
+
+def test_format_assessment_no_signals():
+    a = FraudScorer().assess(_clean_order())
+    text = format_assessment(a)
+    assert "No risk signals" in text
+
+
+# --------------------------------------------------------------------------- #
+# Regression tests for the adversarial-review fixes
+# --------------------------------------------------------------------------- #
+
+
+def test_benign_international_gift_not_held():
+    """A legit first-time guest sending a $500+ gift abroad must NOT be flagged to review.
+
+    Country mismatch (15) + recipient-name mismatch (10) + high value (10) + guest high
+    value (10) = 45 → MEDIUM/approve. Calibrated so only a gateway signal escalates.
+    """
+    order = _clean_order(customer_id=0, total="600.00")
+    order["shipping"] = {
+        **order["shipping"],
+        "country": "GB",
+        "first_name": "Gift",
+        "last_name": "Recipient",
+    }
+    a = FraudScorer().assess(order)
+    assert a.score == 45
+    assert a.level is RiskLevel.MEDIUM
+    assert a.recommended_action == "approve"
+
+
+def test_gateway_signal_still_escalates_international():
+    """But the same order with an AVS failure must escalate to review."""
+    order = _clean_order(customer_id=0, total="600.00", avs_result="N")
+    order["shipping"] = {**order["shipping"], "country": "GB"}
+    a = FraudScorer().assess(order)
+    assert a.recommended_action in ("review", "hold")
+
+
+def test_bad_weight_value_does_not_raise():
+    order = _clean_order(cvv_result="N")
+    a = FraudScorer(weights={"cvv_failure": "thirty-five"}).assess(order)  # type: ignore[dict-item]
+    assert isinstance(a, FraudAssessment)
+    assert 0 <= a.score <= 100
+
+
+def test_naive_aware_velocity_still_fires():
+    order = _clean_order(date_created="2026-06-20T10:00:00+00:00")  # aware
+    email = order["billing"]["email"]
+    history = [  # naive timestamps (no offset) — must still count
+        {"billing": {"email": email}, "date_created": "2026-06-20T09:30:00"},
+        {"billing": {"email": email}, "date_created": "2026-06-20T08:00:00"},
+        {"billing": {"email": email}, "date_created": "2026-06-20T07:00:00"},
+    ]
+    a = FraudScorer(velocity_count=3).assess(order, history=history)
+    assert "velocity_email" in _rules(a)
+
+
+def test_velocity_detail_masks_pii():
+    order = _clean_order()
+    email = order["billing"]["email"]
+    history = [
+        {"billing": {"email": email}, "date_created": "2026-06-20T09:30:00"},
+        {"billing": {"email": email}, "date_created": "2026-06-20T08:00:00"},
+        {"billing": {"email": email}, "date_created": "2026-06-20T07:00:00"},
+    ]
+    a = FraudScorer(velocity_count=3).assess(order, history=history)
+    detail = next(s.detail for s in a.signals if s.rule == "velocity_email")
+    assert email not in detail  # raw email must not leak
+    assert "***@" in detail
+
+
+def test_current_order_not_counted_in_velocity():
+    order = _clean_order()  # id=1001
+    email = order["billing"]["email"]
+    # Two genuine priors + the current order echoed back in history → must count 2, not 3.
+    history = [
+        {"id": 1001, "billing": {"email": email}, "date_created": "2026-06-20T09:59:00"},
+        {"billing": {"email": email}, "date_created": "2026-06-20T09:30:00"},
+        {"billing": {"email": email}, "date_created": "2026-06-20T08:00:00"},
+    ]
+    a = FraudScorer(velocity_count=3).assess(order, history=history)
+    assert "velocity_email" not in _rules(a)  # only 2 eligible priors
+
+
+def test_nan_total_treated_as_unknown():
+    a = FraudScorer(high_value_threshold=1.0).assess(_clean_order(total=float("nan")))
+    assert "high_value_order" not in _rules(a)
+    assert 0 <= a.score <= 100
+
+
+def test_markdown_cells_escape_pipes():
+    order = _clean_order()
+    order["shipping"] = {**order["shipping"], "country": "N|G"}  # pipe in a field
+    a = FraudScorer().assess(order)
+    text = format_assessment(a)
+    # No raw unescaped pipe from the country value should break the table.
+    assert "N\\|G" in text
+
+
+def test_package_reexports_importable():
+    from services.risk import FraudAssessment as A
+    from services.risk import FraudScorer as S
+    from services.risk import RiskLevel as L
+    from services.risk import RiskSignal as Sig
+    from services.risk import format_assessment as f
+
+    assert all(x is not None for x in (A, S, L, Sig, f))

--- a/tests/services/test_recommender.py
+++ b/tests/services/test_recommender.py
@@ -1,0 +1,208 @@
+"""Tests for services.personalization.recommender — deterministic per-user reranker.
+
+Contract: deterministic, never-raises, advisory. Content-based + co-purchase + popularity
+cold-start. No ML training, no network (an optional similarity backend is a separate port).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from services.personalization.recommender import (
+    Recommendation,
+    RecommendationSet,
+    Recommender,
+    Strategy,
+    format_recommendations,
+)
+
+CATALOG = [
+    {"id": "br-1", "collection": "Black Rose", "price": 200, "tags": ["bomber"], "popularity": 5},
+    {"id": "br-2", "collection": "Black Rose", "price": 180, "tags": ["tee"], "popularity": 2},
+    {"id": "sig-1", "collection": "Signature", "price": 90, "tags": ["tee"], "popularity": 50},
+    {"id": "sig-2", "collection": "Signature", "price": 100, "tags": ["hoodie"], "popularity": 40},
+    {"id": "lh-1", "collection": "Love Hurts", "price": 150, "tags": ["bomber"], "popularity": 10},
+]
+
+
+def _ids(rs: RecommendationSet) -> list[str]:
+    return [r.item_id for r in rs.items]
+
+
+# --------------------------------------------------------------------------- #
+# Personalization
+# --------------------------------------------------------------------------- #
+
+
+def test_personalized_prefers_same_collection():
+    rs = Recommender().recommend({"id": "u1", "purchased": ["br-1"]}, CATALOG)
+    assert rs.strategy is Strategy.PERSONALIZED
+    assert _ids(rs)[0] == "br-2"  # same collection beats popular Signature items
+    assert _ids(rs).index("br-2") < _ids(rs).index("sig-1")
+
+
+def test_excludes_owned_items():
+    rs = Recommender().recommend({"id": "u1", "purchased": ["br-1"]}, CATALOG)
+    assert "br-1" not in _ids(rs)
+
+
+def test_cold_start_falls_back_to_popularity():
+    rs = Recommender().recommend({"id": "u2", "purchased": []}, CATALOG)
+    assert rs.strategy is Strategy.POPULARITY_COLD_START
+    assert _ids(rs)[0] == "sig-1"  # highest popularity
+    assert _ids(rs)[:2] == ["sig-1", "sig-2"]
+
+
+def test_unknown_purchases_treated_as_cold_start():
+    rs = Recommender().recommend({"id": "u3", "purchased": ["does-not-exist"]}, CATALOG)
+    assert rs.strategy is Strategy.POPULARITY_COLD_START
+
+
+def test_copurchase_boost_changes_ranking():
+    co = {"br-1": {"sig-2": 1000}}
+    rs = Recommender().recommend({"id": "u1", "purchased": ["br-1"]}, CATALOG, co_purchase=co)
+    assert _ids(rs)[0] == "sig-2"
+
+
+def test_top_n_limits_results():
+    rs = Recommender(top_n=2).recommend({"id": "u1", "purchased": ["br-1"]}, CATALOG)
+    assert len(rs.items) == 2
+
+
+def test_recommendations_have_reasons():
+    rs = Recommender().recommend({"id": "u1", "purchased": ["br-1"]}, CATALOG)
+    assert all(isinstance(r.reasons, tuple) for r in rs.items)
+    assert any(r.reasons for r in rs.items)
+
+
+def test_purchased_as_item_dicts():
+    rs = Recommender().recommend(
+        {"id": "u1", "purchased": [{"id": "br-1", "collection": "Black Rose"}]}, CATALOG
+    )
+    assert "br-1" not in _ids(rs)
+    assert rs.strategy is Strategy.PERSONALIZED
+
+
+# --------------------------------------------------------------------------- #
+# Robustness
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "user,catalog",
+    [
+        (None, CATALOG),
+        ({}, CATALOG),
+        ({"purchased": None}, CATALOG),
+        ({"purchased": "nope"}, CATALOG),
+        ({"purchased": [None, 5, {"no_id": 1}]}, CATALOG),
+        ({"purchased": ["br-1"]}, None),
+        ({"purchased": ["br-1"]}, "nope"),
+        ({"purchased": ["br-1"]}, [None, "x", {"no_id": 1}]),
+        ({"purchased": ["br-1"]}, []),
+    ],
+)
+def test_never_raises_on_garbage(user, catalog):
+    rs = Recommender().recommend(user, catalog)
+    assert isinstance(rs, RecommendationSet)
+    assert all(isinstance(r, Recommendation) for r in rs.items)
+
+
+# --------------------------------------------------------------------------- #
+# Determinism + immutability + serialization
+# --------------------------------------------------------------------------- #
+
+
+def test_deterministic():
+    u = {"id": "u1", "purchased": ["br-1"]}
+    assert Recommender().recommend(u, CATALOG) == Recommender().recommend(u, CATALOG)
+
+
+def test_tie_break_is_stable():
+    flat = [{"id": f"x-{i}", "collection": "Z", "price": 100, "popularity": 0} for i in range(5)]
+    rs = Recommender().recommend({"id": "u", "purchased": []}, flat)
+    # All equal score → ordered by id ascending, deterministically.
+    assert _ids(rs) == sorted(_ids(rs))
+
+
+def test_frozen():
+    rs = Recommender().recommend({"id": "u1", "purchased": ["br-1"]}, CATALOG)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        rs.items[0].score = 9.0  # type: ignore[misc]
+
+
+def test_as_dict_json_safe():
+    import json
+
+    rs = Recommender().recommend({"id": "u1", "purchased": ["br-1"]}, CATALOG)
+    payload = rs.as_dict()
+    json.dumps(payload)
+    assert payload["strategy"] == rs.strategy.name
+    assert payload["user_id"] == "u1"
+    assert isinstance(payload["recommendations"], list)
+    assert payload["recommendations"][0]["item_id"] == _ids(rs)[0]
+
+
+# --------------------------------------------------------------------------- #
+# Tunability + reporting + optional similarity port
+# --------------------------------------------------------------------------- #
+
+
+def test_weights_tunable():
+    # Crank popularity weight so a popular cross-collection item can outrank same-collection.
+    high_pop = Recommender(popularity_weight=10.0)
+    rs = high_pop.recommend({"id": "u1", "purchased": ["br-1"]}, CATALOG)
+    assert _ids(rs)[0] == "sig-1"
+
+
+def test_similarity_backend_port_blends_in():
+    class FakeBackend:
+        def similar(self, item_id, k):
+            return [("lh-1", 1.0)] if item_id == "br-1" else []
+
+    rs = Recommender(similarity_weight=1000.0).recommend(
+        {"id": "u1", "purchased": ["br-1"]}, CATALOG, similarity_backend=FakeBackend()
+    )
+    assert _ids(rs)[0] == "lh-1"
+
+
+def test_format_renders_markdown():
+    rs = Recommender().recommend({"id": "u1", "purchased": ["br-1"]}, CATALOG)
+    text = format_recommendations(rs)
+    assert "Recommendations" in text
+    assert _ids(rs)[0] in text
+
+
+# --------------------------------------------------------------------------- #
+# Regression: adversarial-review fixes
+# --------------------------------------------------------------------------- #
+
+
+def test_popularity_does_not_swamp_personalization():
+    """A wildly popular cross-collection item must not outrank a same-collection match
+    at default weights — popularity is log-scaled, not raw."""
+    catalog = [
+        {"id": "br-1", "collection": "Black Rose", "price": 200, "popularity": 1},
+        {"id": "br-2", "collection": "Black Rose", "price": 190, "popularity": 1},
+        {"id": "sig-hot", "collection": "Signature", "price": 90, "popularity": 100000},
+    ]
+    rs = Recommender().recommend({"id": "u1", "purchased": ["br-1"]}, catalog)
+    assert _ids(rs)[0] == "br-2"  # same collection wins despite sig-hot's huge popularity
+
+
+def test_price_zero_is_not_dropped():
+    from services.personalization.recommender import _price
+
+    assert _price({"price": 0, "regular_price": 999}) == 0.0
+    assert _price({"price": None, "regular_price": 999}) == 999.0
+
+
+def test_dict_purchase_not_in_catalog_is_personalized():
+    # A purchase supplied as a dict with attributes builds a profile even if it's not in the
+    # catalog — a bare unknown string id does not (that path is cold-start, tested above).
+    rs = Recommender().recommend(
+        {"id": "u1", "purchased": [{"id": "ghost", "collection": "Black Rose"}]}, CATALOG
+    )
+    assert rs.strategy is Strategy.PERSONALIZED
+    assert _ids(rs)[0] in ("br-1", "br-2")  # Black Rose items surface first

--- a/tests/services/test_retention.py
+++ b/tests/services/test_retention.py
@@ -1,0 +1,259 @@
+"""Tests for services.lifecycle.retention — deterministic RFM + lifecycle scorer.
+
+Contract: deterministic given ``as_of``, never-raises, advisory-only (suggests a Klaviyo
+segment/flow; never sends).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime
+
+import pytest
+from services.lifecycle.retention import (
+    LifecycleStage,
+    RetentionAssessment,
+    RetentionScorer,
+    format_assessment,
+)
+
+AS_OF = datetime(2026, 6, 20, 12, 0, tzinfo=UTC)
+
+
+def _cust(orders=None, **fields):
+    c = {"id": 7, "email": "buyer@example.com"}
+    if orders is not None:
+        c["orders"] = orders
+    c.update(fields)
+    return c
+
+
+def _orders(*dates_and_totals):
+    return [{"date_created": d, "total": t} for d, t in dates_and_totals]
+
+
+# --------------------------------------------------------------------------- #
+# Lifecycle stages
+# --------------------------------------------------------------------------- #
+
+
+def test_new_customer_single_recent_order():
+    a = RetentionScorer().assess(_cust(_orders(("2026-06-15T10:00:00", "120.00"))), as_of=AS_OF)
+    assert isinstance(a, RetentionAssessment)
+    assert a.lifecycle_stage is LifecycleStage.NEW
+    assert a.frequency == 1
+    assert a.recency_days == 5
+    assert a.churn_risk < 30
+
+
+def test_active_customer_repeat_recent():
+    orders = _orders(
+        ("2026-06-10T10:00:00", "120.00"),
+        ("2026-05-20T10:00:00", "90.00"),
+        ("2026-05-01T10:00:00", "150.00"),
+    )
+    a = RetentionScorer().assess(_cust(orders), as_of=AS_OF)
+    assert a.lifecycle_stage is LifecycleStage.ACTIVE
+    assert a.frequency == 3
+
+
+def test_loyal_customer_high_frequency_and_spend():
+    orders = _orders(*[(f"2026-06-{d:02d}T10:00:00", "300.00") for d in range(1, 13)])
+    a = RetentionScorer().assess(_cust(orders), as_of=AS_OF)
+    assert a.lifecycle_stage is LifecycleStage.LOYAL
+    assert a.rfm == "5-5-5"  # most recent, most frequent, top spend
+
+
+def test_at_risk_customer():
+    a = RetentionScorer().assess(_cust(_orders(("2026-03-01T10:00:00", "120.00"))), as_of=AS_OF)
+    assert a.lifecycle_stage is LifecycleStage.AT_RISK
+
+
+def test_dormant_customer():
+    a = RetentionScorer().assess(_cust(_orders(("2025-12-15T10:00:00", "120.00"))), as_of=AS_OF)
+    assert a.lifecycle_stage is LifecycleStage.DORMANT
+
+
+def test_churned_customer_high_churn_risk():
+    a = RetentionScorer().assess(_cust(_orders(("2025-04-01T10:00:00", "120.00"))), as_of=AS_OF)
+    assert a.lifecycle_stage is LifecycleStage.CHURNED
+    assert a.churn_risk >= 80
+
+
+def test_zero_orders_is_new_no_recency():
+    a = RetentionScorer().assess(_cust([]), as_of=AS_OF)
+    assert a.lifecycle_stage is LifecycleStage.NEW
+    assert a.recency_days is None
+    assert a.frequency == 0
+    assert a.monetary == 0.0
+    assert a.churn_risk == 0
+
+
+# --------------------------------------------------------------------------- #
+# RFM computation
+# --------------------------------------------------------------------------- #
+
+
+def test_rfm_from_orders_list():
+    orders = _orders(
+        ("2026-06-18T10:00:00", "600.00"),
+        ("2026-06-01T10:00:00", "600.00"),
+        ("2026-05-15T10:00:00", "600.00"),
+    )
+    a = RetentionScorer().assess(_cust(orders), as_of=AS_OF)
+    # recency 2d -> 5, freq 3 -> 3, monetary 1800 -> 5
+    assert a.rfm == "5-3-5"
+    assert a.monetary == 1800.0
+
+
+def test_precomputed_fields_used_when_no_orders():
+    cust = _cust(last_order_date="2026-06-15T00:00:00", order_count=4, total_spent=520.0)
+    a = RetentionScorer().assess(cust, as_of=AS_OF)
+    assert a.frequency == 4
+    assert a.monetary == 520.0
+    assert a.recency_days == 5
+
+
+# --------------------------------------------------------------------------- #
+# Action + Klaviyo segment (advisory only)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "stage",
+    list(LifecycleStage),
+)
+def test_every_stage_has_action_and_segment(stage):
+    assert RetentionScorer.action_for(stage)
+    seg = RetentionScorer.klaviyo_segment_for(stage)
+    assert isinstance(seg, str) and seg
+
+
+def test_churned_recommends_winback():
+    a = RetentionScorer().assess(_cust(_orders(("2025-04-01T10:00:00", "120.00"))), as_of=AS_OF)
+    assert "winback" in a.recommended_action
+
+
+# --------------------------------------------------------------------------- #
+# Robustness — never raises
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {},
+        {"orders": None},
+        {"orders": "nope"},
+        {"orders": [None, "x", {"date_created": "garbage", "total": "x"}]},
+        {"last_order_date": "garbage", "order_count": "x", "total_spent": None},
+        {"orders": [{"total": "120.00"}]},  # order with no date
+    ],
+)
+def test_never_raises_on_garbage(bad):
+    a = RetentionScorer().assess(bad, as_of=AS_OF)
+    assert isinstance(a, RetentionAssessment)
+    assert 0 <= a.churn_risk <= 100
+
+
+def test_none_customer_does_not_raise():
+    a = RetentionScorer().assess(None, as_of=AS_OF)  # type: ignore[arg-type]
+    assert a.lifecycle_stage is LifecycleStage.NEW
+    assert a.churn_risk == 0
+
+
+def test_default_as_of_does_not_raise():
+    a = RetentionScorer().assess(_cust(_orders(("2026-06-15T10:00:00", "120.00"))))
+    assert isinstance(a, RetentionAssessment)
+
+
+# --------------------------------------------------------------------------- #
+# Determinism + immutability + serialization
+# --------------------------------------------------------------------------- #
+
+
+def test_deterministic():
+    cust = _cust(_orders(("2026-05-01T10:00:00", "300.00"), ("2026-04-01T10:00:00", "300.00")))
+    assert RetentionScorer().assess(cust, as_of=AS_OF) == RetentionScorer().assess(
+        cust, as_of=AS_OF
+    )
+
+
+def test_frozen():
+    a = RetentionScorer().assess(_cust([]), as_of=AS_OF)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        a.churn_risk = 50  # type: ignore[misc]
+
+
+def test_as_dict_json_safe():
+    import json
+
+    a = RetentionScorer().assess(_cust(_orders(("2026-03-01T10:00:00", "120.00"))), as_of=AS_OF)
+    payload = a.as_dict()
+    json.dumps(payload)
+    assert payload["lifecycle_stage"] == a.lifecycle_stage.name
+    assert payload["rfm"] == a.rfm
+    assert payload["recommended_action"] == a.recommended_action
+    assert payload["suggested_klaviyo_segment"]
+
+
+# --------------------------------------------------------------------------- #
+# Tunability
+# --------------------------------------------------------------------------- #
+
+
+def test_churned_window_tunable():
+    cust = _cust(_orders(("2026-01-01T10:00:00", "120.00")))  # ~170 days before AS_OF
+    assert RetentionScorer(churned_days=150).assess(cust, as_of=AS_OF).lifecycle_stage is (
+        LifecycleStage.CHURNED
+    )
+    assert RetentionScorer(churned_days=400).assess(cust, as_of=AS_OF).lifecycle_stage is not (
+        LifecycleStage.CHURNED
+    )
+
+
+def test_format_renders_markdown():
+    a = RetentionScorer().assess(_cust(_orders(("2026-03-01T10:00:00", "120.00"))), as_of=AS_OF)
+    text = format_assessment(a)
+    assert "Retention" in text
+    assert a.lifecycle_stage.name in text
+
+
+# --------------------------------------------------------------------------- #
+# Regression: adversarial-review fixes
+# --------------------------------------------------------------------------- #
+
+
+def test_loyal_buyer_in_drop_gap_stays_loyal():
+    """A 5-order buyer whose last order was 96d ago (normal inter-drop gap) is LOYAL,
+    not AT_RISK — the recency gate must not pre-empt the loyalty check."""
+    orders = [
+        {"date_created": f"2026-0{m}-15T10:00:00", "total": "300.00"} for m in (1, 2, 3)
+    ] + _orders(("2026-03-16T10:00:00", "300.00"), ("2026-03-17T10:00:00", "300.00"))
+    a = RetentionScorer().assess(_cust(orders), as_of=AS_OF)  # last order 2026-03-17 ≈ 95d
+    assert a.frequency == 5
+    assert a.recency_days > 90
+    assert a.lifecycle_stage is LifecycleStage.LOYAL
+    assert a.recommended_action == "vip_reward"
+
+
+def test_loyal_buyer_past_dormant_window_degrades():
+    orders = [{"date_created": "2025-12-01T10:00:00", "total": "300.00"} for _ in range(5)]
+    a = RetentionScorer().assess(_cust(orders), as_of=AS_OF)  # ~201d > dormant_days
+    assert a.frequency == 5
+    assert a.lifecycle_stage is LifecycleStage.DORMANT
+
+
+def test_new_with_last_order_but_no_count_has_zero_churn():
+    # Precomputed path with last_order_date but no order_count → NEW with no contradictory churn.
+    a = RetentionScorer().assess(_cust(last_order_date="2025-01-01T00:00:00"), as_of=AS_OF)
+    assert a.frequency == 0
+    assert a.lifecycle_stage is LifecycleStage.NEW
+    assert a.churn_risk == 0
+
+
+def test_parse_dt_accepts_datetime_objects():
+    orders = [{"date_created": datetime(2026, 6, 15, tzinfo=UTC), "total": 120.0}]
+    a = RetentionScorer().assess(_cust(orders), as_of=AS_OF)
+    assert a.recency_days == 5
+    assert a.frequency == 1

--- a/tests/test_fleet_emitter.py
+++ b/tests/test_fleet_emitter.py
@@ -1,0 +1,130 @@
+"""Tests for the fleet-telemetry emitter — record_llm_usage() + LLMRouter wiring.
+
+The observability gap had two halves: no consumer (FleetObserver, tested separately) AND a
+dead emit path (get_token_tracker had zero callers). These tests cover the emit half:
+record_llm_usage attributes a call to the current agent (via ContextVar), records failures,
+never raises, and LLMRouter.complete() actually calls it on both success and failure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.token_tracker import current_agent_id, get_token_tracker, record_llm_usage
+from llm import ModelProvider
+from llm.base import CompletionResponse, Message
+from llm.router import LLMRouter
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracker_and_ctx():
+    import core.token_tracker as _tt
+
+    _tt._global_tracker = None
+    _tt.current_agent_id.set(None)
+    yield
+    _tt.get_token_tracker().clear()
+    _tt.current_agent_id.set(None)
+
+
+# --- record_llm_usage helper ---------------------------------------------------
+
+
+def test_record_llm_usage_attributes_to_contextvar():
+    current_agent_id.set("agentX")
+    record_llm_usage(provider="openai", model="gpt-4o", input_tokens=10, output_tokens=5)
+    by_agent = get_token_tracker().get_usage_by_agent()
+    assert by_agent["agentX"]["requests"] == 1
+    assert by_agent["agentX"]["total_tokens"] == 15  # auto-filled by record()
+
+
+def test_record_llm_usage_explicit_agent_id_overrides_contextvar():
+    current_agent_id.set("ctxAgent")
+    record_llm_usage(provider="openai", model="gpt-4o", agent_id="explicit", input_tokens=1)
+    by_agent = get_token_tracker().get_usage_by_agent()
+    assert "explicit" in by_agent
+    assert "ctxAgent" not in by_agent
+
+
+def test_record_llm_usage_unknown_when_no_contextvar():
+    record_llm_usage(provider="openai", model="gpt-4o", input_tokens=1)
+    assert "unknown" in get_token_tracker().get_usage_by_agent()
+
+
+def test_record_llm_usage_records_failure():
+    record_llm_usage(provider="openai", model="gpt-4o", success=False, error="boom")
+    recs = get_token_tracker().records()
+    assert len(recs) == 1
+    assert recs[0].success is False
+    assert recs[0].error == "boom"
+
+
+def test_record_llm_usage_never_raises(monkeypatch):
+    def boom():
+        raise RuntimeError("tracker exploded")
+
+    monkeypatch.setattr("core.token_tracker.get_token_tracker", boom)
+    record_llm_usage(provider="openai", model="gpt-4o", input_tokens=1)  # must not raise
+
+
+# --- LLMRouter.complete() wiring ----------------------------------------------
+
+
+async def test_router_complete_records_success(monkeypatch):
+    router = LLMRouter()
+    resp = CompletionResponse(
+        content="hi",
+        model="gpt-4o",
+        provider="openai",
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=15,
+        latency_ms=120.0,
+    )
+
+    class _FakeClient:
+        async def complete(self, messages, model=None, **kwargs):
+            return resp
+
+    monkeypatch.setattr(router, "_get_client", lambda provider: _FakeClient())
+    current_agent_id.set("router_agent")
+
+    out = await router.complete([Message.user("hi")], provider=ModelProvider.OPENAI)
+
+    assert out is resp
+    by_agent = get_token_tracker().get_usage_by_agent()
+    assert by_agent["router_agent"]["requests"] == 1
+    assert by_agent["router_agent"]["total_tokens"] == 15
+
+
+async def test_router_complete_records_failure(monkeypatch):
+    router = LLMRouter()
+
+    class _BoomClient:
+        async def complete(self, messages, model=None, **kwargs):
+            raise RuntimeError("provider down")
+
+    monkeypatch.setattr(router, "_get_client", lambda provider: _BoomClient())
+    current_agent_id.set("boom_agent")
+
+    with pytest.raises(Exception):
+        await router.complete([Message.user("hi")], provider=ModelProvider.OPENAI)
+
+    recs = get_token_tracker().records()
+    assert any((not r.success) and r.agent_id == "boom_agent" for r in recs)
+
+
+async def test_router_circuit_breaker_open_records_failure(monkeypatch):
+    """A circuit-breaker-blocked call still emits a failure record (no silent telemetry gap)."""
+    router = LLMRouter()
+    monkeypatch.setattr(router.circuit_breaker, "is_available", lambda provider: False)
+    current_agent_id.set("cb_agent")
+
+    with pytest.raises(Exception):
+        await router.complete([Message.user("hi")], provider=ModelProvider.OPENAI)
+
+    recs = get_token_tracker().records()
+    assert any(
+        (not r.success) and r.agent_id == "cb_agent" and "circuit_breaker" in (r.error or "")
+        for r in recs
+    )

--- a/tests/test_fleet_health_consumer.py
+++ b/tests/test_fleet_health_consumer.py
@@ -1,0 +1,247 @@
+"""Tests for the fleet-health observability consumer (monitoring/fleet_observer.py).
+
+Closes the Tier-1 observability gap: core/token_tracker.py records per-agent telemetry but
+had zero consumers. FleetObserver reads that telemetry and emits alerts (budget, per-agent
+cost, error rate, p95 latency, stale agent, consecutive failures). It is alert+recommend
+only — it never mutates the tracker or acts on any agent.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from core.token_tracker import TaskType, TokenUsage, get_token_tracker
+from monitoring.fleet_observer import (
+    AlertSeverity,
+    FleetObserver,
+    HealthReport,
+    format_health_report,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_token_tracker():
+    """Isolate the module-global tracker per test (mirrors tests/orchestration pattern)."""
+    import core.token_tracker as _tt
+
+    _tt._global_tracker = None
+    yield
+    _tt.get_token_tracker().clear()
+
+
+def _usage(
+    agent_id: str | None = "agentA",
+    *,
+    model: str = "gpt-4o",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    latency_ms: float = 0.0,
+    success: bool = True,
+    error: str | None = None,
+    ts: datetime | None = None,
+) -> TokenUsage:
+    return TokenUsage(
+        provider="openai",
+        model=model,
+        task_type=TaskType.CHAT,
+        agent_id=agent_id,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        latency_ms=latency_ms,
+        success=success,
+        error=error,
+        timestamp=ts or datetime.now(UTC),
+    )
+
+
+def _record(*usages: TokenUsage) -> None:
+    tracker = get_token_tracker()
+    for u in usages:
+        tracker.record(u)
+
+
+def _observer(**overrides: float) -> FleetObserver:
+    """Permissive observer (every threshold off) so a test can isolate one rule."""
+    cfg = dict(
+        budget_usd=1e9,
+        cost_per_agent_usd=1e9,
+        error_rate_pct=1e9,
+        p95_latency_ms=1e12,
+        stale_agent_secs=10**9,
+        consecutive_failures=10**9,
+        window_seconds=3600,
+    )
+    cfg.update(overrides)
+    return FleetObserver(**cfg)
+
+
+# --- TokenTracker.records() accessor (added for the consumer) -------------------
+
+
+def test_records_returns_snapshot_copy():
+    _record(_usage(), _usage())
+    recs = get_token_tracker().records()
+    assert len(recs) == 2
+    recs.append("mutation")  # mutating the returned list must not affect the tracker
+    assert len(get_token_tracker().records()) == 2
+
+
+def test_records_since_filters_old():
+    now = datetime.now(UTC)
+    _record(_usage(ts=now - timedelta(hours=2)), _usage(ts=now))
+    assert len(get_token_tracker().records(since=now - timedelta(minutes=30))) == 1
+
+
+# --- FleetObserver alert rules -------------------------------------------------
+
+
+def test_no_usages_produces_no_alerts():
+    report = _observer().evaluate()
+    assert report.alerts == ()
+    assert report.fleet_cost_usd == 0.0
+    assert report.fleet_requests == 0
+
+
+def test_budget_overrun_fires_ticket():
+    _record(_usage(input_tokens=1000))  # gpt-4o input = $2.50/1M -> $0.0025
+    report = _observer(budget_usd=0.001).evaluate()
+    fired = [a for a in report.alerts if a.rule == "budget_overrun"]
+    assert len(fired) == 1
+    assert fired[0].agent_id is None
+    assert fired[0].severity == AlertSeverity.TICKET
+
+
+def test_agent_cost_overrun_fires_for_named_agent():
+    _record(_usage(agent_id="spendy", input_tokens=1000))
+    report = _observer(cost_per_agent_usd=0.001).evaluate()
+    fired = [a for a in report.alerts if a.rule == "agent_cost_overrun"]
+    assert len(fired) == 1
+    assert fired[0].agent_id == "spendy"
+
+
+def test_error_rate_below_50_is_ticket():
+    _record(
+        *[_usage(agent_id="qa", success=True) for _ in range(4)],
+        _usage(agent_id="qa", success=False),
+    )
+    report = _observer(error_rate_pct=10.0).evaluate()
+    fired = [a for a in report.alerts if a.rule == "error_rate"]
+    assert len(fired) == 1
+    assert fired[0].severity == AlertSeverity.TICKET  # 20% < 50%
+
+
+def test_error_rate_above_50_is_page():
+    _record(_usage(agent_id="qa", success=False), _usage(agent_id="qa", success=False))
+    report = _observer(error_rate_pct=10.0).evaluate()
+    fired = [a for a in report.alerts if a.rule == "error_rate"]
+    assert len(fired) == 1
+    assert fired[0].severity == AlertSeverity.PAGE  # 100% > 50%
+
+
+def test_p95_latency_fires_ticket():
+    _record(*[_usage(agent_id="slow", latency_ms=6000.0) for _ in range(20)])
+    report = _observer(p95_latency_ms=5000.0).evaluate()
+    fired = [a for a in report.alerts if a.rule == "p95_latency"]
+    assert len(fired) == 1
+    assert fired[0].value >= 5000.0
+
+
+def test_stale_agent_fires_dashboard():
+    _record(_usage(agent_id="idle", ts=datetime.now(UTC) - timedelta(seconds=400)))
+    report = _observer(stale_agent_secs=300).evaluate()
+    fired = [a for a in report.alerts if a.rule == "stale_agent"]
+    assert len(fired) == 1
+    assert fired[0].severity == AlertSeverity.DASHBOARD
+
+
+def test_active_agent_no_stale_alert():
+    _record(_usage(agent_id="active", ts=datetime.now(UTC) - timedelta(seconds=30)))
+    report = _observer(stale_agent_secs=300).evaluate()
+    assert [a for a in report.alerts if a.rule == "stale_agent"] == []
+
+
+def test_consecutive_failures_at_threshold_is_ticket():
+    base = datetime.now(UTC)
+    _record(
+        *[
+            _usage(agent_id="flaky", success=False, ts=base - timedelta(seconds=3 - i))
+            for i in range(3)
+        ]
+    )
+    report = _observer(consecutive_failures=3, error_rate_pct=1e9).evaluate()
+    fired = [a for a in report.alerts if a.rule == "consecutive_failures"]
+    assert len(fired) == 1
+    assert fired[0].value == 3.0
+    assert fired[0].severity == AlertSeverity.TICKET  # 3 < 2*3
+
+
+def test_consecutive_failures_at_double_threshold_is_page():
+    base = datetime.now(UTC)
+    _record(
+        *[
+            _usage(agent_id="flaky", success=False, ts=base - timedelta(seconds=6 - i))
+            for i in range(6)
+        ]
+    )
+    report = _observer(consecutive_failures=3, error_rate_pct=1e9).evaluate()
+    fired = [a for a in report.alerts if a.rule == "consecutive_failures"]
+    assert len(fired) == 1
+    assert fired[0].value == 6.0
+    assert fired[0].severity == AlertSeverity.PAGE  # 6 >= 2*3
+
+
+def test_window_seconds_excludes_old_usage():
+    _record(_usage(input_tokens=1000, ts=datetime.now(UTC) - timedelta(hours=2)))
+    report = _observer(window_seconds=3600, budget_usd=0.0001).evaluate()
+    assert report.fleet_requests == 0
+    assert report.fleet_cost_usd == 0.0
+    assert report.alerts == ()
+
+
+def test_healthy_agent_produces_no_alerts():
+    _record(*[_usage(agent_id="good", input_tokens=1, latency_ms=10.0) for _ in range(5)])
+    # real-ish thresholds; nothing should fire
+    report = FleetObserver().evaluate()
+    assert report.alerts == ()
+
+
+# --- contracts: immutability + read-only ---------------------------------------
+
+
+def test_report_and_alert_are_frozen():
+    _record(_usage(input_tokens=1000))
+    report = _observer(budget_usd=0.001).evaluate()
+    assert isinstance(report, HealthReport)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        report.fleet_cost_usd = 5.0  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        report.alerts[0].value = 1.0  # type: ignore[misc]
+
+
+def test_evaluate_never_mutates_tracker():
+    _record(_usage(agent_id="a", input_tokens=10), _usage(agent_id="b", input_tokens=20))
+    before = get_token_tracker().get_usage_by_agent()
+    obs = _observer(budget_usd=0.0)  # would alert, but must not mutate
+    obs.evaluate()
+    obs.evaluate()
+    assert get_token_tracker().get_usage_by_agent() == before
+    assert len(get_token_tracker().records()) == 2
+
+
+# --- formatter -----------------------------------------------------------------
+
+
+def test_format_health_report_no_alerts():
+    out = format_health_report(_observer().evaluate())
+    assert "No alerts" in out
+
+
+def test_format_health_report_lists_alert():
+    _record(_usage(agent_id="spendy", input_tokens=1000))
+    out = format_health_report(_observer(cost_per_agent_usd=0.001).evaluate())
+    assert "agent_cost_overrun" in out
+    assert "spendy" in out
+    assert "TICKET" in out


### PR DESCRIPTION
## Summary

Closes all six high-priority agent gaps from ticket **#17660** (verified file:line before building; brainstorm overstated #1/#2 as missing — both were built-but-unwired). Each gap is a **deterministic, never-raises, advisory-only** core in `services/` (or `monitoring/`/`evaluation/`), behind the project's hexagonal/AI-portability lock: AI-free compute, any LLM/embedding behind an injected port, the no-LLM path shipped by default. Nothing writes to WooCommerce/Klaviyo/production — every surface scores and recommends only.

| Gap | Core | MCP tool |
|---|---|---|
| #2 Observability | `monitoring/fleet_observer.py` — fleet-health consumer + `record_llm_usage` emitter | `devskyy_fleet_health` |
| #1 Evaluator | `evaluation/domains/copy.py` — copy/content evaluator adapter | — |
| #4 Fraud | `services/risk/fraud.py` — 11-signal chargeback scorer | `devskyy_fraud_assess` |
| #5 Retention | `services/lifecycle/retention.py` — RFM + lifecycle + churn | `devskyy_retention_assess` |
| #3 Forecasting | `services/forecasting/demand.py` — velocity/sellout forecaster | `devskyy_demand_forecast` |
| #6 Personalization | `services/personalization/recommender.py` — per-user reranker | `devskyy_recommend` |

`total_tools` in the health check is now computed from the FastMCP registry (was a hardcoded constant that kept drifting).

## How it was verified
- **207 tests pass** across the seven new test files (fraud 53, retention 34, forecasting 31, recommender 28, analytics wiring 8, fleet 26, copy 33 — superset run on this branch's base).
- ruff / black / mypy clean on all new code; repo pre-commit gate (full mypy over 1376 files + fast unit tests) passed for every commit.
- **Two adversarial-review passes before merge** — fraud (16 confirmed findings fixed, `bug-150`) and the retention/forecasting/personalization trio (43 confirmed, `bug-151`). Highlights fixed: a `sum()` outside the never-raises guard; an international-gift fraud false-positive; LOYAL lifecycle stage being unreachable past 90 days; pre-orders firing false CRITICAL reorder alerts; popularity raw-count swamping personalization.

## Scope
8 single-concern commits, agent-gap files only. No production deploy, no live-data writes. Founder-tunable thresholds left at calibrated defaults; ML/Pinecone upgrades reserved for the injected ports.

## Test plan
- [ ] CI green (lint, type-check, unit, integration)
- [ ] Confirm advisory contract holds end-to-end (no WC/Klaviyo writes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes six high-priority gaps from Linear #17660 with deterministic, advisory-only cores for fraud, retention, forecasting, personalization, copy evaluation, and fleet observability. Removes “ML module not available” dead ends and adds per‑agent LLM telemetry with read‑only health alerts.

- New Features
  - Fleet observability: per‑agent LLM usage emitter + `FleetObserver` alerts (budget, error rate, latency, stale/consecutive failures); MCP tool `devskyy_fleet_health`.
  - Copy evaluator: new adapter and `CopyEvaluator`, wired into content agent via an opt‑in soft gate; records verdicts, never blocks.
  - Deterministic cores: fraud risk, retention/RFM + lifecycle, demand/sellout forecasting, and per‑user reranking; MCP tools `devskyy_fraud_assess`, `devskyy_retention_assess`, `devskyy_demand_forecast`, `devskyy_recommend`.
  - Agent wiring: analytics now falls back to the forecasting/segmentation cores; sub‑agent calls are attributed for telemetry; LLM router records success/failure and circuit‑open events.
  - MCP health: `health_check` now reports `total_tools` from the registry instead of a hardcoded count.

- Migration
  - No production writes; all outputs are recommendations only.
  - Copy quality gate is off by default; enable via `COPY_EVAL_ENABLED` if you want verdicts on generated copy.
  - No other changes required; agents and MCP tools pick up the new cores automatically.

<sup>Written for commit ad40e34074260b3bda05fdf7f2b5f9e066a3a80d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added demand forecasting service for inventory and sales predictions
* Added customer lifecycle and retention scoring system
* Added fraud risk assessment for order evaluation
* Added product recommendation engine with personalization
* Added brand copy quality evaluation for content generation
* Added fleet health monitoring and observability dashboards
* Enhanced analytics agent with deterministic fallback behavior when ML modules unavailable

**Bug Fixes**
* Resolved 6 logged issues covering render QC problems, CI stability, copy evaluation robustness, fleet telemetry tracking, fraud detection calibration, and scorer determinism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->