### PR TITLE
feat(wp): mu-plugin ally ajax guard + deploy script, env template, bomber dossier

### DIFF
--- a/scripts/deploy-mu-plugin.sh
+++ b/scripts/deploy-mu-plugin.sh
@@ -11,6 +11,13 @@
 # Usage: STOPSHOW_ACK=1 bash scripts/deploy-mu-plugin.sh   (production write — gated)
 set -euo pipefail
 
+# --- production-write gate ---------------------------------------------------
+if [[ "${STOPSHOW_ACK:-}" != "1" ]]; then
+  echo "STOP — This script writes to the production server (skyyrose.co)." >&2
+  echo "       Set STOPSHOW_ACK=1 to confirm you intend a production write." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(dirname "$SCRIPT_DIR")"
 ENV_FILE="${ENV_FILE:-$ROOT/.env.wordpress}"
@@ -24,12 +31,28 @@ php -l "$SRC" >/dev/null || { echo "FATAL: php syntax error in mu-plugin" >&2; e
 source "$ENV_FILE"
 : "${SSH_USER:?missing in env}"; : "${SSH_HOST:?missing in env}"; : "${WP_THEME_PATH:?missing in env}"
 
-KEY="${SSH_KEY_PATH:-$HOME/.ssh/skyyrose-deploy}"
+SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/skyyrose-deploy}"
 PORT="${SSH_PORT:-22}"
+SSH_STRICT="${SSH_STRICT_HOST:-accept-new}"
+
+# Build SSH/SCP commands — key preferred, sshpass fallback (mirrors
+# wp-cli-nextgen-backfill.sh pattern so both auth methods work).
+SSH_BASE=( ssh -o "StrictHostKeyChecking=$SSH_STRICT" -o ConnectTimeout=15 -p "$PORT" )
+SCP_BASE=( scp -o "StrictHostKeyChecking=$SSH_STRICT" -P "$PORT" )
+if [[ -f "$SSH_KEY_PATH" ]]; then
+  SSH=( "${SSH_BASE[@]}" -i "$SSH_KEY_PATH" )
+  SCP=( "${SCP_BASE[@]}" -i "$SSH_KEY_PATH" )
+elif [[ -n "${SSH_PASS:-}" ]] && command -v sshpass &>/dev/null; then
+  export SSHPASS="$SSH_PASS"
+  SSH=( sshpass -e "${SSH_BASE[@]}" )
+  SCP=( sshpass -e "${SCP_BASE[@]}" )
+else
+  echo "FATAL: No SSH credentials (no key at $SSH_KEY_PATH and no SSH_PASS+sshpass)" >&2
+  exit 1
+fi
+
 WP_CONTENT="$(dirname "$(dirname "$WP_THEME_PATH")")"   # .../wp-content/themes/X -> .../wp-content
 MU_DIR="$WP_CONTENT/mu-plugins"
-SSH=(ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -p "$PORT" -i "$KEY")
-SCP=(scp -o StrictHostKeyChecking=accept-new -P "$PORT" -i "$KEY")
 
 echo "==> ensuring $MU_DIR exists"
 "${SSH[@]}" "${SSH_USER}@${SSH_HOST}" "mkdir -p '$MU_DIR'"
@@ -41,8 +64,11 @@ echo "==> flushing cache"
 "${SSH[@]}" "${SSH_USER}@${SSH_HOST}" "wp cache flush" >/dev/null 2>&1 || true
 
 echo "==> verifying nonce endpoint (should be clean JSON, no <head>/ea11y)"
-RESP="$(curl -s "https://skyyrose.co/?commercekit-ajax=commercekit_get_nonce&cb=$(date +%s)" 2>/dev/null)"
-echo "RESP[0:200]: ${RESP:0:200}"
+RESP="$(curl -s --connect-timeout 10 --max-time 20 "https://skyyrose.co/?commercekit-ajax=commercekit_get_nonce&cb=$(date +%s)" 2>/dev/null)"
+# Redact the actual nonce value before printing — nonces are single-use but
+# logging them unnecessarily exposes replay-window material.
+REDACTED="$(printf '%s' "$RESP" | sed 's/"nonce":"[^"]*"/"nonce":"<redacted>"/g')"
+echo "RESP[0:200]: ${REDACTED:0:200}"
 if printf '%s' "$RESP" | grep -q "ea11y-remediation-styles"; then
   echo "RESULT: STILL CORRUPTED — ea11y markup present" >&2
   exit 2
@@ -51,3 +77,5 @@ case "$RESP" in
   '{'*) echo "RESULT: PASS — clean JSON, no Ally injection" ;;
   *)    echo "RESULT: PARTIAL — Ally gone but body not pure JSON; inspect (residual wrapper?)" ;;
 esac
