### PR TITLE
ci(green-loop): skip Dependabot PRs

### DIFF
--- a/.github/workflows/pr-green-loop.yml
+++ b/.github/workflows/pr-green-loop.yml
@@ -30,10 +30,13 @@ concurrency:
 
 jobs:
   green-loop:
-    # Internal, non-draft PRs only. (labeled events also pass when an `auto-merge` label is added.)
+    # Internal, non-draft, non-Dependabot PRs only. Dependabot has its own rebase/merge
+    # flow (`@dependabot rebase`/`recreate`); the code-fix loop adds nothing to a dep bump
+    # and would burn a run on every one. (labeled events still pass for the `auto-merge` gate.)
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 50
     steps:


### PR DESCRIPTION
Adds a `dependabot[bot]` exclusion to the PR Green Loop job guard. Dependabot has its own `@dependabot rebase`/`recreate` + merge flow; the code-fix loop adds nothing to a version bump and would burn a workflow run on every dep PR and every rebase. One-line `if` change.

Follow-up to #584 (green-loop rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip running the PR Green Loop workflow on Dependabot PRs to avoid wasted CI runs. Adds an `if` guard in `.github/workflows/pr-green-loop.yml` to exclude PRs opened by `dependabot[bot]`, since Dependabot uses its own rebase/merge flow.

<sup>Written for commit 9e15bc0ea2fc0d00433679e496e0ea32bae39039. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to refine pull request processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->