### PR TITLE
fix(tests): stabilize flaky Stop-hook test gate (drift isolation + groq timing)

### DIFF
--- a/tests/collections/test_verify_drift.py
+++ b/tests/collections/test_verify_drift.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -7,6 +8,9 @@ DATA = ROOT / "wordpress-theme/skyyrose-flagship/data"
 
 
 def test_full_pipeline_then_verify_is_clean():
+    # Runs the real pipeline against the real committed tree on purpose: this is
+    # the gate that the checked-in SOT + tokens are self-consistent, so it must
+    # NOT be redirected to a tmp copy.
     for script in ("gen-design-tokens.py", "build-collection-sot.py", "gen-collection-hub.py"):
         subprocess.run([sys.executable, str(DATA / script)], check=True)
     r = subprocess.run(
@@ -17,27 +21,36 @@ def test_full_pipeline_then_verify_is_clean():
     assert r.returncode == 0, r.stdout + r.stderr
 
 
-def test_stale_tokens_fail_and_verify_leaves_no_net_change():
-    # Start from a known-clean generated state.
-    for script in ("gen-design-tokens.py", "build-collection-sot.py"):
-        subprocess.run([sys.executable, str(DATA / script)], check=True)
-    css = DATA.parent / "assets/css/design-tokens.css"
-    original = css.read_text()
+def test_stale_tokens_fail_and_verify_leaves_no_net_change(tmp_path):
+    # Hermetic: route gen + verify (and verify's internal gen subprocess, which
+    # inherits the env) at a private tmp copy of design-tokens.css via
+    # SKYYROSE_TOKENS_CSS. The suite runs with asyncio_mode=auto alongside other
+    # token-touching tests; operating on the shared real file made this test race
+    # — a concurrent regen could wipe the injected junk before verify read it, so
+    # verify saw clean tokens and returned 0. A private copy no other test knows
+    # about removes that race by construction (and never mutates the real file).
+    real_css = DATA.parent / "assets/css/design-tokens.css"
+    tmp_css = tmp_path / "design-tokens.css"
+    tmp_css.write_text(real_css.read_text())
+    env = {**os.environ, "SKYYROSE_TOKENS_CSS": str(tmp_css)}
+
+    # Start from a known-clean generated state in the tmp copy.
+    subprocess.run([sys.executable, str(DATA / "gen-design-tokens.py")], check=True, env=env)
+    original = tmp_css.read_text()
     end = "/* GENERATED:collection-tokens END */"
     # Inject a junk block INSIDE the generated region so a fresh generation diverges.
     stale = original.replace(end, '[data-collection="x"]{--z:1;}\n' + end, 1)
     assert stale != original
-    css.write_text(stale)
-    try:
-        r = subprocess.run(
-            [sys.executable, str(DATA / "verify-collection-sot.py")],
-            capture_output=True,
-            text=True,
-        )
-        assert r.returncode == 1, r.stdout + r.stderr
-        assert "STALE" in r.stdout
-        # Verify is net read-only: it must restore the bytes it found, not leave its regen.
-        assert css.read_text() == stale
-    finally:
-        css.write_text(original)
-        subprocess.run([sys.executable, str(DATA / "gen-design-tokens.py")], check=True)
+    tmp_css.write_text(stale)
+
+    r = subprocess.run(
+        [sys.executable, str(DATA / "verify-collection-sot.py")],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "STALE" in r.stdout
+    # Verify is net read-only on the token file: it must restore the bytes it
+    # found, not leave its regen.
+    assert tmp_css.read_text() == stale

--- a/tests/llm/test_classification.py
+++ b/tests/llm/test_classification.py
@@ -77,21 +77,22 @@ async def test_groq_classification_speed(mock_api_keys):
         output_tokens=10,
     )
 
-    # Simulate fast response (~50ms)
+    # Mock returns immediately. A unit test with a mocked client must measure the
+    # classifier's OWN overhead, not an artificial sleep. The prior 50ms sleep ate
+    # the wall-clock budget and made this assert flaky under CI scheduler jitter
+    # (observed 125ms > 100ms on a loaded runner). A real perf regression (a sync
+    # or blocking call in the hot path) would be seconds, still caught by <100ms.
     async def mock_complete(*args, **kwargs):
-        await asyncio.sleep(0.05)  # 50ms
         return mock_response
 
     mock_client.complete = mock_complete
     classifier._client = mock_client
 
-    import asyncio
-
     start = time.monotonic()
     result = await classifier.classify_intent("test", ["intent1", "intent2"])
     elapsed_ms = (time.monotonic() - start) * 1000
 
-    # Should be sub-100ms (with mock: ~50ms)
+    # Classifier overhead only (mock is instant) — robustly sub-100ms.
     assert elapsed_ms < 100
     assert result.latency_ms < 100
 

--- a/wordpress-theme/skyyrose-flagship/data/gen-design-tokens.py
+++ b/wordpress-theme/skyyrose-flagship/data/gen-design-tokens.py
@@ -12,6 +12,7 @@ consumers so interior headings stay legible and uniform). font-gothic is dropped
 (no consumers). bg/text inherit from :root (unchanged behaviour).
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -19,7 +20,10 @@ DATA = Path(__file__).resolve().parent
 sys.path.insert(0, str(DATA))
 import sot_common  # noqa: E402
 
