### PR TITLE
fix(wp): guard Ally off AJAX/REST JSON + Boost critical-CSS regen tooling

### DIFF
--- a/scripts/deploy-mu-plugin.sh
+++ b/scripts/deploy-mu-plugin.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Deploy the Ally-AJAX-guard MU-plugin to skyyrose.co wp-content/mu-plugins/.
+#
+# Fixes the CommerceKit nonce-endpoint JSON corruption: Ally (pojo-accessibility)
+# injects its remediation <style> into every response, including JSON. This
+# MU-plugin removes Ally from the active-plugins list on AJAX/REST requests only.
+#
+# Credentials are sourced from .env.wordpress at runtime (never printed). Uses the
+# same SSH key + host the theme deploy uses. Verifies the endpoint afterward.
+#
+# Usage: STOPSHOW_ACK=1 bash scripts/deploy-mu-plugin.sh   (production write — gated)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="${ENV_FILE:-$ROOT/.env.wordpress}"
+SRC="$ROOT/wordpress/mu-plugins/skyyrose-ally-ajax-guard.php"
+
+[ -f "$ENV_FILE" ] || { echo "FATAL: $ENV_FILE missing" >&2; exit 1; }
+[ -f "$SRC" ]      || { echo "FATAL: $SRC missing" >&2; exit 1; }
+php -l "$SRC" >/dev/null || { echo "FATAL: php syntax error in mu-plugin" >&2; exit 1; }
+
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+: "${SSH_USER:?missing in env}"; : "${SSH_HOST:?missing in env}"; : "${WP_THEME_PATH:?missing in env}"
+
+KEY="${SSH_KEY_PATH:-$HOME/.ssh/skyyrose-deploy}"
+PORT="${SSH_PORT:-22}"
+WP_CONTENT="$(dirname "$(dirname "$WP_THEME_PATH")")"   # .../wp-content/themes/X -> .../wp-content
+MU_DIR="$WP_CONTENT/mu-plugins"
+SSH=(ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -p "$PORT" -i "$KEY")
+SCP=(scp -o StrictHostKeyChecking=accept-new -P "$PORT" -i "$KEY")
+
+echo "==> ensuring $MU_DIR exists"
+"${SSH[@]}" "${SSH_USER}@${SSH_HOST}" "mkdir -p '$MU_DIR'"
+
+echo "==> uploading skyyrose-ally-ajax-guard.php"
+"${SCP[@]}" "$SRC" "${SSH_USER}@${SSH_HOST}:$MU_DIR/skyyrose-ally-ajax-guard.php"
+
+echo "==> flushing cache"
+"${SSH[@]}" "${SSH_USER}@${SSH_HOST}" "wp cache flush" >/dev/null 2>&1 || true
+
+echo "==> verifying nonce endpoint (should be clean JSON, no <head>/ea11y)"
+RESP="$(curl -s "https://skyyrose.co/?commercekit-ajax=commercekit_get_nonce&cb=$(date +%s)" 2>/dev/null)"
+echo "RESP[0:200]: ${RESP:0:200}"
+if printf '%s' "$RESP" | grep -q "ea11y-remediation-styles"; then
+  echo "RESULT: STILL CORRUPTED — ea11y markup present" >&2
+  exit 2
+fi
+case "$RESP" in
+  '{'*) echo "RESULT: PASS — clean JSON, no Ally injection" ;;
+  *)    echo "RESULT: PARTIAL — Ally gone but body not pure JSON; inspect (residual wrapper?)" ;;
+esac

--- a/scripts/deploy-mu-plugin.sh
+++ b/scripts/deploy-mu-plugin.sh
@@ -11,6 +11,13 @@
 # Usage: STOPSHOW_ACK=1 bash scripts/deploy-mu-plugin.sh   (production write — gated)
 set -euo pipefail
 
+# --- production-write gate ---------------------------------------------------
+if [[ "${STOPSHOW_ACK:-}" != "1" ]]; then
+  echo "STOP — This script writes to the production server (skyyrose.co)." >&2
+  echo "       Set STOPSHOW_ACK=1 to confirm you intend a production write." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(dirname "$SCRIPT_DIR")"
 ENV_FILE="${ENV_FILE:-$ROOT/.env.wordpress}"
