### PR TITLE
fix(ci): cap Playwright step at 15min so E2E can't gate main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,6 +551,10 @@ jobs:
           NEXT_TELEMETRY_DISABLED: 1
 
       - name: Run Playwright tests
+        # Step-level cap: a slow/failing E2E suite fails HERE (step failure, absorbed by this
+        # job's continue-on-error) instead of running to the 30-min JOB timeout, which fires as
+        # a cancellation that continue-on-error cannot absorb — that gated the pipeline.
+        timeout-minutes: 15
         run: ./node_modules/.bin/playwright test --reporter=html
         working-directory: frontend
         env:


### PR DESCRIPTION
## Problem
main CI is red: the `🎭 Playwright E2E Tests` job runs to its 30-min **job** timeout, which surfaces as a **cancellation**. The job has `continue-on-error: true`, but that only absorbs *failures* — not cancellations — so the cancelled E2E job gates every main run.

## Fix
Add `timeout-minutes: 15` to the **Run Playwright tests step**. A step timeout produces a *step failure* (which `continue-on-error` absorbs) and fires before the 30-min job timeout, so the pipeline **completes** instead of being cancelled. One line; no behavior change to other jobs.

## Scope
ci.yml only (+4 −0). Does **not** touch the separate, pre-existing `🐳 Docker Build` failure (a pip wheel build error, push-only gate) — that needs its own fix.

## Verify
After merge, the next main push run: e2e job completes (Playwright fails-fast, non-gating) rather than cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a 15-minute timeout on the Playwright test step so slow E2E runs fail the step (handled by `continue-on-error`) instead of hitting the 30-minute job timeout that cancels and gates the workflow. This unblocks main CI by letting the pipeline complete even when E2E is flaky.

<sup>Written for commit e0bced260a8c4e12c310fc293853601b19716081. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test execution reliability with enhanced timeout configuration for end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->