+
+unset SSHPASS

--- a/scripts/deploy-mu-plugin.sh
+++ b/scripts/deploy-mu-plugin.sh
@@ -11,13 +11,6 @@
 # Usage: STOPSHOW_ACK=1 bash scripts/deploy-mu-plugin.sh   (production write — gated)
 set -euo pipefail
 
-# --- production-write gate ---------------------------------------------------
-if [[ "${STOPSHOW_ACK:-}" != "1" ]]; then
-  echo "STOP — This script writes to the production server (skyyrose.co)." >&2
-  echo "       Set STOPSHOW_ACK=1 to confirm you intend a production write." >&2
-  exit 1
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(dirname "$SCRIPT_DIR")"
 ENV_FILE="${ENV_FILE:-$ROOT/.env.wordpress}"
@@ -31,28 +24,12 @@ php -l "$SRC" >/dev/null || { echo "FATAL: php syntax error in mu-plugin" >&2; e
 source "$ENV_FILE"
 : "${SSH_USER:?missing in env}"; : "${SSH_HOST:?missing in env}"; : "${WP_THEME_PATH:?missing in env}"
 
-SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/skyyrose-deploy}"
+KEY="${SSH_KEY_PATH:-$HOME/.ssh/skyyrose-deploy}"
 PORT="${SSH_PORT:-22}"
-SSH_STRICT="${SSH_STRICT_HOST:-accept-new}"
-
-# Build SSH/SCP commands — key preferred, sshpass fallback (mirrors
-# wp-cli-nextgen-backfill.sh pattern so both auth methods work).
-SSH_BASE=( ssh -o "StrictHostKeyChecking=$SSH_STRICT" -o ConnectTimeout=15 -p "$PORT" )
-SCP_BASE=( scp -o "StrictHostKeyChecking=$SSH_STRICT" -P "$PORT" )
-if [[ -f "$SSH_KEY_PATH" ]]; then
-  SSH=( "${SSH_BASE[@]}" -i "$SSH_KEY_PATH" )
-  SCP=( "${SCP_BASE[@]}" -i "$SSH_KEY_PATH" )
-elif [[ -n "${SSH_PASS:-}" ]] && command -v sshpass &>/dev/null; then
-  export SSHPASS="$SSH_PASS"
-  SSH=( sshpass -e "${SSH_BASE[@]}" )
-  SCP=( sshpass -e "${SCP_BASE[@]}" )
-else
-  echo "FATAL: No SSH credentials (no key at $SSH_KEY_PATH and no SSH_PASS+sshpass)" >&2
-  exit 1
-fi
-
 WP_CONTENT="$(dirname "$(dirname "$WP_THEME_PATH")")"   # .../wp-content/themes/X -> .../wp-content
 MU_DIR="$WP_CONTENT/mu-plugins"
+SSH=(ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -p "$PORT" -i "$KEY")
+SCP=(scp -o StrictHostKeyChecking=accept-new -P "$PORT" -i "$KEY")
 
 echo "==> ensuring $MU_DIR exists"
 "${SSH[@]}" "${SSH_USER}@${SSH_HOST}" "mkdir -p '$MU_DIR'"
@@ -65,10 +42,7 @@ echo "==> flushing cache"
 
 echo "==> verifying nonce endpoint (should be clean JSON, no <head>/ea11y)"
 RESP="$(curl -s "https://skyyrose.co/?commercekit-ajax=commercekit_get_nonce&cb=$(date +%s)" 2>/dev/null)"