@@ -24,12 +31,28 @@ php -l "$SRC" >/dev/null || { echo "FATAL: php syntax error in mu-plugin" >&2; e
 source "$ENV_FILE"
 : "${SSH_USER:?missing in env}"; : "${SSH_HOST:?missing in env}"; : "${WP_THEME_PATH:?missing in env}"
 
-KEY="${SSH_KEY_PATH:-$HOME/.ssh/skyyrose-deploy}"
+SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/skyyrose-deploy}"
 PORT="${SSH_PORT:-22}"
+SSH_STRICT="${SSH_STRICT_HOST:-accept-new}"
+
+# Build SSH/SCP commands — key preferred, sshpass fallback (mirrors
+# wp-cli-nextgen-backfill.sh pattern so both auth methods work).
+SSH_BASE=( ssh -o "StrictHostKeyChecking=$SSH_STRICT" -o ConnectTimeout=15 -p "$PORT" )
+SCP_BASE=( scp -o "StrictHostKeyChecking=$SSH_STRICT" -P "$PORT" )
+if [[ -f "$SSH_KEY_PATH" ]]; then
+  SSH=( "${SSH_BASE[@]}" -i "$SSH_KEY_PATH" )
+  SCP=( "${SCP_BASE[@]}" -i "$SSH_KEY_PATH" )
+elif [[ -n "${SSH_PASS:-}" ]] && command -v sshpass &>/dev/null; then
+  export SSHPASS="$SSH_PASS"
+  SSH=( sshpass -e "${SSH_BASE[@]}" )
+  SCP=( sshpass -e "${SCP_BASE[@]}" )
+else
+  echo "FATAL: No SSH credentials (no key at $SSH_KEY_PATH and no SSH_PASS+sshpass)" >&2
+  exit 1
+fi
+
 WP_CONTENT="$(dirname "$(dirname "$WP_THEME_PATH")")"   # .../wp-content/themes/X -> .../wp-content
 MU_DIR="$WP_CONTENT/mu-plugins"
-SSH=(ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -p "$PORT" -i "$KEY")
-SCP=(scp -o StrictHostKeyChecking=accept-new -P "$PORT" -i "$KEY")
 
 echo "==> ensuring $MU_DIR exists"
 "${SSH[@]}" "${SSH_USER}@${SSH_HOST}" "mkdir -p '$MU_DIR'"
@@ -42,7 +65,10 @@ echo "==> flushing cache"
 
 echo "==> verifying nonce endpoint (should be clean JSON, no <head>/ea11y)"
 RESP="$(curl -s "https://skyyrose.co/?commercekit-ajax=commercekit_get_nonce&cb=$(date +%s)" 2>/dev/null)"
-echo "RESP[0:200]: ${RESP:0:200}"
+# Redact the actual nonce value before printing — nonces are single-use but
+# logging them unnecessarily exposes replay-window material.
+REDACTED="$(printf '%s' "$RESP" | sed 's/"nonce":"[^"]*"/"nonce":"<redacted>"/g')"
+echo "RESP[0:200]: ${REDACTED:0:200}"
 if printf '%s' "$RESP" | grep -q "ea11y-remediation-styles"; then
   echo "RESULT: STILL CORRUPTED — ea11y markup present" >&2
   exit 2
@@ -51,3 +77,5 @@ case "$RESP" in
   '{'*) echo "RESULT: PASS — clean JSON, no Ally injection" ;;
   *)    echo "RESULT: PARTIAL — Ally gone but body not pure JSON; inspect (residual wrapper?)" ;;
 esac
+
+unset SSHPASS

--- a/scripts/regen-boost-critical-css.sh
+++ b/scripts/regen-boost-critical-css.sh
@@ -15,6 +15,13 @@
 # Usage: STOPSHOW_ACK=1 bash scripts/regen-boost-critical-css.sh   (production write — gated)
 set -euo pipefail
 
