### PR TITLE
feat(docker): production-ready stack + dependency cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -121,7 +121,6 @@ wordpress-theme/skyyrose-flagship/*
 **/*.eot
 **/*.zip
 **/*.tar
-**/*.tar.gz
 **/*.tgz
 **/*.7z
 **/*.rar

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,53 +1,155 @@
-# Version control
-.git
-.gitignore
+# =============================================================================
+# DevSkyy .dockerignore — ALLOWLIST strategy.
+#
+# This is a sprawling monorepo with an UNBOUNDED amount of local scratch at the
+# repo root (backups/, ci_mirror/, editorial-staging/, graphify-out/, datasets/,
+# .claude/ worktrees @ 33GB, etc.). A denylist rots — new junk dirs appear every
+# week. So we invert it: ignore EVERYTHING, then re-include only the Python
+# packages + canonical text data the API/worker image actually needs, and finally
+# re-strip binary media inside those (last match wins).
+#
+# Note: BuildKit's `*.png`-style patterns only match the ROOT level, so the media
+# re-excludes below MUST use `**/` to reach nested files.
+# =============================================================================
 
-# Python cache
-__pycache__
-*.py[cod]
-*$py.class
-*.so
-.Python
-.mypy_cache
-.pytest_cache
-.coverage
-htmlcov/
+# --- Ignore everything by default --------------------------------------------
+*
 
-# Dependencies
-node_modules
-frontend/node_modules
-frontend/.next
-frontend/out
-
-# Environment
-.env
-.env.*
-!.env.example
-
-# IDE
-.vscode
-.idea
-*.swp
-*.swo
-
-# Build artifacts
-dist
-build
-*.egg-info
-
-# Logs
-*.log
-logs/
-
-# Testing
-.pytest_cache
-coverage/
-
-# Documentation
-docs/
-*.md
+# --- Re-include root entrypoints & build metadata ----------------------------
+!*.py
+!pyproject.toml
 !README.md
+!requirements*.txt
+!docker-entrypoint.sh
+!init.sql
 
-# CI/CD
-.github
-.circleci
+# --- Re-include every first-party Python package -----------------------------
+# (every root dir with an __init__.py, plus the sdk/ tree and canonical data/).
+# Including all of them means no `import X` can ever be missing from the image;
+# the media re-strip below keeps the heavy ones (renders/, skyyrose/) lean.
+!adk/
+!agents/
+!ai_3d/
+!aos/
+!api/
+!billing/
+!cli/
+!config/
+!core/
+!database/
+!devskyy_workflows/
+!evaluation/
+!grpc_server/
+!imagery/
+!integrations/
+!llm/
+!mcp_servers/
+!mcp_tools/
+!monitoring/
+!orchestration/
+!pipelines/
+!prompts/
+!renders/
+!scripts/
+!security/
+!services/
+!skyyrose/
+!sync/
+!tools/
+!utils/
+!wordpress/
+!sdk/
+!data/
+
+# Canonical product data lives under the (otherwise-excluded) PHP theme tree.
+# The runtime resolves repo/wordpress-theme/skyyrose-flagship/data/{skyyrose-catalog.csv,
+# dossiers/*.md} (see skyyrose/core/paths.py, elite_studio/sku_resolver.py). Re-include
+# ONLY that data subdir via the nested-allowlist idiom — include an ancestor, exclude its
+# siblings, descend — so we get the 1.3MB of text and not the 465MB theme.
+!wordpress-theme/
+wordpress-theme/*
+!wordpress-theme/skyyrose-flagship/
+wordpress-theme/skyyrose-flagship/*
+!wordpress-theme/skyyrose-flagship/data/
+
+# --- Re-strip caches inside the re-included trees ----------------------------
+**/__pycache__/
+**/*.py[cod]
+**/.pytest_cache/
+**/.mypy_cache/
+**/.ruff_cache/
+**/.DS_Store
+
+# --- Re-strip binary media inside the re-included trees (NEVER needed at runtime)
+# Canonical TEXT data (csv/json/yaml/md — catalog, manifest, dossiers) is kept.
+**/*.png
+**/*.jpg
+**/*.jpeg
+**/*.gif
+**/*.bmp
+**/*.tiff
+**/*.tif
+**/*.webp
+**/*.avif
+**/*.ico
+**/*.svg
+**/*.psd
+**/*.ai
+**/*.eps
+**/*.glb
+**/*.gltf
+**/*.obj
+**/*.fbx
+**/*.usdz
+**/*.blend
+**/*.stl
+**/*.ply
+**/*.mp4
+**/*.mov
+**/*.webm
+**/*.avi
+**/*.mkv
+**/*.wav
+**/*.mp3
+**/*.flac
+**/*.aac
+**/*.ogg
+**/*.woff
+**/*.woff2
+**/*.ttf
+**/*.otf
+**/*.eot
+**/*.zip
+**/*.tar
+**/*.tar.gz
+**/*.tgz
+**/*.7z
+**/*.rar
+**/*.gz
+
+# --- Re-strip ML weights & large binary data ---------------------------------
+**/*.safetensors
+**/*.pt
+**/*.pth
+**/*.ckpt
+**/*.bin
+**/*.onnx
+**/*.pkl
+**/*.pickle
+**/*.npy
+**/*.npz
+**/*.h5
+**/*.hdf5
+**/*.parquet
+**/*.feather
+**/*.arrow
+**/*.sqlite
+**/*.sqlite3
+**/*.db
+**/*.pdf
+
+# --- Never bake secrets ------------------------------------------------------
+**/.env
+**/.env.*
+**/*.pem
+**/*.key

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,68 @@
+# =============================================================================
+# DevSkyy Docker stack — environment template.
+#
+#   1. `make docker-secrets`  → generates .env.docker from this file and fills
+#      POSTGRES_PASSWORD / REDIS_PASSWORD / GRAFANA_ADMIN_PASSWORD / JWT_SECRET_KEY
+#      / ENCRYPTION_MASTER_KEY with strong random values.
+#   2. Paste your real API keys into .env.docker.
+#   3. `make docker-up`.
+#
+# .env.docker is gitignored. NEVER commit real secrets. This .example file
+# ships placeholders only.
+# =============================================================================
+
+# --- Runtime ------------------------------------------------------------------
+ENVIRONMENT=production
+LOG_LEVEL=INFO
+APP_PORT=8000
+HTTP_PORT=80
+# Dependency set baked into the image: all | api,mcp | worker | ml ...
+INSTALL_TARGET=all
+
+# --- Infrastructure secrets (auto-filled by `make docker-secrets`) ------------
+POSTGRES_PASSWORD=__CHANGE_ME__
+REDIS_PASSWORD=__CHANGE_ME__
+GRAFANA_ADMIN_PASSWORD=__CHANGE_ME__
+
+# --- Security keys — MUST stay stable across restarts -------------------------
+# If unset, the entrypoint generates ephemeral keys every boot, which rotates
+# the encryption key and invalidates all issued JWTs. `make docker-secrets`
+# fills both with persistent random values. Treat these like passwords.
+JWT_SECRET_KEY=__CHANGE_ME__
+JWT_REFRESH_SECRET_KEY=__CHANGE_ME__
+ENCRYPTION_MASTER_KEY=__CHANGE_ME__
+
+# --- LLM providers ------------------------------------------------------------
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_API_KEY=
+GOOGLE_AI_API_KEY=
+MISTRAL_API_KEY=
+COHERE_API_KEY=
+GROQ_API_KEY=
+
+# --- Vector / RAG -------------------------------------------------------------
+PINECONE_API_KEY=
+
+# --- 3D / imagery -------------------------------------------------------------
+TRIPO_API_KEY=
+TRIPO3D_API_KEY=
+FASHN_API_KEY=
+
+# --- WordPress / WooCommerce (asset upload, catalog sync) ---------------------
+WORDPRESS_URL=
+WOOCOMMERCE_KEY=
+WOOCOMMERCE_SECRET=
+
+# --- Ops / notifications ------------------------------------------------------
+SLACK_WEBHOOK_URL=
+CORS_ORIGINS=http://localhost:3000,http://localhost:8000
+
+# --- Feature flags ------------------------------------------------------------
+MFA_ENABLED=true
+RATE_LIMIT_ENABLED=true
+REQUEST_SIGNING_ENABLED=true
+
+# --- Elite worker -------------------------------------------------------------
+ELITE_WORKER_CONCURRENCY=1
+ELITE_COST_TRACKING=true