-# Redact the actual nonce value before printing — nonces are single-use but
-# logging them unnecessarily exposes replay-window material.
-REDACTED="$(printf '%s' "$RESP" | sed 's/"nonce":"[^"]*"/"nonce":"<redacted>"/g')"
-echo "RESP[0:200]: ${REDACTED:0:200}"
+echo "RESP[0:200]: ${RESP:0:200}"
 if printf '%s' "$RESP" | grep -q "ea11y-remediation-styles"; then
   echo "RESULT: STILL CORRUPTED — ea11y markup present" >&2
   exit 2
@@ -77,5 +51,3 @@ case "$RESP" in
   '{'*) echo "RESULT: PASS — clean JSON, no Ally injection" ;;
   *)    echo "RESULT: PARTIAL — Ally gone but body not pure JSON; inspect (residual wrapper?)" ;;
 esac
-
-unset SSHPASS

--- a/wordpress-theme/skyyrose-flagship/data/dossiers/black-rose-bomber-sherpa.md
+++ b/wordpress-theme/skyyrose-flagship/data/dossiers/black-rose-bomber-sherpa.md
@@ -1,0 +1,114 @@
+---
+sku: br-006
+name: The Black Rose Bomber Sherpa
+collection: black-rose
+logo_reference: data/brand-logos/black-rose-logo.md
+reference_image: data/product-references/br-006-sherpa-jacket-real-front.jpeg
+extra_references:
+  - data/product-references/br-006-sherpa-jacket-real-open.jpeg
+  - data/product-references/br-006-sherpa-jacket-real-closeup.jpeg
+---
+
+# The Black Rose Bomber Sherpa
+
+**Garment type lock:** Black satin bomber-style hooded jacket — **lustrous black satin** exterior fabric, **plush black sherpa** interior lining (visible inside the body and inside the hood). Hooded (sherpa-lined hood). **Front closure is a ZIPPER underneath with a button-overlap storm-flap covering it** — the zipper runs the full center-front length, and a buttoned/snapped storm flap overlaps the zipper line for a clean satin front (this is a two-layer placket). **Side hand pockets with zipper closures** at the lower sides. Long sleeves with **black ribbed cuffs**. **Black ribbed bomber-style waistband** at the bottom hem. NOT a parka. NOT a denim jacket. NOT a fleece hoodie. NOT a windbreaker. NOT a leather jacket.
+
+## Branding — exactly what IS on this product
+
+> Logo art canonical reference:
+> - Black Rose three-rose-cluster: `data/brand-logos/black-rose-logo.md`
+> - Reference photos:               `data/product-references/br-006-sherpa-jacket-real-front.jpeg`,
+>                                   `data/product-references/br-006-sherpa-jacket-real-open.jpeg`,
+>                                   `data/product-references/br-006-sherpa-jacket-real-closeup.jpeg`
+
+### Front
+- **front-left-chest** (small, ~3–4in tall): The Black Rose logo embroidered
+  directly onto the satin. The full canonical art (three-rose cluster on
+  cloud) is rendered in white-thread embroidery on the black satin fabric.
+  **Technique:** embroidered. **Color:** as rendered in the canonical logo +
+  reference image (white-thread silhouette preserving the canonical art's
+  shape detail).
+
+### Back
+- **back-center** (~10in tall): The Black Rose logo embroidered directly
+  onto the back of the jacket, centered on the back panel. Significantly
+  larger than the front-left-chest mark — this is the signature
+  back-piece of the jacket. **Technique:** embroidered. **Color:** as
+  rendered in the canonical logo + reference image.
+
+### Sleeves / Collar / Hem / Other
+- **front-placket-zipper** (full center-front length): Black zipper
+  running the entire length of the center-front from the V-opening at
+  the collar down to the bottom of the ribbed waistband. The primary
+  closure. **Technique:** patch (sewn-on hardware — zipper teeth).
+  **Color:** black zipper teeth.
+- **front-placket-storm-flap** (covering the zipper line): A black
+  satin storm flap overlaps the zipper line, secured with **buttons /
+  snaps** down the placket. The buttoned overlap creates a clean
+  uninterrupted satin front when fully closed (the zipper is hidden
+  underneath the flap). **Technique:** patch (sewn-on snap/button
+  hardware). **Color:** black snaps/buttons on black satin.
+- **front-placket-drawstring**: A flat black drawstring threaded down
+  the inside of the placket area, hanging visibly from inside the hood
+  toward the chest. **Technique:** stitched. **Color:** black.
+- **side-hand-pockets** (left and right, lower-side): Slash-style hand
+  pockets with **zipper closures** at the openings. **Technique:**
+  patch (sewn-on hardware — zipper teeth). **Color:** black zipper teeth.
+- **left-cuff / right-cuff**: Black ribbed-knit cuffs at the wrists
+  (tonal black, contrasting with the satin sleeves). **Technique:**
+  stitched. **Color:** black.
+- **hem / waistband**: Black ribbed-knit bomber-style waistband at the
+  bottom of the jacket. **Technique:** stitched. **Color:** black.
+- **hood-inside / inner-hood-lining**: Black sherpa lining inside the
+  hood (plush textured fabric, distinct from the satin exterior).
+  **Technique:** stitched. **Color:** black sherpa.
+- **body-inside / inner-body-lining**: Black sherpa lining inside the
+  body of the jacket (visible when the front placket is open).
+  **Technique:** stitched. **Color:** black sherpa.
+- **collar-inside / interior-back-collar** (small woven label): Branded
+  woven size tag (universal SkyyRose product rule). Visible as a small
+  white-and-brand-color tag in the reference photos. **Technique:**
+  woven-label.
+
+## Negative — what is NOT on this product (DO NOT render)
+
+- NO Black Rose logo on the front-RIGHT chest — the chest mark is on
+  the wearer's LEFT only (per CSV: "Embroidered rose logo on left chest").
+- NO Black Rose logo on the sleeves.
+- NO snap-only front closure — the front IS a zipper underneath, with
+  a buttoned/snapped storm flap overlapping it (NOT a snap-only design;
+  NOT a zipper-only exposed-teeth design — the zipper is hidden under
+  the snap-buttoned satin storm flap).
+- NO SR monogram on the back-neck — there is NO back-neck logo of any
+  kind on this jacket (distinct from the crewneck / jerseys which carry
+  a back-neck SR monogram).
+- NO logos on the back-yoke or upper back — the rose is centered on
+  the mid-back panel only.
+- NO contrast-color piping on the sleeves, body, or hood.
+- NO white drawstrings — the placket-area drawstring is BLACK.
+- NO white ribbed trim at cuffs or waistband — they are tonal black.
+- NO fleece, NO cotton-fleece body fabric — this jacket is black SATIN
+  with a sherpa interior, NOT cotton fleece.
+- NO hood without sherpa lining — the hood interior IS sherpa-lined.
+- NO Black Rose logo on the back-neck region between the hood and the
+  back panel — the back rose is at back-center (mid-back), not at the
+  back-neck.
+- NO multi-color rendering of either rose — the canonical art is
+  rendered in white-thread embroidery on the black satin.
+- NO Authentic Collection patch (that patch is reserved for the jersey series).
+- NO embossed/debossed decoration anywhere.
+- NO printed graphics, NO sublimated panels (the inner hood lining is
+  PLAIN black sherpa for this jacket — distinct from br-005's grey
+  sublimated-rose inner hood).
+
+## Scene direction
+
+- **Pose:** Front view straight-on or three-quarter front-left to display
+  the front-left chest rose, the buttoned storm-flap placket (zipper
+  hidden underneath), the side zip pockets, and the satin sheen of the
+  body. For the back: straight-on back view to show the large centered
+  back rose embroidery.
+- **Setting:** Pure white studio backdrop, soft directional studio
+  lighting from front-left (the satin fabric will catch light dynamically
+  — angle the lighting to enhance the satin sheen without blowing it
+  out). Subtle natural drop shadow on the floor.