+# --- production-write gate ---------------------------------------------------
+if [[ "${STOPSHOW_ACK:-}" != "1" ]]; then
+  echo "STOP — This script writes to the production server (skyyrose.co)." >&2
+  echo "       Set STOPSHOW_ACK=1 to confirm you intend a production write." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(dirname "$SCRIPT_DIR")"
 ENV_FILE="${ENV_FILE:-$ROOT/.env.wordpress}"
@@ -23,9 +30,23 @@ ENV_FILE="${ENV_FILE:-$ROOT/.env.wordpress}"
 source "$ENV_FILE"
 : "${SSH_USER:?missing in env}"; : "${SSH_HOST:?missing in env}"
 
-KEY="${SSH_KEY_PATH:-$HOME/.ssh/skyyrose-deploy}"
+SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/skyyrose-deploy}"
 PORT="${SSH_PORT:-22}"
-SSH=(ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -p "$PORT" -i "$KEY")
+SSH_STRICT="${SSH_STRICT_HOST:-accept-new}"
+
+# Build SSH command — key preferred, sshpass fallback (mirrors
+# wp-cli-nextgen-backfill.sh pattern so both auth methods work).
+SSH_BASE=( ssh -o "StrictHostKeyChecking=$SSH_STRICT" -o ConnectTimeout=15 -p "$PORT" )
+if [[ -f "$SSH_KEY_PATH" ]]; then
+  SSH=( "${SSH_BASE[@]}" -i "$SSH_KEY_PATH" )
+elif [[ -n "${SSH_PASS:-}" ]] && command -v sshpass &>/dev/null; then
+  export SSHPASS="$SSH_PASS"
+  SSH=( sshpass -e "${SSH_BASE[@]}" )
+else
+  echo "FATAL: No SSH credentials (no key at $SSH_KEY_PATH and no SSH_PASS+sshpass)" >&2
+  exit 1
+fi
+
 HOST="${SSH_USER}@${SSH_HOST}"
 
 echo "==> [probe] Boost status + CLI surface + critical-css options (read-only)"
@@ -53,3 +74,5 @@ if [ "${HITS}" = "0" ]; then
 else
   echo "RESULT: PENDING — critical CSS may regenerate async on next requests; re-check in a minute" >&2
 fi
+
+unset SSHPASS

--- a/scripts/regen-boost-critical-css.sh
+++ b/scripts/regen-boost-critical-css.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Regenerate Jetpack Boost critical CSS on skyyrose.co.
+#
+# Fixes the stale-cache console error: the theme no longer references the
+# external grainy-gradients.vercel.app/noise.svg, but Boost's cached critical
+# CSS still holds the dead rule. We force a fresh regeneration.
+#
+# Strategy (least-disruptive first):
+#   1. Probe Boost's WP-CLI surface + critical-CSS storage (read-only).
+#   2. If a CLI regenerate/clear command exists, use it in place (no downtime).
+#   3. Otherwise clear the stored critical-CSS option so Boost rebuilds lazily.
+#   4. Guaranteed fallback: reactivate Boost (brief unoptimized window, self-heals).
+# Then flush caches and verify the dead URL is gone from the homepage.
+#
+# Usage: STOPSHOW_ACK=1 bash scripts/regen-boost-critical-css.sh   (production write — gated)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="${ENV_FILE:-$ROOT/.env.wordpress}"
+[ -f "$ENV_FILE" ] || { echo "FATAL: $ENV_FILE missing" >&2; exit 1; }
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+: "${SSH_USER:?missing in env}"; : "${SSH_HOST:?missing in env}"
+
+KEY="${SSH_KEY_PATH:-$HOME/.ssh/skyyrose-deploy}"
+PORT="${SSH_PORT:-22}"
+SSH=(ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -p "$PORT" -i "$KEY")
+HOST="${SSH_USER}@${SSH_HOST}"
+
+echo "==> [probe] Boost status + CLI surface + critical-css options (read-only)"
+"${SSH[@]}" "$HOST" "wp plugin get jetpack-boost --field=status 2>/dev/null; echo '--- cli ---'; wp help jetpack-boost 2>/dev/null | sed -n '1,40p' || echo 'no jetpack-boost CLI'; echo '--- options ---'; wp option list --search='jetpack_boost*' --format=table 2>/dev/null | sed -n '1,40p' || true"
+
+echo "==> [regen] clearing stored critical CSS + reactivating Boost"
+# data_sync stores critical CSS state under jetpack_boost_ds_* ; delete the
+# critical-css state keys if present (harmless — Boost rebuilds them), then
+# reactivate to kick a fresh generation. Each step tolerates absence.
+"${SSH[@]}" "$HOST" "
+  wp option delete jetpack_boost_ds_critical_css_state 2>/dev/null || true
+  wp option delete jetpack_boost_ds_critical_css_state_errors 2>/dev/null || true
+  wp option delete jetpack_boost_critical_css 2>/dev/null || true
+  wp plugin deactivate jetpack-boost 2>/dev/null || true
+  wp plugin activate jetpack-boost 2>/dev/null || true
+  wp cache flush 2>/dev/null || true
+  wp transient delete --all 2>/dev/null || true
+"
+
+echo "==> [verify] dead grain URL gone from homepage critical CSS?"
+HITS="$(curl -s "https://skyyrose.co/?cb=$(date +%s)" 2>/dev/null | grep -c "grainy-gradients.vercel.app" || true)"
+echo "grainy-gradients.vercel.app occurrences on homepage: ${HITS}"
+if [ "${HITS}" = "0" ]; then
+  echo "RESULT: PASS — dead grain URL no longer present"
+else
+  echo "RESULT: PENDING — critical CSS may regenerate async on next requests; re-check in a minute" >&2
+fi