--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -6,7 +6,8 @@
 ## ./
 
 - `.claudeignore` — /*.png (~644 tok)
-- `.dockerignore` — Docker ignore rules (~122 tok)
+- `.dockerignore` — ALLOWLIST: ignore all, re-include first-party packages + canonical data; cuts context 1GB→43MB (~600 tok)
+- `.env.docker.example` — env template for the compose stack; `make docker-secrets` fills secrets (~400 tok)
 - `.eslintrc.cjs` — ESLint configuration (~954 tok)
 - `.gitattributes` — Git attributes (~70 tok)
 - `.gitignore` — Git ignore rules (~2263 tok)
@@ -31,10 +32,9 @@
 - `DESIGN.md` — Design System Inspired by Claude (Anthropic) (~5031 tok)
 - `devskyy_mcp.py` (~1153 tok)
 - `docker-compose.staging.yml` — Docker Compose: 14 services (~3431 tok)
-- `docker-compose.yml` — Docker Compose services (~1920 tok)
-- `docker-entrypoint.sh` — Enterprise startup script with error handling and logging (~1012 tok)
-- `Dockerfile` — Docker container definition (~1133 tok)
-- `Dockerfile.worker` — DevSkyy Worker - Lightweight build for background task processing (~809 tok)
+- `docker-compose.yml` — production stack: postgres/redis/app/worker/elite-worker + monitoring & proxy profiles; one devskyy:local image, fail-loud secrets (~2000 tok)
+- `docker-entrypoint.sh` — startup script; generates JWT/ENC keys if unset, then dispatches a passed command (worker) or defaults to uvicorn (~1100 tok)
+- `Dockerfile` — multi-stage Python image (builder + non-root runtime), `COPY . .` + allowlist .dockerignore, INSTALL_TARGET arg, tini PID1; one image for app+workers (~1200 tok)
 - `fastmcp.config.json` (~287 tok)
 - `fly.toml` — fly.toml - DevSkyy Enterprise Platform (~1070 tok)
 - `G1-BUNDLE.md` — G1 STOP — Phase 0 Review Bundle (~2329 tok)
@@ -3886,3 +3886,14 @@ wp-admin console + PHP MCP streamable-HTTP client to api.devskyy.app/mcp/. State
 
 ### wordpress-theme/skyyrose-flagship/assets/js/admin-mcp-console.js (~0.9k tok)
 Admin-only console JS for mcp-bridge.php. Fetches tools/list, invokes tools/call via admin-ajax. Vanilla, createElement/textContent only (no innerHTML). Enqueued only on tools_page_skyyrose-mcp.
+
+## design-system/skyyrose-storefront/
+
+- `package.json` — @skyyrose/storefront-ds v0.1.0; npm scripts build/test/sync/sync:check; peer react>=18 (~300 tok)
+- `tsconfig.json` — ES2020, bundler moduleResolution, react-jsx, strict, noEmit, vitest/globals + jest-dom types (~200 tok)
+- `vite.config.ts` — library mode: es format, skyyrose-ds.es.js, cssFileName skyyrose-ds, dts({ include: ['src'], insertTypesEntry: true }), externals react/react-dom (~250 tok)
+- `vitest.config.ts` — globals:true, jsdom, setupFiles vitest.setup.ts, css:false (~150 tok)
+- `vitest.setup.ts` — imports @testing-library/jest-dom/vitest (~50 tok)
+- `src/types.ts` — exports Collection type ('signature'|'black-rose'|'love-hurts'|'kids-capsule') (~50 tok)
+- `src/index.ts` — re-exports Collection from ./types; placeholder for component exports (~50 tok)
+- `test/smoke.test.ts` — verifies module loads (1 test) (~80 tok)

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,9 +81,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PORT=8000
 
 # Runtime-only system libs: libpq5 (postgres clients), curl (healthcheck),
-# tini (PID1), libgl1 + libglib2.0-0 (OpenCV/cv2 needs them — the imagery &
-# render-QC pipeline imports cv2; without these the slim image silently disables
-# color-histogram comparison).
+# tini (PID1), libgl1 + libglib2.0-0 (OpenCV/cv2 — imagery & render-QC pipeline),
+# libfreetype6 (Pillow text rendering on arm64 source builds), fonts-dejavu-core
+# (TrueType font the imagery overlays load by path — otherwise a bitmap fallback).
 RUN apt-get update --fix-missing || apt-get update --fix-missing && \
     apt-get install -y --no-install-recommends \
         libpq5 \
@@ -92,6 +92,8 @@ RUN apt-get update --fix-missing || apt-get update --fix-missing && \
         tini \
         libgl1 \
         libglib2.0-0 \
+        libfreetype6 \
+        fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,44 @@
-# DevSkyy Platform - Multi-stage Docker Build
-# Optimized for production deployment with security hardening
-# Enterprise hardening: Retry logic, timeouts, minimal layers
-
+# syntax=docker/dockerfile:1.7
 # =============================================================================
-# Stage 1: Frontend Builder (Next.js Dashboard)
+# DevSkyy Platform — Python API / Worker image (multi-stage, security-hardened)
 # =============================================================================
-FROM node:20-alpine AS frontend-builder
-
-WORKDIR /app/frontend
-
-# Copy package files from frontend directory
-COPY frontend/package*.json ./
-
-# Install dependencies with legacy peer deps (React version conflicts)
-RUN npm ci --legacy-peer-deps && npm cache clean --force
-
-# Copy Next.js source code from frontend directory
-COPY frontend/app/ ./app/
-COPY frontend/components/ ./components/
-COPY frontend/contexts/ ./contexts/
-COPY frontend/hooks/ ./hooks/
-COPY frontend/lib/ ./lib/
-COPY frontend/public/ ./public/
-COPY frontend/types/ ./types/
-COPY frontend/*.config.js ./
-COPY frontend/*.config.ts ./
-COPY frontend/tsconfig*.json ./
-COPY frontend/next-env.d.ts ./
-
-# Build Next.js application
-RUN npm run build
-
+# ONE image, three roles (selected by the compose `command:`):
+#   • API          → docker-entrypoint.sh (default) → uvicorn main_enterprise:app
+#   • task worker  → python -m agent_sdk.worker
+#   • elite worker → python -m skyyrose.elite_studio worker
+# The frontend (Next.js) is NOT built here — it deploys to Vercel (devskyy.app).
+# Baking it in served zero requests and doubled build time.
+#
+# INSTALL_TARGET selects which optional-dependency extras to add on top of the
+# base deps (default "all"). NOTE: the ML stack (torch/transformers/diffusers/
+# chromadb) lives in the BASE [project.dependencies], so every target pulls it —
+# a genuinely torch-free image needs those moved into an optional group first.
+#   docker build .                              # INSTALL_TARGET=all (default)
+#   docker build --build-arg INSTALL_TARGET=api # base + api extras only
 # =============================================================================
-# Stage 2: Python Backend Builder
-# =============================================================================
-FROM python:3.12-slim AS backend-builder
 
-# Prevent apt from hanging
-ENV DEBIAN_FRONTEND=noninteractive
+# -----------------------------------------------------------------------------
+# Stage 1: dependency builder — installs third-party wheels into a clean prefix.
+# Cache key is pyproject.toml + README.md only, so source edits never bust it.
+# -----------------------------------------------------------------------------
+FROM python:3.12-slim AS builder
 
-# Set Python environment
-ENV PYTHONUNBUFFERED=1 \
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# Enterprise hardening: apt-get with retry logic and timeout
+# Build toolchain for native wheels. On arm64 several deps have no prebuilt wheel
+# and compile from source: reportlab's renderPM needs freetype (ft2build.h),
+# Pillow needs jpeg/zlib, asyncpg/psycopg need libpq.
 RUN apt-get update --fix-missing || apt-get update --fix-missing && \
     apt-get install -y --no-install-recommends \
         build-essential \
+        libpq-dev \
+        libfreetype6-dev \
+        libjpeg-dev \
+        zlib1g-dev \
         curl \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
@@ -56,89 +46,89 @@ RUN apt-get update --fix-missing || apt-get update --fix-missing && \
 
 WORKDIR /app
 
-# Copy project metadata only. Dependencies resolve from pyproject.toml; the
-# application source is added in the production stage and run from /app, so the
-# builder only needs to install third-party deps. setuptools' explicit
-# packages.find produces an (empty) devskyy wheel here — verified to build from
-# pyproject.toml + README.md alone — which keeps this expensive layer cacheable
-# (busts only when pyproject/README change, not on source edits).
+# uv = fast, reliable resolver/installer. python:3.12-slim ships NO setuptools and
+# pip backtracks for ~10min on the large .[all] set (then dies on a missing
+# setuptools.build_meta during sdist metadata builds). uv resolves deterministically
+# and provisions build envs robustly. Installed into the system interpreter so the
+# production stage's site-packages copy still works.
+COPY --from=ghcr.io/astral-sh/uv:0.9.2 /uv /uvx /bin/
+
+# Which optional-dependency set to install (see pyproject [project.optional-dependencies]).
+ARG INSTALL_TARGET=all
+
+ENV UV_HTTP_TIMEOUT=600 \
+    UV_SYSTEM_PYTHON=1 \
+    UV_LINK_MODE=copy
+
+# Only metadata first → this expensive layer is cached until deps actually change.
+# The devskyy wheel built here is intentionally empty (source isn't copied yet);
+# the runtime stage adds the source via COPY . . and runs it from /app.
 COPY pyproject.toml README.md ./
 
-# Install all production dependencies. Documented Docker install target is
-# ".[all]" (requirements.txt is a deprecated -e . stub). Longer timeout for the
-# large ML wheels (torch/transformers/diffusers).
-RUN pip install --no-cache-dir --timeout=600 ".[all]"
+# BuildKit cache mount keeps uv's wheel cache warm across rebuilds.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system ".[${INSTALL_TARGET}]"
 
-# =============================================================================
-# Stage 3: Production Runtime
-# =============================================================================
+# -----------------------------------------------------------------------------
+# Stage 2: production runtime — slim, non-root, only runtime libs.
+# -----------------------------------------------------------------------------
 FROM python:3.12-slim AS production
 
-# Prevent apt from hanging
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Set Python environment
-ENV PYTHONUNBUFFERED=1 \
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONPATH="/app"
+    PYTHONPATH="/app:/app/sdk/python" \
+    PORT=8000
 
-# Create non-root user for security
-RUN groupadd -r devskyy && useradd -r -g devskyy -m -u 1000 devskyy
-
-# Install runtime dependencies with retry logic
+# Runtime-only system libs: libpq5 (postgres clients), curl (healthcheck),
+# tini (PID1), libgl1 + libglib2.0-0 (OpenCV/cv2 needs them — the imagery &
+# render-QC pipeline imports cv2; without these the slim image silently disables
+# color-histogram comparison).
 RUN apt-get update --fix-missing || apt-get update --fix-missing && \
     apt-get install -y --no-install-recommends \
+        libpq5 \
         curl \
         ca-certificates \
+        tini \
+        libgl1 \
+        libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
+# Non-root runtime user.
+RUN groupadd -r devskyy && useradd -r -g devskyy -m -u 1000 devskyy
+
 WORKDIR /app
 
-# Copy Python dependencies from builder
-COPY --from=backend-builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-COPY --from=backend-builder /usr/local/bin /usr/local/bin
+# Installed third-party packages + console scripts from the builder.
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
 
-# Copy Next.js build artifacts
-COPY --from=frontend-builder /app/frontend/.next ./.next/
-COPY --from=frontend-builder /app/frontend/public ./public/
+# Application source. `.dockerignore` already stripped VCS, deps, secrets, the
+# frontend, and all binary media — so this copies code + canonical text data
+# (catalog CSV, visual manifest, per-SKU dossiers) and nothing heavy.
+COPY . .
 
-# Verify Next.js build artifacts exist
-RUN test -d ./.next || (echo "ERROR: .next directory not found" && exit 1)
-RUN test -d ./public || (echo "ERROR: public directory not found" && exit 1)
-
-# Copy application code
-COPY sdk/python/agent_sdk/ ./agent_sdk/
-COPY agents/ ./agents/
-COPY api/ ./api/
-COPY adk/ ./adk/
-COPY core/ ./core/
-COPY utils/ ./utils/
-COPY integrations/ ./integrations/
-COPY llm/ ./llm/
-COPY mcp_servers/ ./mcp_servers/
-COPY orchestration/ ./orchestration/
-COPY security/ ./security/
-COPY wordpress/ ./wordpress/
-COPY main_enterprise.py ./
-COPY mcp_tools/ ./mcp_tools/
-COPY devskyy_mcp.py ./
-COPY docker-entrypoint.sh /app/
-RUN chmod +x /app/docker-entrypoint.sh
-
-# Create necessary directories
-RUN mkdir -p /app/logs /app/data /app/uploads && \
+RUN chmod +x /app/docker-entrypoint.sh && \
+    mkdir -p /app/logs /app/data /app/uploads && \
     chown -R devskyy:devskyy /app
 
-# Switch to non-root user
 USER devskyy
 
-# Health check with timeout
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+# OCI metadata (overridable at build time via --build-arg).
+ARG BUILD_VERSION=dev
+ARG BUILD_REVISION=unknown
+LABEL org.opencontainers.image.title="DevSkyy Platform" \
+      org.opencontainers.image.description="AI-driven luxury fashion e-commerce platform (API + workers)" \
+      org.opencontainers.image.vendor="SkyyRose" \
+      org.opencontainers.image.source="https://github.com/The-Skyy-Rose-Collection-LLC/DevSkyy" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.revision="${BUILD_REVISION}"
 
-# Expose port
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD curl -fsS "http://localhost:${PORT}/health" || exit 1
+
 EXPOSE 8000
 
-# Start with entrypoint script that handles startup errors
-ENTRYPOINT ["/app/docker-entrypoint.sh"]
+# tini = PID 1 → proper signal forwarding / zombie reaping for the workers.
+ENTRYPOINT ["/usr/bin/tini", "--", "/app/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@
 .PHONY: install dev lint format test clean help \
         ts-build ts-lint ts-test ts-type-check \
         test-all lint-all format-all \
-        demo security docker-build docker-run \
+        demo security \
+        docker-secrets docker-build docker-up docker-up-monitoring \
+        docker-down docker-logs docker-ps docker-config docker-clean docker-run \
         validate-catalog sync-catalog sync-catalog-dry catalog-help \
         fresh fresh-fix
 
@@ -281,14 +283,50 @@ build: clean ts-build
 	$(PYTHON) -m build
 
 # ============================================================================
-# DOCKER
+# DOCKER  (production-grade stack — see docs/DOCKER.md)
 # ============================================================================
+# Flow:  make docker-secrets   → generate .env.docker (random secrets)
+#        (paste API keys into .env.docker)
+#        make docker-up         → build + start core stack (app/db/redis/workers)
+#        make docker-logs       → tail
+# All compose calls pass --env-file .env.docker for both secret interpolation
+# and in-container env.
 
-docker-build:
-	docker build -t devskyy:latest .
+COMPOSE := docker compose --env-file .env.docker
 
-docker-run:
-	docker run -p 8000:8000 devskyy:latest
+_require-docker-env:
+	@[ -f .env.docker ] || { echo "✋ Missing .env.docker — run 'make docker-secrets' first."; exit 1; }
+
+docker-secrets:  ## Generate .env.docker with strong random secrets (won't clobber)
+	bash scripts/docker-secrets.sh
+
+docker-config: _require-docker-env  ## Validate + render the merged compose config
+	$(COMPOSE) config
+
+docker-build: _require-docker-env  ## Build the devskyy:local image
+	$(COMPOSE) build
+
+docker-up: _require-docker-env  ## Build + start the core stack (detached)
+	$(COMPOSE) up -d --build
+
+docker-up-monitoring: _require-docker-env  ## Core + prometheus + grafana
+	$(COMPOSE) --profile monitoring up -d --build
+
+docker-down: _require-docker-env  ## Stop the stack (keeps volumes/data)
+	$(COMPOSE) down
+
+docker-clean: _require-docker-env  ## Stop the stack AND delete volumes (DESTROYS data)
+	$(COMPOSE) down -v
+
+docker-logs: _require-docker-env  ## Tail logs from all services
+	$(COMPOSE) logs -f --tail=100
+
+docker-ps: _require-docker-env  ## Show container status
+	$(COMPOSE) ps
+
+# Legacy single-container build (no compose, no deps wiring).
+docker-run: _require-docker-env
+	$(COMPOSE) up -d --build app
 
 # ============================================================================
 # CATALOG CONSISTENCY

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ docker-logs: _require-docker-env  ## Tail logs from all services
 docker-ps: _require-docker-env  ## Show container status
 	$(COMPOSE) ps
 
-# Legacy single-container build (no compose, no deps wiring).
+# Start just the app service (still via compose, so postgres/redis deps are honored).
 docker-run: _require-docker-env
 	$(COMPOSE) up -d --build app
 

--- a/database/db.py
+++ b/database/db.py
@@ -34,6 +34,7 @@ from sqlalchemy import (
     func,
     select,
 )
+from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -307,9 +308,11 @@ class DatabaseManager:
         # Normalize locally — don't mutate the caller's config object.
         db_url = _normalize_async_url(config.url)
 
-        # Determine pool class based on database type
-        is_sqlite = "sqlite" in db_url
-        is_memory = ":memory:" in db_url
+        # Determine pool class based on database type using proper URL parsing
+        # to avoid misclassification when "sqlite" appears in credentials/db names
+        parsed_url = make_url(db_url)
+        is_sqlite = parsed_url.drivername.startswith("sqlite")
+        is_memory = is_sqlite and (":memory:" in str(parsed_url.database) or parsed_url.database is None)
 
         # Use StaticPool for in-memory SQLite (keeps single connection alive)
         # Use NullPool for file-based SQLite (allows multiple processes)

--- a/database/db.py
+++ b/database/db.py
@@ -62,6 +62,21 @@ class DatabaseConfig(BaseModel):
     echo: bool = os.getenv("DB_ECHO", "false").lower() == "true"
 
 
+def _normalize_async_url(url: str) -> str:
+    """Map a bare sync Postgres URL onto the async driver this engine needs.
+
+    create_async_engine requires an async driver; a plain ``postgresql://`` (what
+    most hosts/secret managers hand out) resolves to psycopg2, which isn't
+    installed. Rewrite it to ``postgresql+asyncpg://`` so any well-formed Postgres
+    URL works without callers having to know the driver. Already-qualified URLs
+    (``postgresql+asyncpg://``, ``sqlite+aiosqlite://``) pass through unchanged.
+    """
+    for prefix in ("postgresql://", "postgres://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix) :]
+    return url
+
+
 # =============================================================================
 # Base Model
 # =============================================================================
@@ -287,6 +302,7 @@ class DatabaseManager:
             return
 
         config = config or DatabaseConfig()
+        config.url = _normalize_async_url(config.url)
 
         # Determine pool class based on database type
         is_sqlite = "sqlite" in config.url

--- a/database/db.py
+++ b/database/db.py
@@ -312,7 +312,9 @@ class DatabaseManager:
         # to avoid misclassification when "sqlite" appears in credentials/db names
         parsed_url = make_url(db_url)
         is_sqlite = parsed_url.drivername.startswith("sqlite")
-        is_memory = is_sqlite and (":memory:" in str(parsed_url.database) or parsed_url.database is None)
+        is_memory = is_sqlite and (
+            ":memory:" in str(parsed_url.database) or parsed_url.database is None
+        )
 
         # Use StaticPool for in-memory SQLite (keeps single connection alive)
         # Use NullPool for file-based SQLite (allows multiple processes)

--- a/database/db.py
+++ b/database/db.py
@@ -41,7 +41,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, selectinload
-from sqlalchemy.pool import NullPool, QueuePool, StaticPool
+from sqlalchemy.pool import AsyncAdaptedQueuePool, NullPool, StaticPool
 
 logger = logging.getLogger(__name__)
 
@@ -294,13 +294,15 @@ class DatabaseManager:
 
         # Use StaticPool for in-memory SQLite (keeps single connection alive)
         # Use NullPool for file-based SQLite (allows multiple processes)
-        # Use QueuePool for PostgreSQL (connection pooling)
+        # Use AsyncAdaptedQueuePool for PostgreSQL — the engine is async
+        # (create_async_engine), so the sync QueuePool raises
+        # "Pool class QueuePool cannot be used with asyncio engine".
         if is_memory:
             pool_class = StaticPool
         elif is_sqlite:
             pool_class = NullPool
         else:
-            pool_class = QueuePool
+            pool_class = AsyncAdaptedQueuePool
 
         # Create engine with connection pooling
         engine_kwargs = {

--- a/database/db.py
+++ b/database/db.py
@@ -71,8 +71,10 @@ def _normalize_async_url(url: str) -> str:
     URL works without callers having to know the driver. Already-qualified URLs
     (``postgresql+asyncpg://``, ``sqlite+aiosqlite://``) pass through unchanged.
     """
+    if not url:
+        return url
     for prefix in ("postgresql://", "postgres://"):
-        if url.startswith(prefix):
+        if url.lower().startswith(prefix):
             return "postgresql+asyncpg://" + url[len(prefix) :]
     return url
 
@@ -281,7 +283,7 @@ class DatabaseManager:
     Async database manager with connection pooling
 
     Features:
-    - Connection pooling (QueuePool for PostgreSQL)
+    - Connection pooling (AsyncAdaptedQueuePool for PostgreSQL)
     - Async session management
     - Automatic reconnection
     - Query logging
@@ -302,11 +304,12 @@ class DatabaseManager:
             return
 
         config = config or DatabaseConfig()
-        config.url = _normalize_async_url(config.url)
+        # Normalize locally — don't mutate the caller's config object.
+        db_url = _normalize_async_url(config.url)
 
         # Determine pool class based on database type
-        is_sqlite = "sqlite" in config.url
-        is_memory = ":memory:" in config.url
+        is_sqlite = "sqlite" in db_url
+        is_memory = ":memory:" in db_url
 
         # Use StaticPool for in-memory SQLite (keeps single connection alive)
         # Use NullPool for file-based SQLite (allows multiple processes)
@@ -341,7 +344,7 @@ class DatabaseManager:
                 }
             )
 
-        self._engine = create_async_engine(config.url, **engine_kwargs)
+        self._engine = create_async_engine(db_url, **engine_kwargs)
 
         # Create session factory
         self._session_factory = async_sessionmaker(
@@ -356,9 +359,7 @@ class DatabaseManager:
         async with self._engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
-        logger.info(
-            f"Database initialized: {config.url.split('@')[-1] if '@' in config.url else config.url}"
-        )
+        logger.info(f"Database initialized: {db_url.split('@')[-1] if '@' in db_url else db_url}")
 
     async def close(self):
         """Close database connection"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,7 +223,8 @@ services:
     container_name: devskyy-prometheus
     profiles: [monitoring]
     ports:
-      - "9090:9090"
+      # loopback-only: Prometheus has no auth and exposes the full metrics tree.
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
@@ -244,7 +245,8 @@ services:
     container_name: devskyy-grafana
     profiles: [monitoring]
     ports:
-      - "3000:3000"
+      # loopback-only by default; front with a TLS proxy to expose externally.
+      - "127.0.0.1:3000:3000"
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD in .env.docker}
       GF_USERS_ALLOW_SIGN_UP: "false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,10 @@ x-app-env: &app-env
   # async driver in the URL. Bare postgresql:// maps to psycopg2 (not installed).
   DATABASE_URL: postgresql+asyncpg://devskyy:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.docker}@postgres:5432/devskyy
   REDIS_URL: redis://:${REDIS_PASSWORD:?set REDIS_PASSWORD in .env.docker}@redis:6379/0
+  # Cryptographic keys — MUST be set or compose fails (prevent booting with unstable placeholder material)
+  JWT_SECRET_KEY: ${JWT_SECRET_KEY:?set JWT_SECRET_KEY in .env.docker}
+  JWT_REFRESH_SECRET_KEY: ${JWT_REFRESH_SECRET_KEY:?set JWT_REFRESH_SECRET_KEY in .env.docker}
+  ENCRYPTION_MASTER_KEY: ${ENCRYPTION_MASTER_KEY:?set ENCRYPTION_MASTER_KEY in .env.docker}
 
 services:
   # ---------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,13 @@ x-logging: &logging
     max-size: "10m"
     max-file: "3"
 
+# Shared resource ceiling for the three Python roles (app + both workers).
+x-svc-resources: &svc-resources
+  resources:
+    limits:
+      cpus: "2.0"
+      memory: 4G
+
 # Shared environment for every Python role. env_file (.env.docker) supplies the
 # API keys + the two stable security keys; these computed URLs point at the
 # in-network service names.
@@ -118,9 +125,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
-    deploy:
-      resources:
-        limits: { cpus: "2.0", memory: 4G }
+    deploy: *svc-resources
     logging: *logging
 
   # ---------------------------------------------------------------------------
@@ -138,8 +143,6 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
-      app:
-        condition: service_started
     volumes:
       - app_data:/app/data
       - app_logs:/app/logs
@@ -151,9 +154,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
-    deploy:
-      resources:
-        limits: { cpus: "2.0", memory: 4G }
+    deploy: *svc-resources
     logging: *logging
 
   # ---------------------------------------------------------------------------
@@ -174,8 +175,6 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
-      app:
-        condition: service_started
     volumes:
       - app_data:/app/data
       - app_logs:/app/logs
@@ -187,9 +186,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
-    deploy:
-      resources:
-        limits: { cpus: "2.0", memory: 4G }
+    deploy: *svc-resources
     logging: *logging
 
   # ---------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,239 +1,263 @@
-services:
-  # Main application
-  devskyy-app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: devskyy-app
-    ports:
-      - "8000:8000"
-    environment:
-      - DATABASE_URL=postgresql://devskyy:${POSTGRES_PASSWORD:-changeme}@postgres:5432/devskyy
-      - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@redis:6379/0
-      - ENVIRONMENT=production
-    depends_on:
-      - postgres
-      - redis
-    volumes:
-      - app_logs:/app/logs
-      - app_data:/app/data
-    networks:
-      - devskyy-network
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
+# =============================================================================
+# DevSkyy — production-grade local / self-hosted stack.
+#
+#   Core (default):      postgres · redis · app · worker · elite-worker
+#   Monitoring profile:  prometheus · grafana   (--profile monitoring)
+#   Proxy profile:       nginx                  (--profile proxy)
+#
+# Secrets come from .env.docker (never committed). The `${VAR:?...}` syntax makes
+# compose FAIL LOUDLY if a required secret is missing — no silent "changeme".
+#
+#   make docker-secrets      # generate .env.docker with strong random secrets
+#   make docker-up           # build + start the core stack
+#   make docker-logs         # tail everything
+#   docker compose --env-file .env.docker --profile monitoring up -d
+#
+# One image (devskyy:local) serves all three Python roles; the compose
+# `command:` selects the role and the entrypoint dispatches it.
+# =============================================================================
 
-  # PostgreSQL database
+x-app-build: &app-build
+  context: .
+  dockerfile: Dockerfile
+  args:
+    INSTALL_TARGET: ${INSTALL_TARGET:-all}
+    BUILD_VERSION: ${BUILD_VERSION:-dev}
+
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
+# Shared environment for every Python role. env_file (.env.docker) supplies the
+# API keys + the two stable security keys; these computed URLs point at the
+# in-network service names.
+x-app-env: &app-env
+  ENVIRONMENT: ${ENVIRONMENT:-production}
+  LOG_LEVEL: ${LOG_LEVEL:-INFO}
+  # +asyncpg: database/db.py uses SQLAlchemy create_async_engine, which needs an
+  # async driver in the URL. Bare postgresql:// maps to psycopg2 (not installed).
+  DATABASE_URL: postgresql+asyncpg://devskyy:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.docker}@postgres:5432/devskyy
+  REDIS_URL: redis://:${REDIS_PASSWORD:?set REDIS_PASSWORD in .env.docker}@redis:6379/0
+
+services:
+  # ---------------------------------------------------------------------------
+  # PostgreSQL
+  # ---------------------------------------------------------------------------
   postgres:
     image: postgres:15-alpine
     container_name: devskyy-postgres
     environment:
-      - POSTGRES_DB=devskyy
-      - POSTGRES_USER=devskyy
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-changeme}
-      - POSTGRES_INITDB_ARGS=--encoding=UTF-8 --lc-collate=C --lc-ctype=C
+      POSTGRES_DB: devskyy
+      POSTGRES_USER: devskyy
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.docker}
+      POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --lc-collate=C --lc-ctype=C"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
-    networks:
-      - devskyy-network
+    networks: [devskyy-network]
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U devskyy -d devskyy"]
       interval: 10s
       timeout: 5s
       retries: 5
+    deploy:
+      resources:
+        limits: { cpus: "1.0", memory: 1G }
+    logging: *logging
 
-  # Redis cache
+  # ---------------------------------------------------------------------------
+  # Redis (task queue + cache)
+  # ---------------------------------------------------------------------------
   redis:
     image: redis:7-alpine
     container_name: devskyy-redis
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:-changeme}
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?set REDIS_PASSWORD in .env.docker}
     volumes:
       - redis_data:/data
-    networks:
-      - devskyy-network
+    networks: [devskyy-network]
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      test: ["CMD-SHELL", "redis-cli -a \"$$REDIS_PASSWORD\" ping | grep -q PONG"]
       interval: 10s
       timeout: 3s
       retries: 5
-
-  # Background worker pool for async tasks (3D generation, marketing, ML)
-  worker:
-    build:
-      context: .
-      dockerfile: Dockerfile.worker
-    container_name: devskyy-worker
-    command: python -m agent_sdk.worker
     environment:
-      # Core services
-      - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@redis:6379/0
-      - DATABASE_URL=postgresql://devskyy:${POSTGRES_PASSWORD:-changeme}@postgres:5432/devskyy
-      - ENVIRONMENT=production
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    deploy:
+      resources:
+        limits: { cpus: "0.5", memory: 512M }
+    logging: *logging
 
-      # 3D Generation APIs
-      - TRIPO_API_KEY=${TRIPO_API_KEY}
-      - FASHN_API_KEY=${FASHN_API_KEY}
-
-      # LLM Providers (for marketing agent)
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - GOOGLE_AI_API_KEY=${GOOGLE_AI_API_KEY}
-
-      # WordPress (for asset upload)
-      - WORDPRESS_URL=${WORDPRESS_URL}
-      - WOOCOMMERCE_KEY=${WOOCOMMERCE_KEY}
-      - WOOCOMMERCE_SECRET=${WOOCOMMERCE_SECRET}
-
-      # Worker configuration
-      - WORKER_PROCESSES=2
-      - WORKER_THREADS=4
-      - TASK_TIMEOUT=600
+  # ---------------------------------------------------------------------------
+  # API — FastAPI (REST + GraphQL + MCP mount)
+  # ---------------------------------------------------------------------------
+  app:
+    build: *app-build
+    image: devskyy:local
+    container_name: devskyy-app
+    env_file: [.env.docker]
+    environment: *app-env
+    ports:
+      - "${APP_PORT:-8000}:8000"
     depends_on:
-      redis:
-        condition: service_healthy
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
-      - app_data:/app/data
       - app_logs:/app/logs
-    networks:
-      - devskyy-network
+      - app_data:/app/data
+    networks: [devskyy-network]
     restart: unless-stopped
-    deploy:
-      replicas: 2  # Run 2 worker instances for redundancy
-      resources:
-        limits:
-          cpus: '2.0'
-          memory: 4G
-        reservations:
-          cpus: '1.0'
-          memory: 2G
     healthcheck:
-      test: ["CMD", "python", "-c", "import sys; sys.exit(0)"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
+    deploy:
+      resources:
+        limits: { cpus: "2.0", memory: 4G }
+    logging: *logging
 
-  # Elite Studio render worker — processes async SKU render jobs
-  elite-worker:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: devskyy-elite-worker
-    command: python -m skyyrose.elite_studio worker
-    environment:
-      - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@redis:6379/0
-      - DATABASE_URL=postgresql://devskyy:${POSTGRES_PASSWORD:-changeme}@postgres:5432/devskyy
-      - ENVIRONMENT=production
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - GOOGLE_AI_API_KEY=${GOOGLE_AI_API_KEY}
-      - ELITE_WORKER_CONCURRENCY=${ELITE_WORKER_CONCURRENCY:-1}
-      - ELITE_COST_TRACKING=${ELITE_COST_TRACKING:-true}
+  # ---------------------------------------------------------------------------
+  # Background worker — async task queue poller (3D gen, marketing, ML)
+  # ---------------------------------------------------------------------------
+  worker:
+    build: *app-build
+    image: devskyy:local
+    container_name: devskyy-worker
+    command: ["python", "-m", "agent_sdk.worker"]
+    env_file: [.env.docker]
+    environment: *app-env
     depends_on:
       redis:
         condition: service_healthy
       postgres:
         condition: service_healthy
+      app:
+        condition: service_started
     volumes:
       - app_data:/app/data
       - app_logs:/app/logs
-    networks:
-      - devskyy-network
+    networks: [devskyy-network]
     restart: unless-stopped
-    deploy:
-      replicas: 1
-      resources:
-        limits:
-          cpus: '2.0'
-          memory: 4G
-        reservations:
-          cpus: '0.5'
-          memory: 1G
     healthcheck:
-      test: ["CMD", "python", "-c", "import sys; sys.exit(0)"]
+      test: ["CMD-SHELL", "python -c \"import os,redis; redis.from_url(os.environ['REDIS_URL']).ping()\""]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      start_period: 30s
+    deploy:
+      resources:
+        limits: { cpus: "2.0", memory: 4G }
+    logging: *logging
 
-  # Celery monitoring (Flower)
-  celery-flower:
-    build: .
-    command: celery -A agent_sdk.worker flower --port=5555
-    container_name: devskyy-flower
-    ports:
-      - "5555:5555"
+  # ---------------------------------------------------------------------------
+  # Elite Studio worker — async SKU render jobs
+  # ---------------------------------------------------------------------------
+  elite-worker:
+    build: *app-build
+    image: devskyy:local
+    container_name: devskyy-elite-worker
+    command: ["python", "-m", "skyyrose.elite_studio", "worker"]
+    env_file: [.env.docker]
     environment:
-      - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@redis:6379/0
+      <<: *app-env
+      ELITE_WORKER_CONCURRENCY: ${ELITE_WORKER_CONCURRENCY:-1}
+      ELITE_COST_TRACKING: ${ELITE_COST_TRACKING:-true}
     depends_on:
-      - celery-worker
-    networks:
-      - devskyy-network
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      app:
+        condition: service_started
+    volumes:
+      - app_data:/app/data
+      - app_logs:/app/logs
+    networks: [devskyy-network]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import os,redis; redis.from_url(os.environ['REDIS_URL']).ping()\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits: { cpus: "2.0", memory: 4G }
+    logging: *logging
 
-  # Nginx reverse proxy
+  # ---------------------------------------------------------------------------
+  # Nginx reverse proxy — opt-in: `--profile proxy`
+  # Serves :80 → app. (TLS is commented in nginx.conf; add certs + a 443 block
+  # there and mount them before exposing 443.)
+  # ---------------------------------------------------------------------------
   nginx:
     image: nginx:alpine
     container_name: devskyy-nginx
+    profiles: [proxy]
     ports:
-      - "80:80"
-      - "443:443"
+      - "${HTTP_PORT:-80}:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./ssl:/etc/nginx/ssl:ro
       - nginx_logs:/var/log/nginx
     depends_on:
-      - devskyy-app
-    networks:
-      - devskyy-network
+      app:
+        condition: service_healthy
+    networks: [devskyy-network]
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost/health"]
       interval: 30s
       timeout: 10s
       retries: 3
+    logging: *logging
 
-  # Monitoring with Prometheus
+  # ---------------------------------------------------------------------------
+  # Prometheus — opt-in: `--profile monitoring`
+  # ---------------------------------------------------------------------------
   prometheus:
     image: prom/prometheus:latest
     container_name: devskyy-prometheus
+    profiles: [monitoring]
     ports:
       - "9090:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/etc/prometheus/console_libraries'
-      - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention.time=200h'
-      - '--web.enable-lifecycle'
-    networks:
-      - devskyy-network
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=200h"
+      - "--web.enable-lifecycle"
+    networks: [devskyy-network]
     restart: unless-stopped
+    logging: *logging
 
-  # Grafana for visualization
+  # ---------------------------------------------------------------------------
+  # Grafana — opt-in: `--profile monitoring`
+  # ---------------------------------------------------------------------------
   grafana:
     image: grafana/grafana:latest
     container_name: devskyy-grafana
+    profiles: [monitoring]
     ports:
       - "3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-changeme}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD in .env.docker}
+      GF_USERS_ALLOW_SIGN_UP: "false"
     volumes:
       - grafana_data:/var/lib/grafana
-    networks:
-      - devskyy-network
+    depends_on:
+      - prometheus
+    networks: [devskyy-network]
     restart: unless-stopped
+    logging: *logging
 
 volumes:
   postgres_data:
@@ -243,7 +267,6 @@ volumes:
   nginx_logs:
   prometheus_data:
   grafana_data:
-  raganything_data:
 
 networks:
   devskyy-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,8 @@ x-app-env: &app-env
   LOG_LEVEL: ${LOG_LEVEL:-INFO}
   # +asyncpg: database/db.py uses SQLAlchemy create_async_engine, which needs an
   # async driver in the URL. Bare postgresql:// maps to psycopg2 (not installed).
-  DATABASE_URL: postgresql+asyncpg://devskyy:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.docker}@postgres:5432/devskyy
-  REDIS_URL: redis://:${REDIS_PASSWORD:?set REDIS_PASSWORD in .env.docker}@redis:6379/0
+  DATABASE_URL: postgresql+asyncpg://devskyy:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.docker}@postgres:5432/devskyy  # ggignore
+  REDIS_URL: redis://:${REDIS_PASSWORD:?set REDIS_PASSWORD in .env.docker}@redis:6379/0  # ggignore
   # Cryptographic keys — MUST be set or compose fails (prevent booting with unstable placeholder material)
   JWT_SECRET_KEY: ${JWT_SECRET_KEY:?set JWT_SECRET_KEY in .env.docker}
   JWT_REFRESH_SECRET_KEY: ${JWT_REFRESH_SECRET_KEY:?set JWT_REFRESH_SECRET_KEY in .env.docker}
@@ -62,7 +62,7 @@ services:
     environment:
       POSTGRES_DB: devskyy
       POSTGRES_USER: devskyy
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.docker}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.docker}  # ggignore
       POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --lc-collate=C --lc-ctype=C"
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -85,7 +85,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: devskyy-redis
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?set REDIS_PASSWORD in .env.docker}
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?set REDIS_PASSWORD in .env.docker}  # ggignore
     volumes:
       - redis_data:/data
     networks: [devskyy-network]
@@ -252,7 +252,7 @@ services:
       # loopback-only by default; front with a TLS proxy to expose externally.
       - "127.0.0.1:3000:3000"
     environment:
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD in .env.docker}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD in .env.docker}  # ggignore
       GF_USERS_ALLOW_SIGN_UP: "false"
     volumes:
       - grafana_data:/var/lib/grafana

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,16 +33,17 @@ python3 -c "import sys; print(f'Python {sys.version}')" || {
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] Checking secrets..."
 ts() { date '+%Y-%m-%d %H:%M:%S'; }
 gen_secret() {
-    # $1 = env var name, $2 = python expression that prints the secret value
+    # $1 = env var name, $2 = python expression that prints the secret value.
+    # printenv reads the named var without eval (call sites pass literal names).
     var="$1"
-    [ -n "$(eval "printf '%s' \"\${$var}\"")" ] && return 0
+    [ -n "$(printenv "$var")" ] && return 0
     echo "[$(ts)] Generating $var..."
     val=$(python3 -c "$2" 2>&1) || {
         echo "[$(ts)] ERROR: Failed to generate $var: $val"
         exit 1
     }
     export "$var=$val"
-    echo "[$(ts)] $var generated (length: $(eval "printf '%s' \"\${#$var}\""))"
+    echo "[$(ts)] $var generated (length: ${#val})"
 }
 
 gen_secret JWT_SECRET_KEY "import secrets; print(secrets.token_urlsafe(64))"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,6 +38,16 @@ if [ -z "$JWT_SECRET_KEY" ]; then
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] JWT_SECRET_KEY generated (length: ${#JWT_SECRET_KEY})"
 fi
 
+if [ -z "$JWT_REFRESH_SECRET_KEY" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Generating JWT_REFRESH_SECRET_KEY..."
+    JWT_R=$(python3 -c "import secrets; print(secrets.token_urlsafe(64))" 2>&1) || {
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: Failed to generate JWT_REFRESH_SECRET_KEY: $JWT_R"
+        exit 1
+    }
+    export JWT_REFRESH_SECRET_KEY="$JWT_R"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] JWT_REFRESH_SECRET_KEY generated (length: ${#JWT_REFRESH_SECRET_KEY})"
+fi
+
 if [ -z "$ENCRYPTION_MASTER_KEY" ]; then
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Generating ENCRYPTION_MASTER_KEY..."
     ENC_KEY=$(python3 -c "import secrets, base64; print(base64.b64encode(secrets.token_bytes(32)).decode())" 2>&1) || {
@@ -46,6 +56,15 @@ if [ -z "$ENCRYPTION_MASTER_KEY" ]; then
     }
     export ENCRYPTION_MASTER_KEY="$ENC_KEY"
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] ENCRYPTION_MASTER_KEY generated (length: ${#ENCRYPTION_MASTER_KEY})"
+fi
+
+# Command dispatch: this one image serves the API *and* the background workers.
+# If compose (or `docker run`) passed a command, run THAT instead of uvicorn —
+# the workers still inherit the secret bootstrap above. The API role passes no
+# command and falls through to the uvicorn default below.
+if [ "$#" -gt 0 ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Executing passed command: $*"
+    exec "$@"
 fi
 
 # Check if main_enterprise.py exists

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,6 +34,8 @@ echo "[$(date '+%Y-%m-%d %H:%M:%S')] Checking secrets..."
 ts() { date '+%Y-%m-%d %H:%M:%S'; }
 gen_secret() {
     # $1 = env var name, $2 = python expression that prints the secret value.
+    # SECURITY: $2 is fed to `python3 -c`, so CALL SITES MUST PASS A LITERAL — never
+    # a variable / env-expanded value (that would be arbitrary code at startup).
     # printenv reads the named var without eval (call sites pass literal names).
     var="$1"
     [ -n "$(printenv "$var")" ] && return 0
@@ -83,10 +85,10 @@ echo "[$(date '+%Y-%m-%d %H:%M:%S')] ======================================"
 # - proxy-headers: enabled for X-Forwarded-* from Fly.io proxy
 exec python3 -m uvicorn main_enterprise:app \
     --host 0.0.0.0 \
-    --port 8000 \
+    --port "${PORT:-8000}" \
     --workers 1 \
     --timeout-keep-alive 65 \
     --lifespan on \
     --proxy-headers \
-    --forwarded-allow-ips '*' \
+    --forwarded-allow-ips "${FORWARDED_ALLOW_IPS:-127.0.0.1}" \
     --access-log 2>&1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,37 +26,28 @@ python3 -c "import sys; print(f'Python {sys.version}')" || {
     exit 1
 }
 
-# Generate required secrets if not provided (BEFORE uvicorn startup)
+# Generate required secrets if not provided (BEFORE uvicorn startup). This keeps
+# the API + workers bootable without a committed .env; .env.docker is the
+# expected production source (see docs/DOCKER.md). Ephemeral keys rotate on
+# restart — set them explicitly for any real deployment.
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] Checking secrets..."
-if [ -z "$JWT_SECRET_KEY" ]; then
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Generating JWT_SECRET_KEY..."
-    JWT_KEY=$(python3 -c "import secrets; print(secrets.token_urlsafe(64))" 2>&1) || {
-        echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: Failed to generate JWT_SECRET_KEY: $JWT_KEY"
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+gen_secret() {
+    # $1 = env var name, $2 = python expression that prints the secret value
+    var="$1"
+    [ -n "$(eval "printf '%s' \"\${$var}\"")" ] && return 0
+    echo "[$(ts)] Generating $var..."
+    val=$(python3 -c "$2" 2>&1) || {
+        echo "[$(ts)] ERROR: Failed to generate $var: $val"
         exit 1
     }
-    export JWT_SECRET_KEY="$JWT_KEY"
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] JWT_SECRET_KEY generated (length: ${#JWT_SECRET_KEY})"
-fi
+    export "$var=$val"
+    echo "[$(ts)] $var generated (length: $(eval "printf '%s' \"\${#$var}\""))"
+}
 
-if [ -z "$JWT_REFRESH_SECRET_KEY" ]; then
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Generating JWT_REFRESH_SECRET_KEY..."
-    JWT_R=$(python3 -c "import secrets; print(secrets.token_urlsafe(64))" 2>&1) || {
-        echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: Failed to generate JWT_REFRESH_SECRET_KEY: $JWT_R"
-        exit 1
-    }
-    export JWT_REFRESH_SECRET_KEY="$JWT_R"
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] JWT_REFRESH_SECRET_KEY generated (length: ${#JWT_REFRESH_SECRET_KEY})"
-fi
-
-if [ -z "$ENCRYPTION_MASTER_KEY" ]; then
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Generating ENCRYPTION_MASTER_KEY..."
-    ENC_KEY=$(python3 -c "import secrets, base64; print(base64.b64encode(secrets.token_bytes(32)).decode())" 2>&1) || {
-        echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: Failed to generate ENCRYPTION_MASTER_KEY: $ENC_KEY"
-        exit 1
-    }
-    export ENCRYPTION_MASTER_KEY="$ENC_KEY"
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ENCRYPTION_MASTER_KEY generated (length: ${#ENCRYPTION_MASTER_KEY})"
-fi
+gen_secret JWT_SECRET_KEY "import secrets; print(secrets.token_urlsafe(64))"
+gen_secret JWT_REFRESH_SECRET_KEY "import secrets; print(secrets.token_urlsafe(64))"
+gen_secret ENCRYPTION_MASTER_KEY "import secrets, base64; print(base64.b64encode(secrets.token_bytes(32)).decode())"
 
 # Command dispatch: this one image serves the API *and* the background workers.
 # If compose (or `docker run`) passed a command, run THAT instead of uvicorn —

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -24,7 +24,7 @@ One image — `devskyy:local` — serves three roles, selected by the compose
 | `app`          | FastAPI REST + GraphQL + MCP      | *(default)* → uvicorn `main_enterprise:app` |
 | `worker`       | async task queue poller (3D/ML)   | `python -m agent_sdk.worker`              |
 | `elite-worker` | Elite Studio render jobs          | `python -m skyyrose.elite_studio worker`  |
-| `postgres`     | PostgreSQL 15 (schema in `init.sql`) | —                                      |
+| `postgres`     | PostgreSQL 15 (extensions only; schema via `create_all`) | —                     |
 | `redis`        | task queue + cache (authed)       | —                                         |
 
 Opt-in profiles:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,99 @@
+# Docker — DevSkyy Production Stack
+
+The canonical containerized stack for the Python API + background workers. The
+Next.js dashboard is **not** in here — it deploys to Vercel (`devskyy.app`).
+
+## TL;DR
+
+```bash
+make docker-secrets     # 1. generate .env.docker with strong random secrets
+#   edit .env.docker → paste your OPENAI_API_KEY / ANTHROPIC_API_KEY / etc.
+make docker-up          # 2. build + start core stack (detached)
+make docker-logs        # 3. watch it boot
+curl localhost:8000/health
+make docker-down        # stop (keeps data)
+```
+
+## What runs
+
+One image — `devskyy:local` — serves three roles, selected by the compose
+`command:` and dispatched by `docker-entrypoint.sh`:
+
+| Service        | Role                              | Command                                   |
+|----------------|-----------------------------------|-------------------------------------------|
+| `app`          | FastAPI REST + GraphQL + MCP      | *(default)* → uvicorn `main_enterprise:app` |
+| `worker`       | async task queue poller (3D/ML)   | `python -m agent_sdk.worker`              |
+| `elite-worker` | Elite Studio render jobs          | `python -m skyyrose.elite_studio worker`  |
+| `postgres`     | PostgreSQL 15 (schema in `init.sql`) | —                                      |
+| `redis`        | task queue + cache (authed)       | —                                         |
+
+Opt-in profiles:
+
+```bash
+docker compose --env-file .env.docker --profile monitoring up -d   # + prometheus + grafana
+docker compose --env-file .env.docker --profile proxy up -d        # + nginx (:80 → app)
+```
+
+## Secrets
+
+`.env.docker` (gitignored) holds everything. `make docker-secrets` fills the
+infra passwords and the two security keys with random values; you paste the API
+keys. Compose **fails loudly** (`${VAR:?...}`) if a required secret is missing —
+there is no silent `changeme` fallback.
+
+> **`JWT_SECRET_KEY` and `ENCRYPTION_MASTER_KEY` must stay stable.** If unset,
+> the entrypoint generates ephemeral keys every boot, which rotates the
+> encryption key (data becomes unreadable) and invalidates all JWTs. The
+> generator persists both — keep `.env.docker` safe and backed up.
+
+## Build targets
+
+```bash
+make docker-build       # builds devskyy:local (INSTALL_TARGET=all default)
+```
+
+`INSTALL_TARGET` selects which `pyproject.toml` *extras* to add on top of the
+base dependencies. **It does not give you a slim, torch-free image**: the ML
+stack (torch, transformers, diffusers, chromadb) lives in the base
+`[project.dependencies]`, so every build pulls it. The first build downloads
+that wheel stack (multi-GB, ~15–20 min) and produces a large (~6 GB) image;
+subsequent builds hit the BuildKit cache. A genuinely slim API image would
+require moving the ML deps into an optional group in `pyproject.toml` first.
+
+The `.dockerignore` is an **allowlist** (ignore everything, re-include only the
+first-party Python packages + canonical text data). It cut the build context
+from ~1 GB to ~43 MB by excluding the unbounded local scratch at the repo root
+(`backups/`, `ci_mirror/`, `editorial-staging/`, `.claude/` worktrees, etc.),
+all binary media, the 465 MB PHP theme (only its `data/` subdir — catalog CSV +
+36 dossiers + logo registry — is re-included), the frontend, and `.git`.
+
+## Scaling
+
+`docker compose up` ignores `deploy.replicas`; scale a role explicitly:
+
+```bash
+docker compose --env-file .env.docker up -d --scale worker=3
+```
+
+## Make targets
+
+| Target                   | Does                                              |
+|--------------------------|---------------------------------------------------|
+| `make docker-secrets`    | generate `.env.docker` (won't clobber an existing one) |
+| `make docker-config`     | validate + render the merged compose config       |
+| `make docker-build`      | build `devskyy:local`                             |
+| `make docker-up`         | build + start core stack (detached)               |
+| `make docker-up-monitoring` | core + prometheus + grafana                    |
+| `make docker-logs`       | tail all services                                 |
+| `make docker-ps`         | container status                                  |
+| `make docker-down`       | stop (keeps volumes)                              |
+| `make docker-clean`      | stop **and delete volumes** (destroys data)       |
+
+## Other Dockerfiles in the repo
+
+- `Dockerfile.mcp` — slim standalone MCP HTTP service (`mcp_service:app`, no ML
+  stack), selected by `fly.toml` for Fly.io.
+- `docker-compose.staging.yml` — elaborate staging stack with the full
+  Prometheus/Grafana/Loki/Promtail observability tree. It references a
+  `config/<service>/...` config layout; confirm those files exist before using it.
+- `deploy/clothing_3d/` — standalone 3D service, separate concern.

--- a/init.sql
+++ b/init.sql
@@ -1,110 +1,11 @@
--- DevSkyy Database Initialization
--- PostgreSQL 15+ compatible
+-- DevSkyy Database Initialization (PostgreSQL 15+)
+-- ============================================================================
+-- EXTENSIONS ONLY. The application owns its schema: database/db.py creates all
+-- tables from the SQLAlchemy models on startup (create_all). A hand-maintained
+-- table schema here drifts from the models and conflicts on FK types
+-- (e.g. order_items.order_id vs a UUID orders.id) — which aborts app startup.
+-- Keep this file to the extensions the models rely on; let the app build tables.
+-- ============================================================================
 
--- Enable extensions
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS "pg_trgm";
-
--- Users table
-CREATE TABLE IF NOT EXISTS users (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    email VARCHAR(255) UNIQUE NOT NULL,
-    username VARCHAR(100) UNIQUE NOT NULL,
-    password_hash VARCHAR(255) NOT NULL,
-    full_name VARCHAR(255),
-    role VARCHAR(50) DEFAULT 'customer',
-    is_active BOOLEAN DEFAULT true,
-    is_verified BOOLEAN DEFAULT false,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    last_login TIMESTAMP WITH TIME ZONE,
-    metadata JSONB DEFAULT '{}'::jsonb
-);
-
-CREATE INDEX idx_users_email ON users(email);
-CREATE INDEX idx_users_role ON users(role);
-
--- Products table
-CREATE TABLE IF NOT EXISTS products (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    sku VARCHAR(100) UNIQUE NOT NULL,
-    name VARCHAR(500) NOT NULL,
-    description TEXT,
-    category VARCHAR(100),
-    price DECIMAL(10, 2) NOT NULL,
-    inventory_quantity INTEGER DEFAULT 0,
-    status VARCHAR(50) DEFAULT 'draft',
-    tags TEXT[],
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    metadata JSONB DEFAULT '{}'::jsonb
-);
-
-CREATE INDEX idx_products_sku ON products(sku);
-CREATE INDEX idx_products_status ON products(status);
-
--- Orders table
-CREATE TABLE IF NOT EXISTS orders (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    order_number VARCHAR(50) UNIQUE NOT NULL,
-    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
-    status VARCHAR(50) DEFAULT 'pending',
-    total_price DECIMAL(10, 2) NOT NULL,
-    subtotal DECIMAL(10, 2) NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    metadata JSONB DEFAULT '{}'::jsonb
-);
-
-CREATE INDEX idx_orders_user_id ON orders(user_id);
-CREATE INDEX idx_orders_status ON orders(status);
-
--- LLM Round Table Results
-CREATE TABLE IF NOT EXISTS llm_round_table_results (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    result_id VARCHAR(100) UNIQUE NOT NULL,
-    prompt TEXT NOT NULL,
-    task_category VARCHAR(100),
-    winner_provider VARCHAR(50),
-    winner_response TEXT,
-    participants JSONB NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    metadata JSONB DEFAULT '{}'::jsonb
-);
-
-CREATE INDEX idx_llm_results_category ON llm_round_table_results(task_category);
-
--- Agent Execution Logs
-CREATE TABLE IF NOT EXISTS agent_executions (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    execution_id VARCHAR(100) UNIQUE NOT NULL,
-    agent_name VARCHAR(100) NOT NULL,
-    prompt TEXT NOT NULL,
-    status VARCHAR(50) DEFAULT 'running',
-    result JSONB,
-    tokens_used INTEGER,
-    duration_ms INTEGER,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    metadata JSONB DEFAULT '{}'::jsonb
-);
-
-CREATE INDEX idx_agent_executions_agent ON agent_executions(agent_name);
-CREATE INDEX idx_agent_executions_status ON agent_executions(status);
-
--- Auto-update timestamp trigger
-CREATE OR REPLACE FUNCTION update_updated_at_column()
-RETURNS TRIGGER AS $BODY$
-BEGIN
-    NEW.updated_at = CURRENT_TIMESTAMP;
-    RETURN NEW;
-END;
-$BODY$ LANGUAGE plpgsql;
-
-CREATE TRIGGER update_users_updated_at BEFORE UPDATE ON users
-    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-
-CREATE TRIGGER update_products_updated_at BEFORE UPDATE ON products
-    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-
-CREATE TRIGGER update_orders_updated_at BEFORE UPDATE ON orders
-    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -39,24 +39,11 @@ scrape_configs:
     metrics_path: '/metrics'
     scheme: 'http'
 
-  # Celery workers (if they expose metrics)
-  - job_name: 'celery-workers'
-    scrape_interval: 15s
-    static_configs:
-      - targets: ['celery-worker:9091']
-        labels:
-          service: 'celery'
-          component: 'worker'
-    # Note: Requires prometheus-client in worker.py
-
-  # Celery Flower monitoring
-  - job_name: 'celery-flower'
-    scrape_interval: 15s
-    static_configs:
-      - targets: ['celery-flower:5555']
-        labels:
-          service: 'celery'
-          component: 'flower'
+  # NOTE: the background workers (`worker`, `elite-worker`) are hand-rolled
+  # asyncio Redis pollers, not Celery, and do not yet expose a Prometheus
+  # metrics endpoint. Add prometheus-client to worker.py and a job here once
+  # they do. (Removed the stale celery-worker / celery-flower scrape jobs —
+  # those hosts never existed.)
 
   # Redis exporter (optional - requires redis_exporter sidecar)
   # - job_name: 'redis'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,9 @@ ml = [
     "nltk>=3.9.3",  # Fixed: CVE-2025-xxx path traversal, fixed in 3.9.3
     "spacy>=3.8.2",
     "textblob>=0.18.0.post0",
-    "mlflow>=3.9.0",  # Fixed: 2 advisories (GHSA-*) resolved in 3.9.0
+    # mlflow removed 2026-06-22: imported in 0 files (dead dep) and its
+    # cryptography<49 cap conflicted with the mcp extra's cryptography==49.0.0
+    # security pin, making .[all] unresolvable (Docker + local + CI).
     "bentoml>=1.4.34",
     "wandb>=0.24.2",  # Updated for protobuf 6.x compatibility
     "tensorboard==2.20.0",
@@ -256,14 +258,12 @@ ml = [
     "category-encoders==2.9.0",
     "optuna==4.9.0",
     "hyperopt==0.2.7",
-    "librosa==0.11.0",
-    "soundfile==0.13.1",
-    "statsmodels==0.14.6",
-    "prophet==1.3.0",
-    "gymnasium>=1.0.0",
-    "stable-baselines3>=2.5.0",
-    "shap==0.52.0",
-    "lime==0.2.0.1",
+    # Removed 2026-06-22 — all imported in 0 files (runtime + tests) AND they
+    # forced source builds that break a clean py3.12 install:
+    #   librosa, shap → numba → llvmlite 0.36 (no py3.12 support)
+    #   prophet, statsmodels → cmdstan/compile
+    #   gymnasium, stable-baselines3, soundfile, lime → dead RL/audio/explainability
+    # This unbreaks `uv pip install .[all]` on Python 3.12.
     "polars==1.41.2",
     "pyarrow==24.0.0",
     "hydra-core==1.3.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,10 +258,13 @@ ml = [
     "category-encoders==2.9.0",
     "optuna==4.9.0",
     "hyperopt==0.2.7",
-    # Removed 2026-06-22 — all imported in 0 files (runtime + tests) AND they
-    # forced source builds that break a clean py3.12 install:
+    # Removed 2026-06-22 — all force source builds that break a clean py3.12
+    # install, and all are unused EXCEPT prophet:
     #   librosa, shap → numba → llvmlite 0.36 (no py3.12 support)
-    #   prophet, statsmodels → cmdstan/compile
+    #   prophet, statsmodels → cmdstan/compile. prophet is imported only behind a
+    #     try/except ImportError in agents/base_super_agent/ml_module.py with a
+    #     TrendExtrapolationWrapper fallback, so removal degrades gracefully (and
+    #     prophet's cmdstan build never succeeded in the py3.12 image anyway).
     #   gymnasium, stable-baselines3, soundfile, lime → dead RL/audio/explainability
     # This unbreaks `uv pip install .[all]` on Python 3.12.
     "polars==1.41.2",

--- a/scripts/docker-secrets.sh
+++ b/scripts/docker-secrets.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Generate .env.docker from .env.docker.example with strong random secrets.
+# Refuses to clobber an existing .env.docker (it holds your real secrets/keys).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+TEMPLATE=".env.docker.example"
+OUT=".env.docker"
+
+if [ -f "$OUT" ]; then
+    echo "✋ $OUT already exists — refusing to overwrite (it holds your secrets)."
+    echo "   Delete it first if you really want a fresh set: rm $OUT && make docker-secrets"
+    exit 1
+fi
+[ -f "$TEMPLATE" ] || { echo "ERROR: $TEMPLATE not found"; exit 1; }
+
+# URL-safe tokens (chars [-_A-Za-z0-9]) are safe inside the postgres:// / redis:// URLs.
+gen() { python3 -c "import secrets; print(secrets.token_urlsafe($1))"; }
+# Matches the entrypoint's ENCRYPTION_MASTER_KEY format: base64(32 random bytes).
+enc() { python3 -c "import secrets,base64; print(base64.b64encode(secrets.token_bytes(32)).decode())"; }
+
+PG=$(gen 24); RD=$(gen 24); GF=$(gen 18); JWT=$(gen 64); JWTR=$(gen 64); ENC=$(enc)
+
+cp "$TEMPLATE" "$OUT"
+
+python3 - "$OUT" "$PG" "$RD" "$GF" "$JWT" "$JWTR" "$ENC" <<'PY'
+import sys
+path, pg, rd, gf, jwt, jwtr, enc = sys.argv[1:8]
+repl = {
+    "POSTGRES_PASSWORD": pg,
+    "REDIS_PASSWORD": rd,
+    "GRAFANA_ADMIN_PASSWORD": gf,
+    "JWT_SECRET_KEY": jwt,
+    "JWT_REFRESH_SECRET_KEY": jwtr,
+    "ENCRYPTION_MASTER_KEY": enc,
+}
+lines = []
+for line in open(path):
+    key = line.split("=", 1)[0].strip()
+    lines.append(f"{key}={repl[key]}\n" if key in repl else line)
+open(path, "w").writelines(lines)
+PY
+
+chmod 600 "$OUT"
+echo "✅ Wrote $OUT (chmod 600) with random POSTGRES/REDIS/GRAFANA passwords + JWT/ENCRYPTION keys."
+echo "   Next: paste your API keys into $OUT, then run 'make docker-up'."

--- a/scripts/docker-secrets.sh
+++ b/scripts/docker-secrets.sh
@@ -24,9 +24,13 @@ PG=$(gen 24); RD=$(gen 24); GF=$(gen 18); JWT=$(gen 64); JWTR=$(gen 64); ENC=$(e
 
 cp "$TEMPLATE" "$OUT"
 
-python3 - "$OUT" "$PG" "$RD" "$GF" "$JWT" "$JWTR" "$ENC" <<'PY'
+# Secrets go via stdin (newline-delimited), not argv — argv is world-readable in
+# /proc/<pid>/cmdline and `ps` while the process runs.
+printf '%s\n' "$PG" "$RD" "$GF" "$JWT" "$JWTR" "$ENC" | python3 - "$OUT" <<'PY'
 import sys
-path, pg, rd, gf, jwt, jwtr, enc = sys.argv[1:8]
+
+path = sys.argv[1]
+pg, rd, gf, jwt, jwtr, enc = sys.stdin.read().splitlines()
 repl = {
     "POSTGRES_PASSWORD": pg,
     "REDIS_PASSWORD": rd,
@@ -35,11 +39,14 @@ repl = {
     "JWT_REFRESH_SECRET_KEY": jwtr,
     "ENCRYPTION_MASTER_KEY": enc,
 }
+with open(path) as f:
+    src = f.readlines()
 lines = []
-for line in open(path):
+for line in src:
     key = line.split("=", 1)[0].strip()
     lines.append(f"{key}={repl[key]}\n" if key in repl else line)
-open(path, "w").writelines(lines)
+with open(path, "w") as f:
+    f.writelines(lines)
 PY
 
 chmod 600 "$OUT"

--- a/scripts/docker-secrets.sh
+++ b/scripts/docker-secrets.sh
@@ -24,13 +24,14 @@ PG=$(gen 24); RD=$(gen 24); GF=$(gen 18); JWT=$(gen 64); JWTR=$(gen 64); ENC=$(e
 
 cp "$TEMPLATE" "$OUT"
 
-# Secrets go via stdin (newline-delimited), not argv — argv is world-readable in
-# /proc/<pid>/cmdline and `ps` while the process runs.
-printf '%s\n' "$PG" "$RD" "$GF" "$JWT" "$JWTR" "$ENC" | python3 - "$OUT" <<'PY'
+# Secrets go via env vars (not argv — argv is world-readable in /proc/<pid>/cmdline
+# and `ps` while the process runs).
+PG="$PG" RD="$RD" GF="$GF" JWT="$JWT" JWTR="$JWTR" ENC="$ENC" python3 - "$OUT" <<'PY'
 import sys
+import os
 
 path = sys.argv[1]
-pg, rd, gf, jwt, jwtr, enc = sys.stdin.read().splitlines()
+pg, rd, gf, jwt, jwtr, enc = os.environ["PG"], os.environ["RD"], os.environ["GF"], os.environ["JWT"], os.environ["JWTR"], os.environ["ENC"]
 repl = {
     "POSTGRES_PASSWORD": pg,
     "REDIS_PASSWORD": rd,


### PR DESCRIPTION
Clean docker-only re-cut of #601 (which got entangled with a concurrent session's design-system work on a shared branch name). 3 commits, 13 files, docker-only.

## What
Make the Docker infra actually **build and boot** — it existed but had never run end-to-end. Verified live: `make docker-up` → all 5 services healthy (restarts=0), `/health` `/ready` `/live` → 200, `/health` body `database:healthy`.

## Commits
1. **feat(docker): production-ready stack + dependency cleanup** — one image (`devskyy:local`) for app + worker + elite-worker (entrypoint dispatches the role); dropped the dead Next.js build stage (frontend = Vercel); `COPY . .` + an allowlist `.dockerignore` (build context **1.04GB → 43MB**, fixes `skyyrose/`+`billing/` missing); builder uses **uv** (slim image has no setuptools; pip backtracked ~10min); removed broken `celery-flower`; fail-loud secrets via `.env.docker`; health-gated deps; monitoring/proxy profiles; `make docker-*` + `docs/DOCKER.md` + secret generator. Code fixes surfaced by the first real Postgres cold start: `database/db.py` async pool + URL driver; `init.sql` → extensions-only (app owns schema); removed 9 build-breaking deps from the `ml` extra (mlflow crypto conflict; numba/llvmlite + cmdstan py3.12 source-build failures).
2. **refactor(docker): /simplify pass** — `gen_secret` helper, `x-svc-resources` anchor, workers decoupled from `app`, `_normalize_async_url` so any `postgresql://` URL works.
3. **fix(docker): apply /code-review findings** — Prometheus/Grafana bound to loopback; no `eval` in secret-gen; secrets via stdin; URL-normalize empty/case guards + no config mutation; `libfreetype6` + `fonts-dejavu-core` (imagery text was falling back to a bitmap font); accurate prophet note.

## Test plan
- [x] `make docker-up` → 5/5 healthy, restarts=0; `/health` `/ready` `/live` → 200; `database:healthy`
- [x] image runs non-root (uid 1000); `import cv2` 4.13.0; DejaVu TTF present
- [x] `docker compose config` exit 0; build context 43MB (busybox probe: 36 dossiers + catalog, 0 png/scratch/.env)
- [x] pre-commit gate green per commit (ruff/black/isort/mypy 1374 files/fast tests/freshness)

Supersedes the docker portion of #601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Docker stack production-ready and self-contained. Improves security defaults, reduces build context, and fixes the Postgres async path so the stack builds and boots cleanly.

- **New Features**
  - Single `devskyy:local` image for API, `worker`, and `elite-worker` (entrypoint dispatch, `tini`, non-root).
  - New compose stack: `postgres`, `redis`, `app`, `worker`, `elite-worker` with optional `monitoring` (Prometheus + Grafana, loopback-only) and `proxy` (nginx) profiles; fail-loud secrets via `.env.docker`; health-gated deps; resource/log limits.
  - Allowlist `.dockerignore` cuts build context ~1.04GB → 43MB; removed dead Next.js build.
  - `uv`-based builder for deterministic installs; `Makefile` `docker-*` targets; `.env.docker.example`, `scripts/docker-secrets.sh`, and `docs/DOCKER.md`.

- **Bug Fixes**
  - Postgres path fixed: async pooling via `AsyncAdaptedQueuePool`, automatic `postgresql://` → `postgresql+asyncpg://` normalization, robust SQLite detection via `make_url`; `init.sql` now extensions-only (app owns schema).
  - Dependency cleanup unblocks `.[all]` on Python 3.12 and resolves `cryptography` conflicts by removing unused/breaking ML extras.
  - Secret tooling hardened: no `eval`; secrets via env; generator fills `JWT_REFRESH_SECRET_KEY`; compose enforces JWT/ENCRYPTION keys at boot.
  - Entrypoint hardening: defaults `--forwarded-allow-ips` to `127.0.0.1` (override with `FORWARDED_ALLOW_IPS`), threads `${PORT:-8000}` to uvicorn so healthchecks and server port stay aligned.
  - Lint/CI: black formatting applied; added `# ggignore` comments in compose to silence false-positive secret scanners.

<sup>Written for commit e66b6e3bed01d9dc3d36c6a84be10bb2bfc97cf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker secret bootstrap using a generated `.env.docker` template
  * Introduced a profile-driven container stack (app/worker/elite-worker) with optional proxy and monitoring
* **Documentation**
  * Added/updated Docker production stack guidance and setup instructions
* **Bug Fixes & Improvements**
  * Improved PostgreSQL async connection URL handling and async pooling
  * Refreshed service healthchecks and tightened Redis health verification
  * Removed stale Celery metrics scrape targets from Prometheus config
* **Chores**
  * Reworked Docker image build to a Python-focused production layout (with caching and labels)
  * Updated Docker Compose, Makefile targets, and entrypoint behavior; reduced DB init to extensions only
  * Secured build context with an allowlist-style `.dockerignore` and provided a complete `.env.docker.example` template
<!-- end of auto-generated comment: release notes by coderabbit.ai -->