### PR TITLE
ci: automated PR green-loop on every internal PR (label-gated merge)

### DIFF
--- a/.github/workflows/pr-green-loop.yml
+++ b/.github/workflows/pr-green-loop.yml
@@ -1,0 +1,101 @@
+name: PR Green Loop
+
+# Automated drive-to-green for every internal pull request.
+# Waits for CI, fixes real failures (root cause, locally verified), pushes, re-runs CI,
+# and loops until green — then merges ONLY if the PR carries the `auto-merge` label.
+#
+# Safety model:
+# - Internal branches only. Fork PRs are excluded (forks must never receive write secrets);
+#   they still get the read-only Claude Code Review from claude-code-review.yml.
+# - The whole fix -> verify -> re-run-CI -> re-check loop runs inside ONE job. Pushes use the
+#   default GITHUB_TOKEN, which by design does NOT re-trigger workflows -> no recursion.
+# - concurrency cancels a stale loop when a new commit lands.
+# - Never force-pushes, never deploys, never calls a paid API, never weakens a test.
+#   Merge is label-gated; everything else is drive-to-green + a ready-to-merge comment.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+
+permissions:
+  contents: write # push fixes to the PR head branch
+  pull-requests: write # resolve threads, comment, merge
+  actions: write # re-run failed CI checks after a fix
+  checks: read
+  id-token: write
+
+concurrency:
+  group: pr-green-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  green-loop:
+    # Internal, non-draft PRs only. (labeled events also pass when an `auto-merge` label is added.)
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure bot identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run PR green loop
+        uses: anthropics/claude-code-action@35037bb980d9bc03f0f74b65b68618b0be46c268 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: >-
+            --allowed-tools "Bash,Read,Edit,Write,Grep,Glob"
+          prompt: |
+            You are driving PR #${{ github.event.pull_request.number }} in
+            ${{ github.repository }} to green. The PR head branch is checked out and writable
+            with the default GITHUB_TOKEN (`gh` is authenticated). Follow the project agent
+            `.claude/agents/pr-green-loop.md` if present; otherwise use these rules verbatim.
+
+            ## Loop (run entirely within this job — do NOT wait on a re-trigger)
+            1. `gh pr checks ${{ github.event.pull_request.number }}` and read mergeability:
+               `gh pr view ${{ github.event.pull_request.number }} --json mergeable,mergeStateStatus,reviewDecision,labels,headRefName`.
+            2. Wait for in-flight checks to finish (`gh pr checks <N> --watch --interval 30` is fine;
+               respect the job timeout).
+            3. Split signals into REAL vs NOISE. NOISE (ignore): `PR Agent Analysis` concurrency
+               self-cancel, Vercel preview/agent, any `skipping` check, and Playwright E2E /
+               API-Integration when they end non-green for the known non-gating timeout (read the
+               run to confirm it is NOT a real failure of this diff).
+            4. For each REAL failure or actionable review comment (bots CodeRabbit/cubic/
+               claude-review are ADVISORY — verify each against the code; fix real ones, reply +
+               dismiss false ones): fix the ROOT CAUSE. Verify locally before pushing —
+               `python -m pytest <paths> -q`, `ruff check`, `black --check`, `mypy <module>`,
+               or the frontend/phpcs equivalent. Never weaken a test or suppress a check.
+            5. Commit (conventional subject) and `git push`. Because GITHUB_TOKEN pushes do not
+               re-trigger CI, immediately re-run the failed checks: `gh run rerun --failed` on the
+               relevant run id(s) (find via `gh run list --branch <headRefName> --limit 5`).
+               Return to step 2.
+            6. Stop when every gating check is `pass`/`skipping`, no actionable comment remains,
+               and `reviewDecision` is not CHANGES_REQUESTED. Hard caps: stop after 5 fix cycles,
+               or if the same check fails twice after a fix you believed addressed it, or if a
+               failure traces to the base branch rather than this diff — comment a concise
+               summary of what is blocked and why, then exit.
+
+            ## Terminal action
+            - If the PR is fully green AND has the `auto-merge` label:
+              `gh pr merge ${{ github.event.pull_request.number }} --merge --delete-branch`.
+              Then confirm main is not broken.
+            - If green WITHOUT the label: post ONE comment — "✅ All gating checks green and
+              comments resolved. Add the `auto-merge` label to merge, or merge manually." Do not merge.
+
+            ## Boundaries (absolute)
+            Never force-push. Never merge a PR lacking the `auto-merge` label. Never merge over a
+            human CHANGES_REQUESTED (report instead). Never deploy to skyyrose.co, never a
+            WooCommerce/media write, never a paid API call. Anti-hallucination: every "the failure
+            is X" must trace to a CI log you read this run.


### PR DESCRIPTION
## Summary

Makes the PR green-loop **automatic on every internal PR**. New workflow `.github/workflows/pr-green-loop.yml` runs `anthropics/claude-code-action` on `pull_request` events: waits for CI, fixes real failures (root cause, **locally verified before push**), pushes, re-runs failed CI, and loops until green.

Decisions (founder-selected):
- **Merge = label-gated.** The loop merges only when the PR has the `auto-merge` label (created in this change). Without it: driven to green + a ready-to-merge comment; you click merge.
- **Fix scope = internal branches only.** Fork PRs are excluded (a fork must never get a write token); they keep the existing read-only `claude-code-review`.

## Why it's safe / non-recursive
- The whole **fix → verify → re-run-CI → re-check** loop runs inside **one job**. Pushes use the default `GITHUB_TOKEN`, which by GitHub design does **not** re-trigger workflows — so no infinite loop; CI is re-validated explicitly via `gh run rerun --failed`.
- `concurrency` cancels a stale loop when a new commit lands.
- Hard boundaries baked into the prompt: never force-pushes, never merges without the label, never merges over a human `CHANGES_REQUESTED`, never deploys / WC-writes / paid-API, never weakens a test.
- Actions are SHA-pinned (org policy); reuses the existing `CLAUDE_CODE_OAUTH_TOKEN` secret.

## Pairs with
- `pr-green-loop` agent + `/pr-green <N>` command (#583) — the manual/interactive form of the same loop.

## Activation
Live once merged to main. From then: open an internal PR → it's driven to green automatically; add `auto-merge` to let it land itself.

## Test plan
- [ ] Open a trivial internal PR after merge → confirm the loop runs, filters noise, acts only on real red
- [ ] Add `auto-merge` label to a green PR → confirm it merges + deletes branch
- [ ] Confirm a fork PR does NOT trigger the write loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates a drive-to-green loop for every internal PR via a new GitHub Actions workflow, with label-gated auto-merge. It waits for CI, fixes real failures, reruns checks, and merges only when the `auto-merge` label is set.

- **New Features**
  - Adds `.github/workflows/pr-green-loop.yml` to run `anthropics/claude-code-action` on internal, non-draft `pull_request` events.
  - Runs fix → verify → rerun inside one job. Pushes with `GITHUB_TOKEN`, then `gh run rerun --failed` to recheck CI.
  - Merges only when the PR has the `auto-merge` label; otherwise comments when fully green.
  - Excludes forks; internal branches only.

- **Safety**
  - Single-job loop prevents recursion; `concurrency` cancels stale runs.
  - Respects gating checks and human CHANGES_REQUESTED; bots are advisory.
  - Never force-pushes, deploys, uses paid APIs, or weakens tests.

<sup>Written for commit 5506c708092e36fb0df1de49de2f6da67a372a4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

