### PR TITLE
fix(deps): remove asyncio==3.4.3 stdlib-shadowing shim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,6 @@ mcp = [
     "pydantic-settings>=2.8.0",
     "httpx>=0.28.1",
     "aiohttp>=3.12.14",
-    "asyncio==3.4.3",
     # Capped <25 so .[all] resolves: the rag extra (raganything->mineru->gradio)
     # requires aiofiles<25.0; base needs >=24.1.0. Neither fastmcp nor the mcp
     # SDK depend on aiofiles (verified via PyPI requires-dist), so the prior
@@ -267,7 +266,6 @@ ml = [
     "lime==0.2.0.1",
     "polars==1.41.2",
     "pyarrow==24.0.0",
-    "asyncio==3.4.3",
     "hydra-core==1.3.3",
     "omegaconf==2.3.1",
     "tqdm==4.67.3",


### PR DESCRIPTION
## Problem
`asyncio==3.4.3` (PyPI, 2015, abandoned) is a pre-Python-3.4 backport that **shadows the standard-library asyncio** on Python 3.11+. It installs a stale `site-packages/asyncio/` that can intermittently break `async`/`await` and event-loop resolution depending on `sys.path` order. Flagged **HIGH** in code review.

## Fix
Remove both pins (base deps line 178 + ML extra line 270). `asyncio` is stdlib on all supported versions.

## Verification
- `grep asyncio==3.4.3` → 0
- TOML parses, 57 base deps intact, `aiofiles` cap comment preserved
- `python -c 'import asyncio; print(asyncio.__file__)'` → resolves to cpython 3.13 stdlib, not site-packages

Branched off `origin/main` (isolated from the in-flight Docker WIP that entangles `pyproject.toml` on other branches).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the obsolete PyPI `asyncio==3.4.3` shim from `pyproject.toml` (base and `ml` extra) to stop shadowing the stdlib and avoid async/await and event-loop issues on Python 3.11+. `import asyncio` now resolves to the CPython stdlib on all supported versions.

<sup>Written for commit 1dca904f9a9f40e9d6a319b19e794bd8a891244f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