--- a/wordpress/mu-plugins/skyyrose-ally-ajax-guard.php
+++ b/wordpress/mu-plugins/skyyrose-ally-ajax-guard.php
@@ -8,7 +8,7 @@
  *   can break cart/checkout. We remove Ally from the active-plugins list ONLY for
  *   AJAX / WC-AJAX / REST requests, so it never loads its buffer there. Normal
  *   front-end HTML pages are untouched — Ally still runs everywhere it should.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: SkyyRose Dev Team
  *
  * Why an MU-plugin: this must run before the `active_plugins` option is consumed
@@ -26,10 +26,16 @@ add_filter(
 			return $plugins;
 		}
 
-		$uri        = isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '';
+		$uri        = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( (string) $_SERVER['REQUEST_URI'] ) : '';
 		$is_ck_ajax = isset( $_GET['commercekit-ajax'] );
 		$is_wc_ajax = isset( $_GET['wc-ajax'] );
-		$is_rest    = ( '' !== $uri && false !== strpos( $uri, '/wp-json/' ) );
+
+		// Detect REST requests via two routing styles:
+		//   1. Pretty-permalink route:  /wp-json/...
+		//   2. Index-PHP route (WP.com Atomic / plain-permalink fallback):
+		//      index.php?rest_route=...  or  ?rest_route=...
+		$is_rest = ( '' !== $uri && false !== strpos( $uri, '/wp-json/' ) )
+		        || isset( $_GET['rest_route'] );
 
 		if ( ! ( $is_ck_ajax || $is_wc_ajax || $is_rest ) ) {
 			return $plugins;

--- a/wordpress/mu-plugins/skyyrose-ally-ajax-guard.php
+++ b/wordpress/mu-plugins/skyyrose-ally-ajax-guard.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Plugin Name: SkyyRose — Keep Ally off non-HTML responses
+ * Description: Ally (pojo-accessibility) runs an unconditional output buffer that
+ *   injects its remediation <style id="ea11y-remediation-styles"> into EVERY
+ *   response, including JSON. That corrupts CommerceKit's nonce endpoint
+ *   (?commercekit-ajax=commercekit_get_nonce) and any AJAX/REST JSON body, which
+ *   can break cart/checkout. We remove Ally from the active-plugins list ONLY for
+ *   AJAX / WC-AJAX / REST requests, so it never loads its buffer there. Normal
+ *   front-end HTML pages are untouched — Ally still runs everywhere it should.
+ * Version: 1.0.0
+ * Author: SkyyRose Dev Team
+ *
+ * Why an MU-plugin: this must run before the `active_plugins` option is consumed
+ * (i.e. before regular plugins load). The theme and regular plugins are too late.
+ *
+ * @package SkyyRose
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_filter(
+	'option_active_plugins',
+	static function ( $plugins ) {
+		if ( ! is_array( $plugins ) ) {
+			return $plugins;
+		}
+
+		$uri        = isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '';
+		$is_ck_ajax = isset( $_GET['commercekit-ajax'] );
+		$is_wc_ajax = isset( $_GET['wc-ajax'] );
+		$is_rest    = ( '' !== $uri && false !== strpos( $uri, '/wp-json/' ) );
+
+		if ( ! ( $is_ck_ajax || $is_wc_ajax || $is_rest ) ) {
+			return $plugins;
+		}
+
+		return array_values(
+			array_filter(
+				$plugins,
+				static function ( $plugin ) {
+					return false === strpos( (string) $plugin, 'pojo-accessibility/' );
+				}
+			)
+		);
+	},
+	1
+);


### PR DESCRIPTION
## What

Source-of-truth for two **already-deployed-and-verified** live fixes to two skyyrose.co homepage console errors. Both were plugin/cache issues, not theme code.

### Error 2 — Ally corrupts CommerceKit nonce JSON (functional, cart/checkout)
`pojo-accessibility` (Ally, Elementor) runs an unconditional output buffer that injects `<style id="ea11y-remediation-styles">` + a `<head>` into **every** response — including CommerceKit's `?commercekit-ajax=commercekit_get_nonce` JSON, breaking the nonce. New MU-plugin `wordpress/mu-plugins/skyyrose-ally-ajax-guard.php` removes Ally from `active_plugins` on `?commercekit-ajax` / `?wc-ajax` / `/wp-json/` requests **only** (must be an MU-plugin — runs before `option_active_plugins` is consumed). HTML pages: Ally unchanged.
- **Verified live:** endpoint now returns `{"status":1,"nonce":"…","state":0}` — clean JSON, no injection.

### Error 1 — stale Jetpack Boost critical CSS (cosmetic)
Theme source no longer references the external `grainy-gradients.vercel.app/noise.svg`, but Boost's cached critical CSS still held the dead rule (it was stuck `status: pending`). `scripts/regen-boost-critical-css.sh` clears `jetpack_boost_ds_critical_css_state` + reactivates Boost to force a clean rebuild.
- **Verified live:** 0 occurrences of the dead URL on the homepage; homepage HTTP 200 / 185KB / no PHP errors after.

### Tooling
`scripts/deploy-mu-plugin.sh` (scp the MU-plugin + verify) and `scripts/regen-boost-critical-css.sh`. Both source `.env.wordpress` at runtime — no secrets in repo.

## Notes
- The MU-plugin is **already live** on skyyrose.co; this PR is its version-controlled source of truth (avoids the unversioned-prod-code stranding risk).
- Deploy scripts reference `~/.ssh/skyyrose-deploy`; that key path may live on the `coreyfoster` machine (worked here via a fallback key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01QJF6Lg6RQzXtxdAciZt5w9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `pojo-accessibility` from injecting markup into AJAX/REST JSON (including `?rest_route=`) and add safe tooling to regenerate `Jetpack Boost` critical CSS. Fixes broken checkout nonces and removes the stale `grainy-gradients.vercel.app` rule on the homepage.

- **Bug Fixes**
  - Added MU-plugin to exclude `pojo-accessibility` on `?commercekit-ajax`, `?wc-ajax`, `/wp-json/`, and `?rest_route=` requests by filtering `active_plugins` early; HTML pages unchanged.
  - Added `scripts/deploy-mu-plugin.sh` to upload/verify the MU-plugin with a `STOPSHOW_ACK=1` gate, SSH key-or-`sshpass` fallback, and nonce redaction in logs.
  - Added `scripts/regen-boost-critical-css.sh` to clear `jetpack_boost_ds_critical_css_state` and related options, reactivate `jetpack-boost`, flush cache/transients, and verify the dead URL is gone.

<sup>Written for commit c6d30707530684b042528ca91920844e44fb0d58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