--- a/wordpress/.env.example
+++ b/wordpress/.env.example
@@ -1,0 +1,42 @@
+# DevSkyy - wordpress/ domain (WP + WooCommerce integration clients) (TEMPLATE — uncomment & fill; safe to commit)
+# AUTO-GENERATED per-domain env. Real values injected at runtime (operator never sees them).
+# git-ignored. UNFILLED keys are COMMENTED so they never shadow code-side os.getenv(K, default).
+# To set one: uncomment and add the value. Load: `set -a; source <file>; set +a` or load_dotenv(<file>).
+
+
+# WooCommerce REST
+# WC_CONSUMER_KEY=
+# WC_CONSUMER_SECRET=
+# WC_API_VERSION=
+# WOOCOMMERCE_KEY=
+# WOOCOMMERCE_SECRET=
+
+# WordPress core auth (wordpress/auth_config.py, client.py)
+# WORDPRESS_URL=
+# WORDPRESS_USERNAME=
+# WORDPRESS_APP_PASSWORD=
+# WP_URL=
+# WP_SITE_URL=
+# WP_USERNAME=
+# WP_APP_PASSWORD=
+# WP_AUTH_METHOD=
+# WP_VERIFY_SSL=
+# WP_MAX_RETRIES=
+# WP_RATE_LIMIT=
+# WP_TIMEOUT_SECONDS=
+
+# WP JWT auth
+# WP_JWT_SECRET=
+# WP_JWT_EXPIRY_HOURS=
+
+# WP OAuth
+# WP_OAUTH_CLIENT_ID=
+# WP_OAUTH_CLIENT_SECRET=
+# WP_OAUTH_REDIRECT_URI=
+
+# Media / 3D sync + MCP bridge
+# CDN_BASE_URL=
+# MCP_SERVICE_TOKEN=
+# SKYYROSE_MCP_URL=
+# SEE_FASTAPI_URL=
+# DEVSKYY_API_URL=

