### PR TITLE
fix(forecasting): clamp lead/horizon in DemandForecaster (#18004)

### DIFF
--- a/services/forecasting/demand.py
+++ b/services/forecasting/demand.py
@@ -149,8 +149,12 @@ class DemandForecaster:
         self.baseline_days = max(
             1, baseline_days if baseline_days is not None else self.window_days
         )
-        self.lead_time_days = lead_time_days
-        self.sellout_horizon_days = sellout_horizon_days
+        # Clamp both bands defensively (mirrors the window/baseline clamps above). The class is
+        # founder-tunable, and _sellout_risk's cascade assumes 0 < lead_time_days < sellout_horizon
+        # _days. Without this, lead <= 0 makes CRITICAL unreachable (silent under-alert) and
+        # lead >= horizon collapses the HIGH band to empty. +1 keeps HIGH a non-empty interval.
+        self.lead_time_days = max(1, lead_time_days)
+        self.sellout_horizon_days = max(self.lead_time_days + 1, sellout_horizon_days)
         self.accel_ratio = accel_ratio
         self.decline_ratio = decline_ratio
 

--- a/tests/services/test_demand_forecast.py
+++ b/tests/services/test_demand_forecast.py
@@ -255,3 +255,38 @@ def test_parse_dt_accepts_datetime_objects():
     sales = [{"date": AS_OF - timedelta(days=d), "units": 2} for d in range(1, 15)]
     f = DemandForecaster().forecast(_product(sales), as_of=AS_OF)
     assert f.daily_velocity == pytest.approx(2.0)
+
+
+# --------------------------------------------------------------------------- #
+# Regression: #18004 lead/horizon clamp
+# --------------------------------------------------------------------------- #
+
+
+def test_sellout_high_reachable_when_lead_exceeds_horizon():
+    """Misconfig lead > horizon must not collapse the HIGH band (was unreachable pre-fix)."""
+    # lead=45, horizon=30 -> clamped to lead=45, horizon=46. velocity 2/day, inventory 91
+    # -> days_to_sellout=45.5, which lands in the HIGH band (45 < 45.5 <= 46).
+    f = DemandForecaster(lead_time_days=45, sellout_horizon_days=30).forecast(
+        _product(_daily(2, 1, 28), inventory=91), as_of=AS_OF
+    )
+    assert f.days_to_sellout == pytest.approx(45.5)
+    assert f.sellout_risk is SelloutRisk.HIGH
+    assert f.recommended_action == "reorder_soon"
+
+
+def test_sellout_critical_reachable_with_nonpositive_lead():
+    """lead<=0 must not make CRITICAL unreachable (was a silent under-alert pre-fix)."""
+    # lead=0 -> clamped to 1. velocity 2/day, inventory 1 -> days_to_sellout=0.5 <= 1 -> CRITICAL.
+    f = DemandForecaster(lead_time_days=0).forecast(
+        _product(_daily(2, 1, 28), inventory=1), as_of=AS_OF
+    )
+    assert f.days_to_sellout == pytest.approx(0.5)
+    assert f.sellout_risk is SelloutRisk.CRITICAL
+    assert f.recommended_action == "reorder_now"
+
+
+def test_constructor_clamps_lead_and_horizon():
+    """Constructor clamps lead>=1 and horizon>=lead+1 regardless of input."""
+    fc = DemandForecaster(lead_time_days=0, sellout_horizon_days=-5)
+    assert fc.lead_time_days == 1
+    assert fc.sellout_horizon_days == 2


### PR DESCRIPTION
Extracted from #594 (closed as superseded — see below).

## What
`DemandForecaster.__init__` now clamps `lead_time_days >= 1` and `sellout_horizon_days >= lead+1`, mirroring the existing `max(1, …)` clamps on `window_days`/`baseline_days`. Closes issue #18004's two silent failure modes on the founder-tunable constructor:
- `lead <= 0` → CRITICAL band (`dts <= lead`) unreachable → genuine sellout emergencies silently downgraded to HIGH (under-alert).
- `lead >= horizon` → HIGH band (`lead < dts <= horizon`) collapses to empty → over-alert / lost gradation.

The `+1` keeps HIGH a non-empty interval. **Zero behavior change at the default `lead=14`/`horizon=30`.** +3 regression tests (HIGH reachable under `lead=45`, CRITICAL reachable under `lead<=0`, constructor clamp).

## Verification
`tests/services/test_demand_forecast.py` → 33 passed. Cherry-picked cleanly onto current `main` (the clamp is the only diff in `demand.py`).

## Why not #594
#594 carried this fix alongside the Tier-1+2 agent services — but those services **already landed on `main` independently via parallel PRs**, so #594 became a stale fork (262 files, would revert ~11k lines of main). The #18004 clamp was its only unique value, extracted here as a clean 2-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01QJF6Lg6RQzXtxdAciZt5w9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp `DemandForecaster` inputs to keep risk bands valid and prevent silent misclassification. Fixes #18004 by enforcing a safe range for `lead_time_days` and `sellout_horizon_days`.

- **Bug Fixes**
  - Clamp `lead_time_days` to at least 1.
  - Clamp `sellout_horizon_days` to at least `lead_time_days + 1` to keep the HIGH band non-empty.
  - Added 3 regression tests to ensure HIGH and CRITICAL remain reachable under misconfigurations.
  - No change to defaults (`lead=14`, `horizon=30`).

<sup>Written for commit ad252f1ed07b1efeac19e6c1108daf0b44c37c8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Demand forecasting system now includes automatic validation and correction of lead time and sales horizon parameters. Invalid configurations that previously resulted in incorrect risk band calculations are now handled defensively, ensuring accurate assessments and preventing system errors across all edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->