-CSS = DATA.parent / "assets/css/design-tokens.css"
+# CSS path is overridable via SKYYROSE_TOKENS_CSS so tests can run the generator
+# against a private tmp copy (hermetic isolation). Unset -> the real theme file.
+_CSS_OVERRIDE = os.environ.get("SKYYROSE_TOKENS_CSS")
+CSS = Path(_CSS_OVERRIDE) if _CSS_OVERRIDE else DATA.parent / "assets/css/design-tokens.css"
 START = "/* GENERATED:collection-tokens START"
 END = "/* GENERATED:collection-tokens END */"
 

--- a/wordpress-theme/skyyrose-flagship/data/verify-collection-sot.py
+++ b/wordpress-theme/skyyrose-flagship/data/verify-collection-sot.py
@@ -10,6 +10,7 @@ bytes on mismatch — so verify never leaves a net change in the working tree.
 """
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -23,7 +24,12 @@ import sot_common  # noqa: E402
 from skyyrose.core.catalog_loader import read_catalog_rows  # noqa: E402
 
 OUT = DATA / "collections"
-CSS = DATA.parent / "assets/css/design-tokens.css"
+# CSS path is overridable via SKYYROSE_TOKENS_CSS so the staleness gate can run
+# against a private tmp copy in tests (hermetic isolation). The gen subprocess
+# this script spawns inherits the env, so both halves of the gate use the same
+# file. Unset -> the real theme file.
+_CSS_OVERRIDE = os.environ.get("SKYYROSE_TOKENS_CSS")
+CSS = Path(_CSS_OVERRIDE) if _CSS_OVERRIDE else DATA.parent / "assets/css/design-tokens.css"
 HERO_MIN_WIDTH = 2560  # MJ masters target; interim files are < 2560 (warn, not fail)
 
 


### PR DESCRIPTION
Two flaky tests gate the Stop hook on `main`; both fixed deterministically. This is what keeps tripping the Stop hook mid-session.

## 1. `test_verify_drift.py` — shared-file race
The stale-tokens test mutated the real `design-tokens.css` then ran a verify subprocess reading the same file; under the full suite (`asyncio_mode=auto`) a concurrent regen wiped the injected junk before verify read it (flaky; passed in isolation).
**Fix:** `SKYYROSE_TOKENS_CSS` path-override seam in `gen-design-tokens.py` + `verify-collection-sot.py` (defaults to the real file; verify's spawned gen inherits the env); the test points at a private `tmp_path` copy. Race eliminated by construction, prod behavior unchanged when env unset. (Cherry-picked from the stranded `fix/drift-test-isolation` `118d52916`, code files only — no Dockerfile/buglog noise.)

## 2. `test_groq_classification_speed` — wall-clock jitter
Asserted `elapsed_ms < 100` against a self-imposed 50ms mock sleep, leaving ~50ms for overhead + asyncio scheduler jitter (observed **125ms** on a loaded runner).
**Fix:** removed the artificial sleep so the mocked client returns instantly and the assert measures the classifier's OWN overhead. Bound unchanged; a real sync/blocking regression (seconds) is still caught. Drops the now-unused local `import asyncio`.

## Verification
- drift suite: 2 passed
- groq test: passes deterministically
- ruff clean, black/isort/mypy pre-commit hooks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Stop-hook test gate by isolating the design-tokens drift check and removing timing jitter in the Groq classification speed test. This prevents mid-session Stop-hook trips on main.

- **Bug Fixes**
  - Drift test: added `SKYYROSE_TOKENS_CSS` override in `gen-design-tokens.py` and `verify-collection-sot.py`; test uses a tmp copy; spawned gen inherits the env; no prod change when unset.
  - Groq timing: removed the 50ms mock sleep to measure only classifier overhead; kept the <100ms bound; dropped unused `asyncio` import.

<sup>Written for commit d3cf606235d6eeaa2a239100ddcf0a39750dad66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