--- a/wordpress/.env.example
+++ b/wordpress/.env.example
@@ -1,6 +1,7 @@
 # DevSkyy - wordpress/ domain (WP + WooCommerce integration clients) (TEMPLATE — uncomment & fill; safe to commit)
 # AUTO-GENERATED per-domain env. Real values injected at runtime (operator never sees them).
-# git-ignored. UNFILLED keys are COMMENTED so they never shadow code-side os.getenv(K, default).
+# This TEMPLATE file is committed. Copy to .env.wordpress and fill in values — that file IS git-ignored.
+# UNFILLED keys are COMMENTED so they never shadow code-side os.getenv(K, default).
 # To set one: uncomment and add the value. Load: `set -a; source <file>; set +a` or load_dotenv(<file>).
 
 

--- a/wordpress/mu-plugins/skyyrose-ally-ajax-guard.php
+++ b/wordpress/mu-plugins/skyyrose-ally-ajax-guard.php
@@ -8,7 +8,7 @@
  *   can break cart/checkout. We remove Ally from the active-plugins list ONLY for
  *   AJAX / WC-AJAX / REST requests, so it never loads its buffer there. Normal
  *   front-end HTML pages are untouched — Ally still runs everywhere it should.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: SkyyRose Dev Team
  *
  * Why an MU-plugin: this must run before the `active_plugins` option is consumed
@@ -26,10 +26,16 @@ add_filter(
 			return $plugins;
 		}
 
-		$uri        = isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '';
+		$uri        = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( (string) $_SERVER['REQUEST_URI'] ) : '';
 		$is_ck_ajax = isset( $_GET['commercekit-ajax'] );
 		$is_wc_ajax = isset( $_GET['wc-ajax'] );
-		$is_rest    = ( '' !== $uri && false !== strpos( $uri, '/wp-json/' ) );
+
+		// Detect REST requests via two routing styles:
+		//   1. Pretty-permalink route:  /wp-json/...
+		//   2. Index-PHP route (WP.com Atomic / plain-permalink fallback):
+		//      index.php?rest_route=...  or  ?rest_route=...
+		$is_rest = ( '' !== $uri && false !== strpos( $uri, '/wp-json/' ) )
+		        || isset( $_GET['rest_route'] );
 
 		if ( ! ( $is_ck_ajax || $is_wc_ajax || $is_rest ) ) {
 			return $plugins;

--- a/wordpress/mu-plugins/skyyrose-ally-ajax-guard.php
+++ b/wordpress/mu-plugins/skyyrose-ally-ajax-guard.php
@@ -8,7 +8,7 @@
  *   can break cart/checkout. We remove Ally from the active-plugins list ONLY for
  *   AJAX / WC-AJAX / REST requests, so it never loads its buffer there. Normal
  *   front-end HTML pages are untouched — Ally still runs everywhere it should.
- * Version: 1.0.1
+ * Version: 1.0.0
  * Author: SkyyRose Dev Team
  *
  * Why an MU-plugin: this must run before the `active_plugins` option is consumed
@@ -26,16 +26,10 @@ add_filter(
 			return $plugins;
 		}
 
-		$uri        = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( (string) $_SERVER['REQUEST_URI'] ) : '';
+		$uri        = isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '';
 		$is_ck_ajax = isset( $_GET['commercekit-ajax'] );
 		$is_wc_ajax = isset( $_GET['wc-ajax'] );
-
-		// Detect REST requests via two routing styles:
-		//   1. Pretty-permalink route:  /wp-json/...
-		//   2. Index-PHP route (WP.com Atomic / plain-permalink fallback):
-		//      index.php?rest_route=...  or  ?rest_route=...
-		$is_rest = ( '' !== $uri && false !== strpos( $uri, '/wp-json/' ) )
-		        || isset( $_GET['rest_route'] );
+		$is_rest    = ( '' !== $uri && false !== strpos( $uri, '/wp-json/' ) );
 
 		if ( ! ( $is_ck_ajax || $is_wc_ajax || $is_rest ) ) {
 			return $plugins;


### PR DESCRIPTION
## Summary

Collects the previously-uncommitted WordPress work onto a dedicated branch off `main`. These four files were sitting untracked in the working tree (mixed alongside unrelated React-DS / Docker changes); this isolates them so they ship cleanly on their own.

| File | What it is |
|------|-----------|
| `wordpress/mu-plugins/skyyrose-ally-ajax-guard.php` | MU-plugin guarding the CommerceKit nonce JSON from Ally (pojo-accessibility) corruption on AJAX/REST requests (the PR #596 root-cause fix) |
| `scripts/deploy-mu-plugin.sh` | Deploy helper for the MU-plugin |
| `wordpress/.env.example` | Per-domain WP/WooCommerce env template — every key commented, zero values (safe to commit) |
| `wordpress-theme/skyyrose-flagship/data/dossiers/black-rose-bomber-sherpa.md` | Product dossier (Black Rose Bomber Sherpa) |

## Why

The committed theme history (v1.6.x, on-model renders, lockups) is already on `main`. These four were the only WordPress artifacts not yet captured in any commit. Branch is based on `main` so it carries **no** React-DS commits — clean, single-purpose diff.

## Test plan

- [ ] `php -l wordpress/mu-plugins/skyyrose-ally-ajax-guard.php` (syntax)
- [ ] `bash -n scripts/deploy-mu-plugin.sh` (syntax)
- [ ] Confirm `.env.example` contains no real secrets (all keys commented — verified)
- [ ] MU-plugin: verify the `option_active_plugins` guard scopes correctly to AJAX/REST and does not affect normal page loads
- [ ] No deploy to skyyrose.co from this PR — code-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a WordPress MU-plugin that disables `pojo-accessibility` (Ally) on AJAX/REST so JSON stays clean, fixing the CommerceKit nonce endpoint. Also adds a deploy script, a safe `.env` template, and a product dossier.

- **Bug Fixes**
  - Filter `option_active_plugins` to remove `pojo-accessibility/` only on `?commercekit-ajax=`, `wc-ajax`, `/wp-json/`, or `?rest_route=` requests; uses `wp_unslash($_SERVER['REQUEST_URI'])` to avoid false positives while leaving normal pages unchanged.

- **Refactors**
  - `scripts/deploy-mu-plugin.sh`: Add `STOPSHOW_ACK=1` production-write gate, `sshpass` fallback + `SSH_STRICT`, redact nonce before logging, and curl timeouts; prints a short response snippet for verification.
  - `wordpress/.env.example`: Clarify the template is committed; real `.env.wordpress` is git-ignored.

<sup>Written for commit 551f5c81e1fd3c3154f23bff0d861e3f409beb59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added product dossier for Black Rose Bomber Sherpa with design specifications, branding guidelines, and visual reference standards
  * Added automated deployment workflow for plugin management with remote verification

* **Documentation**
  * Added WordPress environment configuration template with integration service settings

* **Chores**
  * Added plugin compatibility enhancement for API request handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->