### PR TITLE
chore(elite-studio): vendor 5 CLI harnesses (relocated from vendor/)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -377,6 +377,7 @@ exclude = [
     "dev/",
     "editorial-staging/",
     "hf-spaces/",
+    "skyyrose/cli_harnesses/",  # vendored CLI tooling (relocated from vendor/) — not host-linted
 ]
 
 [tool.ruff.lint]
@@ -449,6 +450,7 @@ exclude = '''
     | build
     | dist
     | legacy
+    | cli_harnesses
 )/
 '''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -462,7 +462,7 @@ exclude = '''
 profile = "black"
 line_length = 100
 known_first_party = ["core", "api", "security", "database", "wordpress", "agents", "orchestration", "runtime", "llm"]
-skip = ["legacy/", ".venv/", ".venv-*/", ".claude/", "_archive/", "open-claude-code/", ".agents/", ".aidesigner/"]
+skip = ["legacy/", ".venv/", ".venv-*/", ".claude/", "_archive/", "open-claude-code/", ".agents/", ".aidesigner/", "skyyrose/cli_harnesses/"]
 
 # =============================================================================
 # MyPy Configuration — canonical config lives in mypy.ini (not here)

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/COMFYUI.md
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/COMFYUI.md
@@ -1,0 +1,301 @@
+# ComfyUI CLI — Command Reference
+
+Full reference for `comfyui` / `cli-anything-comfyui`.
+
+## system
+
+### `system stats`
+
+Fetch server statistics (CPU, RAM, VRAM, device info).
+
+```bash
+comfyui system stats
+comfyui --json system stats
+```
+
+### `system embeddings`
+
+List all available text embeddings.
+
+```bash
+comfyui system embeddings
+comfyui --json system embeddings
+```
+
+---
+
+## nodes
+
+### `nodes list [--filter TEXT]`
+
+List all registered node types. Optionally filter by substring.
+
+```bash
+comfyui nodes list
+comfyui nodes list --filter KSampler
+comfyui --json nodes list --filter Loader
+```
+
+### `nodes info <node_class>`
+
+Show full input/output schema for a node class.
+
+```bash
+comfyui nodes info KSampler
+comfyui --json nodes info CheckpointLoaderSimple
+```
+
+---
+
+## models
+
+### `models list [model_type]`
+
+List models of a given type. If `model_type` is omitted, lists all types first.
+
+```bash
+comfyui models list checkpoints
+comfyui models list loras
+comfyui --json models list vae
+```
+
+### `models types`
+
+List all available model type slugs.
+
+```bash
+comfyui models types
+comfyui --json models types
+```
+
+---
+
+## queue
+
+### `queue list`
+
+Show running and pending items in the queue.
+
+```bash
+comfyui queue list
+comfyui --json queue list
+```
+
+### `queue submit <workflow_file>`
+
+Submit a workflow JSON file to the queue. Returns `prompt_id`.
+
+```bash
+comfyui queue submit my_workflow.json
+comfyui --json queue submit my_workflow.json
+```
+
+### `queue interrupt --confirm`
+
+Interrupt the currently executing prompt. Requires `--confirm`.
+
+```bash
+comfyui queue interrupt --confirm
+```
+
+### `queue clear --confirm`
+
+Clear all pending items from the queue. Requires `--confirm`.
+
+```bash
+comfyui queue clear --confirm
+```
+
+---
+
+## history
+
+### `history list`
+
+List completed prompts (most recent first).
+
+```bash
+comfyui history list
+comfyui --json history list
+```
+
+### `history show <prompt_id>`
+
+Show details for a specific completed prompt.
+
+```bash
+comfyui history show abc123
+comfyui --json history show abc123
+```
+
+### `history extract-outputs <prompt_id>`
+
+Extract and list all output files (images, videos) from a prompt.
+
+```bash
+comfyui history extract-outputs abc123
+comfyui --json history extract-outputs abc123
+```
+
+### `history clear --confirm [prompt_id]`
+
+Clear history. With `prompt_id` clears one entry; without clears all. Requires `--confirm`.
+
+```bash
+comfyui history clear --confirm
+comfyui history clear --confirm abc123
+```
+
+---
+
+## workflow
+
+### `workflow validate <file>`
+
+Parse and validate a workflow JSON file. Exits 0 if valid, nonzero with error messages if invalid.
+
+```bash
+comfyui workflow validate my_workflow.json
+```
+
+### `workflow show <file>`
+
+Display the workflow structure in human-readable form.
+
+```bash
+comfyui workflow show my_workflow.json
+comfyui --json workflow show my_workflow.json
+```
+
+### `workflow save <file> [--output PATH]`
+
+Canonicalise and re-save a workflow JSON (normalises formatting).
+
+```bash
+comfyui workflow save raw.json --output clean.json
+```
+
+### `workflow nodes <file>`
+
+List all node IDs and class types present in the workflow.
+
+```bash
+comfyui workflow nodes my_workflow.json
+comfyui --json workflow nodes my_workflow.json
+```
+
+---
+
+## session
+
+Sessions persist server context (host, history) across invocations.
+
+### `session new`
+
+Create a new session. Returns session ID.
+
+```bash
+comfyui session new
+comfyui --json session new
+```
+
+### `session list`
+
+List all saved sessions.
+
+```bash
+comfyui session list
+comfyui --json session list
+```
+
+### `session show <session_id>`
+
+Show details for a session.
+
+```bash
+comfyui session show <id>
+comfyui --json session show <id>
+```
+
+### `session delete --confirm <session_id>`
+
+Delete a session. Requires `--confirm`.
+
+```bash
+comfyui session delete --confirm <id>
+```
+
+---
+
+## manifest
+
+Manifests describe batched operations as a plan/apply workflow.
+
+### `manifest plan`
+
+Create a new manifest file interactively.
+
+```bash
+comfyui manifest plan
+comfyui --json manifest plan
+```
+
+### `manifest show <file>`
+
+Display manifest contents.
+
+```bash
+comfyui manifest show ops.manifest.json
+comfyui --json manifest show ops.manifest.json
+```
+
+### `manifest apply --confirm <file>`
+
+Execute all operations in the manifest. Destructive operations are listed before execution. Requires `--confirm`.
+
+```bash
+comfyui manifest apply --confirm ops.manifest.json
+```
+
+---
+
+## doctor
+
+### `doctor check`
+
+Verify connectivity to the ComfyUI server and report status.
+
+```bash
+comfyui doctor check
+comfyui --json doctor check
+```
+
+### `doctor deps`
+
+Check that all required Python dependencies are installed and report versions.
+
+```bash
+comfyui doctor deps
+comfyui --json doctor deps
+```
+
+---
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `COMFYUI_HOST` | ComfyUI base URL | `http://127.0.0.1:8188` |
+| `COMFYUI_AUTH_TOKEN` | Bearer token | — |
+| `COMFYUI_JSON` | Set to `1` for JSON output globally | — |
+| `CLI_ANYTHING_HOME` | Override data directory for sessions/manifests | `~/.cli_anything` |
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | CLI error (missing `--confirm`, invalid args, backend error) |
+| `2` | Usage / argument error (Click default) |

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/README.md
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/README.md
@@ -1,0 +1,72 @@
+# cli-anything-comfyui
+
+**Tier 2 #7** — CLI harness for [ComfyUI](https://github.com/comfyanonymous/ComfyUI).
+Manage nodes, models, queue, history, workflows, sessions, and manifests from the command line.
+
+## Install
+
+```bash
+pip install -e ".[dev]"
+# or with REPL support:
+pip install -e ".[all]"
+```
+
+## Quick Start
+
+```bash
+# Point at your ComfyUI instance (default: http://127.0.0.1:8188)
+export COMFYUI_HOST=http://127.0.0.1:8188
+
+comfyui system stats
+comfyui nodes list --filter KSampler
+comfyui models list checkpoints
+comfyui queue list
+comfyui history list
+comfyui workflow validate my_workflow.json
+comfyui queue submit my_workflow.json
+comfyui doctor check
+```
+
+## Command Groups
+
+| Group | Commands | Description |
+|-------|----------|-------------|
+| `system` | `stats`, `embeddings` | Server stats and embedding list |
+| `nodes` | `list [--filter]`, `info <class>` | Node registry browser |
+| `models` | `list [type]`, `types` | Model listing by type |
+| `queue` | `list`, `submit <file>`, `interrupt --confirm`, `clear --confirm` | Execution queue |
+| `history` | `list`, `show <id>`, `extract-outputs <id>`, `clear --confirm` | Completed prompts |
+| `workflow` | `validate`, `show`, `save`, `nodes` | Workflow JSON tools |
+| `session` | `new`, `list`, `show <id>`, `delete --confirm <id>` | Persistent sessions |
+| `manifest` | `plan`, `show`, `apply --confirm` | Batched operations |
+| `doctor` | `check`, `deps` | Health checks |
+
+## Global Flags
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| `--host` | `COMFYUI_HOST` | `http://127.0.0.1:8188` | ComfyUI base URL |
+| `--token` | `COMFYUI_AUTH_TOKEN` | — | Bearer token for auth |
+| `--json` | `COMFYUI_JSON=1` | — | Machine-readable JSON output |
+| `-V` / `--version` | — | — | Print version |
+
+## Interactive REPL
+
+```bash
+comfyui repl
+# > system stats
+# > queue list
+# > exit
+```
+
+## Testing
+
+```bash
+# Offline unit tests (no server required)
+pytest cli_anything/comfyui/tests/ -v
+
+# Full E2E with live ComfyUI
+COMFYUI_E2E=1 pytest cli_anything/comfyui/tests/ -v
+```
+
+See [`cli_anything/comfyui/tests/TEST.md`](cli_anything/comfyui/tests/TEST.md) for the full 9-phase test plan.

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/CLAUDE.md
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/CLAUDE.md
@@ -1,0 +1,3 @@
+<claude-mem-context>
+
+</claude-mem-context>

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/__init__.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/__init__.py
@@ -1,0 +1,4 @@
+"""cli_anything.comfyui — ComfyUI CLI harness (Tier 2 #7)."""
+
+__version__ = "1.0.0"
+__all__ = ["__version__"]

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/__main__.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/__main__.py
@@ -1,0 +1,6 @@
+"""python -m cli_anything.comfyui entry point."""
+
+from cli_anything.comfyui.comfyui_cli import main
+
+if __name__ == "__main__":
+    main()

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/comfyui_cli.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/comfyui_cli.py
@@ -1,0 +1,183 @@
+"""cli-anything-comfyui — root Click group and REPL entry point.
+
+Entry points (setup.py):
+  comfyui                 → main()
+  cli-anything-comfyui   → main()
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+from cli_anything.comfyui import __version__
+from cli_anything.comfyui.commands.doctor_cmds import doctor
+from cli_anything.comfyui.commands.history_cmds import history
+from cli_anything.comfyui.commands.manifest_cmds import manifest
+from cli_anything.comfyui.commands.models_cmds import models
+from cli_anything.comfyui.commands.nodes_cmds import nodes
+from cli_anything.comfyui.commands.queue_cmds import queue
+from cli_anything.comfyui.commands.session_cmds import session
+from cli_anything.comfyui.commands.system_cmds import system
+from cli_anything.comfyui.commands.workflow_cmds import workflow
+from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackendError
+from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+# ---------------------------------------------------------------------------
+# CLI state object
+# ---------------------------------------------------------------------------
+
+
+class CliState:
+    """Shared state passed via Click context object."""
+
+    def __init__(
+        self, json_mode: bool = False, host: str | None = None, token: str | None = None
+    ) -> None:
+        self.json_mode = json_mode
+        self.host = host
+        self.token = token
+        self.skin = ReplSkin(json_mode=json_mode)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def emit(ctx: click.Context, data: Any) -> None:
+    """Emit data honouring json_mode from CliState."""
+    state: CliState = ctx.obj
+    if state.json_mode:
+        click.echo(json.dumps(data, indent=2))
+    else:
+        click.echo(str(data))
+
+
+def handle_backend_error(exc: ComfyUIBackendError, ctx: click.Context) -> None:
+    state: CliState = ctx.obj
+    if state.json_mode:
+        click.echo(json.dumps({"error": str(exc), "status_code": exc.status_code}))
+    else:
+        state.skin.error(str(exc))
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Root group
+# ---------------------------------------------------------------------------
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"], "max_content_width": 100}
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.version_option(__version__, "-V", "--version")
+@click.option(
+    "--json", "json_mode", is_flag=True, envvar="COMFYUI_JSON", help="Output machine-readable JSON"
+)
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token for auth")
+@click.pass_context
+def cli(ctx: click.Context, json_mode: bool, host: str | None, token: str | None) -> None:
+    """cli-anything-comfyui — manage ComfyUI from the command line.
+
+    \b
+    Command groups:
+      system    Server stats and embeddings
+      nodes     Node registry browser
+      models    Model listing by type
+      queue     Submit and manage the execution queue
+      history   Inspect completed prompts and outputs
+      workflow  Load, validate, and render workflow JSON
+      session   Persistent session management
+      manifest  Plan/apply batched operations
+      doctor    Health checks for deps and connectivity
+
+    \b
+    Environment variables:
+      COMFYUI_HOST        Base URL (default: http://127.0.0.1:8188)
+      COMFYUI_AUTH_TOKEN  Bearer token (optional)
+      COMFYUI_JSON        Set to 1 for JSON output mode
+    """
+    ctx.ensure_object(CliState)
+    ctx.obj = CliState(json_mode=json_mode, host=host, token=token)
+
+
+# ---------------------------------------------------------------------------
+# Register subgroups
+# ---------------------------------------------------------------------------
+
+cli.add_command(system)
+cli.add_command(nodes)
+cli.add_command(models)
+cli.add_command(queue)
+cli.add_command(history)
+cli.add_command(workflow)
+cli.add_command(session)
+cli.add_command(manifest)
+cli.add_command(doctor)
+
+
+# ---------------------------------------------------------------------------
+# REPL
+# ---------------------------------------------------------------------------
+
+
+@cli.command("repl")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.pass_context
+def repl_cmd(ctx: click.Context, host: str | None, token: str | None) -> None:
+    """Start an interactive REPL (type 'help' or 'exit')."""
+    from cli_anything.comfyui.core.secrets import resolve_secrets
+
+    state: CliState = ctx.obj
+    skin = state.skin
+    skin.print_banner()
+
+    secrets = resolve_secrets(host, token)
+    skin.info(f"Connected to: {secrets.base_url}")
+    skin.hint("Type a subcommand (e.g. 'system stats') or 'exit' to quit.")
+
+    pt_session = skin.create_prompt_session()
+
+    while True:
+        try:
+            line = skin.get_input(pt_session)
+        except (EOFError, KeyboardInterrupt):
+            skin.info("Bye.")
+            break
+
+        line = line.strip()
+        if not line:
+            continue
+        if line in ("exit", "quit", "q"):
+            skin.info("Bye.")
+            break
+        if line in ("help", "?"):
+            click.echo(ctx.get_help())
+            continue
+
+        # Tokenise and invoke via Click's standalone_mode=False
+        args = line.split()
+        try:
+            cli.main(args=args, standalone_mode=False, obj=ctx.obj)
+        except SystemExit:
+            pass
+        except Exception as exc:  # noqa: BLE001
+            skin.error(str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/__init__.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/__init__.py
@@ -1,0 +1,23 @@
+"""cli_anything.comfyui.commands — Click command groups."""
+
+from cli_anything.comfyui.commands.doctor_cmds import doctor
+from cli_anything.comfyui.commands.history_cmds import history
+from cli_anything.comfyui.commands.manifest_cmds import manifest
+from cli_anything.comfyui.commands.models_cmds import models
+from cli_anything.comfyui.commands.nodes_cmds import nodes
+from cli_anything.comfyui.commands.queue_cmds import queue
+from cli_anything.comfyui.commands.session_cmds import session
+from cli_anything.comfyui.commands.system_cmds import system
+from cli_anything.comfyui.commands.workflow_cmds import workflow
+
+__all__ = [
+    "doctor",
+    "history",
+    "manifest",
+    "models",
+    "nodes",
+    "queue",
+    "session",
+    "system",
+    "workflow",
+]

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/doctor_cmds.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/doctor_cmds.py
@@ -1,0 +1,136 @@
+"""doctor command group — dependency and connectivity health check."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+
+import click
+from cli_anything.comfyui.core.secrets import resolve_secrets
+from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+_REQUIRED_DEPS = ["click", "httpx"]
+_OPTIONAL_DEPS = ["prompt_toolkit"]
+
+
+def _check_import(module: str) -> tuple[bool, str]:
+    """Return (ok, version_or_error)."""
+    try:
+        mod = importlib.import_module(module)
+        version = getattr(mod, "__version__", "installed")
+        return True, version
+    except ImportError as exc:
+        return False, str(exc)
+
+
+@click.group("doctor")
+def doctor() -> None:
+    """Run health checks on dependencies and server connectivity."""
+
+
+@doctor.command("check")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def doctor_check(host: str | None, token: str | None, json_out: bool) -> None:
+    """Check required deps, optional deps, and server connectivity."""
+    skin = ReplSkin(json_mode=json_out)
+    checks: list[dict] = []
+    all_ok = True
+
+    # Required dependencies
+    for dep in _REQUIRED_DEPS:
+        ok, info = _check_import(dep)
+        checks.append({"name": dep, "required": True, "ok": ok, "info": info})
+        if not ok:
+            all_ok = False
+
+    # Optional dependencies
+    for dep in _OPTIONAL_DEPS:
+        ok, info = _check_import(dep)
+        checks.append({"name": dep, "required": False, "ok": ok, "info": info})
+
+    # Server connectivity
+    secrets = resolve_secrets(host, token)
+    server_ok = False
+    server_info = ""
+    try:
+        import httpx
+
+        resp = httpx.get(f"{secrets.base_url}/system_stats", timeout=5.0)
+        server_ok = resp.status_code == 200
+        server_info = f"HTTP {resp.status_code}"
+    except Exception as exc:
+        server_info = str(exc)
+
+    checks.append(
+        {
+            "name": f"comfyui ({secrets.base_url})",
+            "required": True,
+            "ok": server_ok,
+            "info": server_info,
+        }
+    )
+    if not server_ok:
+        all_ok = False
+
+    if json_out:
+        click.echo(json.dumps({"ok": all_ok, "checks": checks}, indent=2))
+        if not all_ok:
+            sys.exit(1)
+        return
+
+    skin.section("Doctor Check")
+    for c in checks:
+        req_tag = "[required]" if c["required"] else "[optional]"
+        if c["ok"]:
+            skin.success(f"{c['name']} {req_tag} — {c['info']}")
+        elif c["required"]:
+            skin.error(f"{c['name']} {req_tag} — {c['info']}")
+        else:
+            skin.warning(f"{c['name']} {req_tag} — {c['info']}")
+
+    if all_ok:
+        skin.success("All checks passed.")
+    else:
+        skin.error("One or more required checks failed.")
+        sys.exit(1)
+
+
+@doctor.command("deps")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def doctor_deps(json_out: bool) -> None:
+    """Check only Python dependency availability (no server required)."""
+    skin = ReplSkin(json_mode=json_out)
+    checks: list[dict] = []
+    all_ok = True
+
+    for dep in _REQUIRED_DEPS:
+        ok, info = _check_import(dep)
+        checks.append({"name": dep, "required": True, "ok": ok, "info": info})
+        if not ok:
+            all_ok = False
+
+    for dep in _OPTIONAL_DEPS:
+        ok, info = _check_import(dep)
+        checks.append({"name": dep, "required": False, "ok": ok, "info": info})
+
+    if json_out:
+        click.echo(json.dumps({"ok": all_ok, "checks": checks}, indent=2))
+        if not all_ok:
+            sys.exit(1)
+        return
+
+    skin.section("Dependency Check")
+    for c in checks:
+        req_tag = "[required]" if c["required"] else "[optional]"
+        if c["ok"]:
+            skin.success(f"{c['name']} {req_tag} — {c['info']}")
+        elif c["required"]:
+            skin.error(f"{c['name']} {req_tag} — {c['info']}")
+        else:
+            skin.warning(f"{c['name']} {req_tag} — {c['info']}")
+
+    if not all_ok:
+        sys.exit(1)

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/history_cmds.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/history_cmds.py
@@ -1,0 +1,166 @@
+"""history command group — completed prompt history."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+from cli_anything.comfyui.core.history import parse_history_response
+from cli_anything.comfyui.core.secrets import resolve_secrets
+from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackend, ComfyUIBackendError
+from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+
+@click.group("history")
+def history() -> None:
+    """Inspect and manage completed prompt history."""
+
+
+@history.command("list")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--max-items", default=None, type=int, help="Limit number of history items")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def history_list(
+    host: str | None, token: str | None, max_items: int | None, json_out: bool
+) -> None:
+    """List completed prompts from /history."""
+    skin = ReplSkin(json_mode=json_out)
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        raw = backend.history(max_items=max_items)
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    items = parse_history_response(raw)
+    if json_out:
+        click.echo(json.dumps([i.to_dict() for i in items], indent=2))
+        return
+
+    skin.section(f"History ({len(items)} prompts)")
+    if not items:
+        skin.hint("No completed prompts.")
+        return
+    rows = [[i.prompt_id[:16], i.status, str(len(i.all_output_files()))] for i in items]
+    skin.table(["Prompt ID", "Status", "Outputs"], rows)
+
+
+@history.command("show")
+@click.argument("prompt_id")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def history_show(prompt_id: str, host: str | None, token: str | None, json_out: bool) -> None:
+    """Show details for a single completed prompt from /history/{prompt_id}."""
+    skin = ReplSkin(json_mode=json_out)
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        raw = backend.history_prompt(prompt_id)
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    if json_out:
+        click.echo(json.dumps(raw, indent=2))
+        return
+
+    items = parse_history_response(raw)
+    if not items:
+        skin.hint(f"No history found for prompt_id: {prompt_id}")
+        return
+
+    item = items[0]
+    skin.section(f"Prompt: {item.prompt_id}")
+    skin.info(f"Status: {item.status}")
+    files = item.all_output_files()
+    if files:
+        skin.section("Output Files")
+        rows = [[f.filename, f.subfolder, f.file_type] for f in files]
+        skin.table(["Filename", "Subfolder", "Type"], rows)
+    if item.node_errors:
+        skin.warning(f"Node errors: {json.dumps(item.node_errors, indent=2)}")
+
+
+@history.command("extract-outputs")
+@click.argument("prompt_id")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def extract_outputs(prompt_id: str, host: str | None, token: str | None, json_out: bool) -> None:
+    """Extract all output file paths for a completed prompt."""
+    skin = ReplSkin(json_mode=json_out)
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        raw = backend.history_prompt(prompt_id)
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    items = parse_history_response(raw)
+    if not items:
+        if json_out:
+            click.echo(json.dumps([]))
+        else:
+            skin.hint("No outputs found.")
+        return
+
+    files = items[0].all_output_files()
+    if json_out:
+        click.echo(json.dumps([f.to_dict() for f in files], indent=2))
+        return
+
+    for f in files:
+        click.echo(f.filename)
+
+
+@history.command("clear")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--prompt-id", default=None, help="Clear a single prompt (omit to clear all)")
+@click.option("--confirm", is_flag=True, help="Required to execute destructive clear")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def history_clear(
+    host: str | None,
+    token: str | None,
+    prompt_id: str | None,
+    confirm: bool,
+    json_out: bool,
+) -> None:
+    """Clear history (all or a single prompt).  Requires --confirm."""
+    skin = ReplSkin(json_mode=json_out)
+    if not confirm:
+        if json_out:
+            click.echo(json.dumps({"error": "Pass --confirm to execute history clear"}))
+        else:
+            skin.warning("Destructive operation. Pass --confirm to proceed.")
+        sys.exit(1)
+
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        result = backend.clear_history(prompt_id=prompt_id)
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    if json_out:
+        click.echo(json.dumps(result, indent=2))
+    else:
+        skin.success("History cleared.")

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/manifest_cmds.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/manifest_cmds.py
@@ -1,0 +1,184 @@
+"""manifest command group — plan/apply action manifests."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+from cli_anything.comfyui.core.manifest import (
+    ActionManifest,
+    ChangeItem,
+    ChangeKind,
+    build_plan,
+    load_manifest,
+    plan_history_clear,
+    plan_queue_clear,
+    plan_queue_interrupt,
+    plan_queue_submit,
+    save_manifest,
+)
+from cli_anything.comfyui.core.secrets import resolve_secrets
+from cli_anything.comfyui.core.workflow import load_workflow
+from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackend, ComfyUIBackendError
+from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+
+@click.group("manifest")
+def manifest() -> None:
+    """Plan and apply batched ComfyUI operations."""
+
+
+@manifest.command("plan")
+@click.option(
+    "--submit", "submit_file", default=None, type=click.Path(), help="Workflow file to submit"
+)
+@click.option("--clear-queue", is_flag=True, help="Add queue clear to plan")
+@click.option("--interrupt", is_flag=True, help="Add interrupt to plan")
+@click.option("--clear-history", is_flag=True, help="Add history clear to plan")
+@click.option("--output", default=None, type=click.Path(), help="Path to save manifest JSON")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def manifest_plan(
+    submit_file: str | None,
+    clear_queue: bool,
+    interrupt: bool,
+    clear_history: bool,
+    output: str | None,
+    json_out: bool,
+) -> None:
+    """Build a manifest of planned actions (does NOT execute them)."""
+    skin = ReplSkin(json_mode=json_out)
+    changes: list[ChangeItem] = []
+
+    if submit_file:
+        changes.append(plan_queue_submit(submit_file))
+    if clear_queue:
+        changes.append(plan_queue_clear())
+    if interrupt:
+        changes.append(plan_queue_interrupt())
+    if clear_history:
+        changes.append(plan_history_clear())
+
+    if not changes:
+        if json_out:
+            click.echo(json.dumps({"error": "No actions specified for plan"}))
+        else:
+            skin.warning(
+                "Specify at least one action (--submit, --clear-queue, --interrupt, --clear-history)."
+            )
+        sys.exit(1)
+
+    m = build_plan(changes)
+    path = save_manifest(m, output)
+
+    if json_out:
+        click.echo(json.dumps({"manifest": m.to_dict(), "path": str(path)}))
+        return
+
+    skin.section("Manifest Plan")
+    for c in m.changes:
+        marker = "[DESTRUCTIVE] " if c.is_destructive() else ""
+        skin.info(f"  {marker}{c.kind.value}: {c.description}")
+    skin.hint(f"Saved to: {path}")
+    skin.hint("Run `manifest apply` to execute.")
+
+
+@manifest.command("show")
+@click.option("--path", "manifest_path", default=None, type=click.Path(), help="Manifest file path")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def manifest_show(manifest_path: str | None, json_out: bool) -> None:
+    """Show the current manifest."""
+    skin = ReplSkin(json_mode=json_out)
+    m = load_manifest(manifest_path)
+
+    if json_out:
+        click.echo(json.dumps(m.to_dict(), indent=2))
+        return
+
+    skin.section("Current Manifest")
+    if not m.changes:
+        skin.hint("No changes in manifest.")
+        return
+    for c in m.changes:
+        skin.info(c.summary())
+    skin.info(f"Applied: {m.applied}")
+
+
+@manifest.command("apply")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--path", "manifest_path", default=None, type=click.Path(), help="Manifest file path")
+@click.option("--confirm", is_flag=True, help="Required when manifest contains destructive changes")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def manifest_apply(
+    host: str | None,
+    token: str | None,
+    manifest_path: str | None,
+    confirm: bool,
+    json_out: bool,
+) -> None:
+    """Apply the current manifest, executing all planned actions."""
+    skin = ReplSkin(json_mode=json_out)
+    m = load_manifest(manifest_path)
+
+    if not m.changes:
+        if json_out:
+            click.echo(json.dumps({"error": "No changes in manifest"}))
+        else:
+            skin.warning("Manifest is empty.")
+        sys.exit(1)
+
+    if m.has_destructive() and not confirm:
+        if json_out:
+            click.echo(
+                json.dumps({"error": "Manifest contains destructive changes; pass --confirm"})
+            )
+        else:
+            skin.warning("Manifest contains destructive changes. Pass --confirm to proceed.")
+        sys.exit(1)
+
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    results: list[dict] = []
+
+    for change in m.changes:
+        try:
+            if change.kind == ChangeKind.QUEUE_SUBMIT:
+                wf_path = change.params.get("workflow_path", "")
+                wf = load_workflow(Path(wf_path))
+                from cli_anything.comfyui.core.queue import build_prompt_payload
+
+                payload = build_prompt_payload(wf.to_dict())
+                result = backend.submit_prompt(payload)
+                results.append({"kind": change.kind.value, "result": result})
+            elif change.kind == ChangeKind.QUEUE_CLEAR:
+                result = backend.queue_clear()
+                results.append({"kind": change.kind.value, "result": result})
+            elif change.kind == ChangeKind.QUEUE_INTERRUPT:
+                result = backend.interrupt()
+                results.append({"kind": change.kind.value, "result": result})
+            elif change.kind == ChangeKind.HISTORY_CLEAR:
+                pid = change.params.get("prompt_id")
+                result = backend.clear_history(prompt_id=pid)
+                results.append({"kind": change.kind.value, "result": result})
+            else:
+                results.append({"kind": change.kind.value, "skipped": True})
+        except ComfyUIBackendError as exc:
+            results.append({"kind": change.kind.value, "error": str(exc)})
+
+    m.applied = True
+    save_manifest(m, manifest_path)
+
+    if json_out:
+        click.echo(json.dumps({"applied": results}, indent=2))
+        return
+
+    skin.section("Apply Results")
+    for r in results:
+        if "error" in r:
+            skin.error(f"{r['kind']}: {r['error']}")
+        elif r.get("skipped"):
+            skin.warning(f"{r['kind']}: skipped")
+        else:
+            skin.success(f"{r['kind']}: ok")

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/models_cmds.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/models_cmds.py
@@ -1,0 +1,80 @@
+"""models command group — model listing by type."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+from cli_anything.comfyui.core.secrets import resolve_secrets
+from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackend, ComfyUIBackendError
+from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+_MODEL_TYPES = [
+    "checkpoints",
+    "loras",
+    "vae",
+    "controlnet",
+    "embeddings",
+    "hypernetworks",
+    "upscale_models",
+    "clip",
+    "clip_vision",
+    "diffusers",
+    "gligen",
+    "style_models",
+    "unet",
+]
+
+
+@click.group("models")
+def models() -> None:
+    """List and inspect ComfyUI models."""
+
+
+@models.command("list")
+@click.argument("model_type", default="checkpoints")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def models_list(model_type: str, host: str | None, token: str | None, json_out: bool) -> None:
+    """List models of MODEL_TYPE from /models/{model_type}.
+
+    MODEL_TYPE defaults to 'checkpoints'.  Common values: checkpoints,
+    loras, vae, controlnet, embeddings, hypernetworks, upscale_models.
+    """
+    skin = ReplSkin(json_mode=json_out)
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        data = backend.models(model_type)
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    if json_out:
+        click.echo(json.dumps(data, indent=2))
+        return
+
+    skin.section(f"Models / {model_type} ({len(data)})")
+    if not data:
+        skin.hint("No models found.")
+        return
+    for name in sorted(data):
+        click.echo(f"  {name}")
+
+
+@models.command("types")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def models_types(json_out: bool) -> None:
+    """List well-known model type names (no server required)."""
+    if json_out:
+        click.echo(json.dumps(_MODEL_TYPES, indent=2))
+        return
+    skin = ReplSkin()
+    skin.section("Known Model Types")
+    for t in _MODEL_TYPES:
+        click.echo(f"  {t}")

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/nodes_cmds.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/nodes_cmds.py
@@ -1,0 +1,82 @@
+"""nodes command group — node registry (object_info)."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+from cli_anything.comfyui.core.secrets import resolve_secrets
+from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackend, ComfyUIBackendError
+from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+
+@click.group("nodes")
+def nodes() -> None:
+    """Browse the ComfyUI node registry."""
+
+
+@nodes.command("list")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+@click.option("--filter", "filter_str", default="", help="Case-insensitive substring filter")
+def nodes_list(host: str | None, token: str | None, json_out: bool, filter_str: str) -> None:
+    """List all available node class types from /object_info."""
+    skin = ReplSkin(json_mode=json_out)
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        data = backend.object_info()
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    names = sorted(data.keys())
+    if filter_str:
+        names = [n for n in names if filter_str.lower() in n.lower()]
+
+    if json_out:
+        click.echo(json.dumps(names, indent=2))
+        return
+
+    skin.section(f"Nodes ({len(names)})")
+    if not names:
+        skin.hint("No nodes match the filter.")
+        return
+    for name in names:
+        click.echo(f"  {name}")
+
+
+@nodes.command("info")
+@click.argument("node_class")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def node_info(node_class: str, host: str | None, token: str | None, json_out: bool) -> None:
+    """Show full spec for a single node class from /object_info/{node_class}."""
+    skin = ReplSkin(json_mode=json_out)
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        data = backend.object_info_node(node_class)
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    if json_out:
+        click.echo(json.dumps(data, indent=2))
+        return
+
+    skin.section(f"Node: {node_class}")
+    node_spec = data.get(node_class, data)
+    if isinstance(node_spec, dict):
+        click.echo(json.dumps(node_spec, indent=2))
+    else:
+        click.echo(str(node_spec))

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/queue_cmds.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/queue_cmds.py
@@ -1,0 +1,186 @@
+"""queue command group — submit, list, interrupt, clear."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+from cli_anything.comfyui.core.queue import build_prompt_payload, parse_queue_response
+from cli_anything.comfyui.core.secrets import resolve_secrets
+from cli_anything.comfyui.core.workflow import load_workflow
+from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackend, ComfyUIBackendError
+from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+
+@click.group("queue")
+def queue() -> None:
+    """Submit and manage the ComfyUI execution queue."""
+
+
+@queue.command("list")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def queue_list(host: str | None, token: str | None, json_out: bool) -> None:
+    """Show running and pending queue items from /queue."""
+    skin = ReplSkin(json_mode=json_out)
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        raw = backend.queue()
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    parsed = parse_queue_response(raw)
+    if json_out:
+        click.echo(
+            json.dumps(
+                {
+                    "running": [i.to_dict() for i in parsed["running"]],
+                    "pending": [i.to_dict() for i in parsed["pending"]],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    skin.section("Queue")
+    running = parsed["running"]
+    pending = parsed["pending"]
+    skin.info(f"Running: {len(running)}  Pending: {len(pending)}")
+
+    if running:
+        skin.section("Running")
+        rows = [[i.prompt_id[:16], str(i.number), i.status.value] for i in running]
+        skin.table(["Prompt ID", "#", "Status"], rows)
+
+    if pending:
+        skin.section("Pending")
+        rows = [[i.prompt_id[:16], str(i.number), i.status.value] for i in pending]
+        skin.table(["Prompt ID", "#", "Status"], rows)
+
+
+@queue.command("submit")
+@click.argument("workflow_file", type=click.Path(exists=True, dir_okay=False))
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--client-id", default=None, help="Client ID (UUID4 generated if omitted)")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def queue_submit(
+    workflow_file: str,
+    host: str | None,
+    token: str | None,
+    client_id: str | None,
+    json_out: bool,
+) -> None:
+    """Submit WORKFLOW_FILE to the ComfyUI queue via POST /prompt."""
+    skin = ReplSkin(json_mode=json_out)
+    try:
+        wf = load_workflow(Path(workflow_file))
+    except (FileNotFoundError, ValueError) as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    errors = wf.validate()
+    if errors:
+        if json_out:
+            click.echo(json.dumps({"error": "Workflow validation failed", "details": errors}))
+        else:
+            skin.error("Workflow validation failed:")
+            for e in errors:
+                skin.hint(f"  {e}")
+        sys.exit(1)
+
+    payload = build_prompt_payload(wf.to_dict(), client_id=client_id)
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        result = backend.submit_prompt(payload)
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    if json_out:
+        click.echo(json.dumps(result, indent=2))
+        return
+
+    prompt_id = result.get("prompt_id", "unknown")
+    skin.success(f"Submitted. prompt_id: {prompt_id}")
+    if result.get("node_errors"):
+        skin.warning(f"Node errors: {result['node_errors']}")
+
+
+@queue.command("interrupt")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--confirm", is_flag=True, help="Required to interrupt the running prompt")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def queue_interrupt(host: str | None, token: str | None, confirm: bool, json_out: bool) -> None:
+    """Interrupt the currently running prompt (POST /interrupt).  Requires --confirm."""
+    skin = ReplSkin(json_mode=json_out)
+    if not confirm:
+        if json_out:
+            click.echo(json.dumps({"error": "Pass --confirm to interrupt"}))
+        else:
+            skin.warning("Destructive operation. Pass --confirm to interrupt.")
+        sys.exit(1)
+
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        result = backend.interrupt()
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    if json_out:
+        click.echo(json.dumps(result, indent=2))
+    else:
+        skin.success("Interrupt signal sent.")
+
+
+@queue.command("clear")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--confirm", is_flag=True, help="Required to clear the pending queue")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def queue_clear(host: str | None, token: str | None, confirm: bool, json_out: bool) -> None:
+    """Clear the pending queue (POST /queue + clear=true).  Requires --confirm."""
+    skin = ReplSkin(json_mode=json_out)
+    if not confirm:
+        if json_out:
+            click.echo(json.dumps({"error": "Pass --confirm to clear the queue"}))
+        else:
+            skin.warning("Destructive operation. Pass --confirm to clear.")
+        sys.exit(1)
+
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        result = backend.queue_clear()
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    if json_out:
+        click.echo(json.dumps(result, indent=2))
+    else:
+        skin.success("Pending queue cleared.")

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/session_cmds.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/session_cmds.py
@@ -1,0 +1,109 @@
+"""session command group — save, load, list, delete sessions."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+from cli_anything.comfyui.core.secrets import resolve_secrets
+from cli_anything.comfyui.core.session import (
+    Session,
+    delete_session,
+    list_sessions,
+    load_session,
+    save_session,
+)
+from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+
+@click.group("session")
+def session() -> None:
+    """Manage persistent CLI sessions."""
+
+
+@session.command("new")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def session_new(host: str | None, token: str | None, json_out: bool) -> None:
+    """Create and persist a new session."""
+    skin = ReplSkin(json_mode=json_out)
+    secrets = resolve_secrets(host, token)
+    sess = Session(host=secrets.base_url)
+    path = save_session(sess)
+
+    if json_out:
+        click.echo(json.dumps({"session_id": sess.session_id, "path": str(path)}))
+    else:
+        skin.success(f"Session created: {sess.session_id}")
+        skin.hint(f"Saved to: {path}")
+
+
+@session.command("list")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def session_list(json_out: bool) -> None:
+    """List all saved sessions."""
+    skin = ReplSkin(json_mode=json_out)
+    sessions = list_sessions()
+
+    if json_out:
+        click.echo(json.dumps(sessions, indent=2))
+        return
+
+    skin.section(f"Sessions ({len(sessions)})")
+    if not sessions:
+        skin.hint("No sessions found.")
+        return
+    rows = [[s["session_id"][:16], s["host"], s["updated_at"][:19]] for s in sessions]
+    skin.table(["Session ID", "Host", "Updated"], rows)
+
+
+@session.command("show")
+@click.argument("session_id")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def session_show(session_id: str, json_out: bool) -> None:
+    """Show details of a session including history."""
+    skin = ReplSkin(json_mode=json_out)
+    try:
+        sess = load_session(session_id)
+    except FileNotFoundError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    if json_out:
+        click.echo(json.dumps(sess.to_dict(), indent=2))
+        return
+
+    skin.section(f"Session: {sess.session_id}")
+    skin.info(f"Host: {sess.host}")
+    skin.info(f"Created: {sess.created_at}")
+    skin.info(f"Updated: {sess.updated_at}")
+    skin.info(f"History entries: {len(sess.history)}")
+
+
+@session.command("delete")
+@click.argument("session_id")
+@click.option("--confirm", is_flag=True, help="Required to delete a session")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def session_delete(session_id: str, confirm: bool, json_out: bool) -> None:
+    """Delete a saved session.  Requires --confirm."""
+    skin = ReplSkin(json_mode=json_out)
+    if not confirm:
+        if json_out:
+            click.echo(json.dumps({"error": "Pass --confirm to delete session"}))
+        else:
+            skin.warning("Pass --confirm to delete.")
+        sys.exit(1)
+
+    deleted = delete_session(session_id)
+    if json_out:
+        click.echo(json.dumps({"deleted": deleted, "session_id": session_id}))
+    elif deleted:
+        skin.success(f"Session deleted: {session_id}")
+    else:
+        skin.warning(f"Session not found: {session_id}")

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/system_cmds.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/system_cmds.py
@@ -1,0 +1,80 @@
+"""system command group — server stats and embeddings."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+from cli_anything.comfyui.core.secrets import resolve_secrets
+from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackend, ComfyUIBackendError
+from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+
+@click.group("system")
+def system() -> None:
+    """Server system information."""
+
+
+@system.command("stats")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def stats(host: str | None, token: str | None, json_out: bool) -> None:
+    """Show CPU, RAM, and VRAM usage from /system_stats."""
+    skin = ReplSkin(json_mode=json_out)
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        data = backend.system_stats()
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    if json_out:
+        click.echo(json.dumps(data, indent=2))
+        return
+
+    skin.section("System Stats")
+    # Flatten nested dicts for display
+    rows: list[list[str]] = []
+    for section_key, section_val in data.items():
+        if isinstance(section_val, dict):
+            for k, v in section_val.items():
+                rows.append([f"{section_key}.{k}", str(v)])
+        else:
+            rows.append([section_key, str(section_val)])
+    skin.table(["Key", "Value"], rows)
+
+
+@system.command("embeddings")
+@click.option("--host", envvar="COMFYUI_HOST", default=None, help="ComfyUI base URL")
+@click.option("--token", envvar="COMFYUI_AUTH_TOKEN", default=None, help="Bearer token")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def embeddings_cmd(host: str | None, token: str | None, json_out: bool) -> None:
+    """List available embedding models from /embeddings."""
+    skin = ReplSkin(json_mode=json_out)
+    secrets = resolve_secrets(host, token)
+    backend = ComfyUIBackend(base_url=secrets.base_url, auth_headers=secrets.auth_headers())
+    try:
+        data = backend.embeddings()
+    except ComfyUIBackendError as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    if json_out:
+        click.echo(json.dumps(data, indent=2))
+        return
+
+    skin.section("Embeddings")
+    if not data:
+        skin.hint("No embeddings found.")
+        return
+    for name in sorted(data):
+        click.echo(f"  {name}")

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/workflow_cmds.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/commands/workflow_cmds.py
@@ -1,0 +1,128 @@
+"""workflow command group — load, save, validate, render."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+from cli_anything.comfyui.core.workflow import Workflow, dump_workflow, load_workflow
+from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+
+@click.group("workflow")
+def workflow() -> None:
+    """Load, validate, and inspect ComfyUI workflow JSON files."""
+
+
+@workflow.command("validate")
+@click.argument("workflow_file", type=click.Path(exists=True, dir_okay=False))
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def workflow_validate(workflow_file: str, json_out: bool) -> None:
+    """Validate a workflow JSON file for structural correctness."""
+    skin = ReplSkin(json_mode=json_out)
+    try:
+        wf = load_workflow(Path(workflow_file))
+    except (FileNotFoundError, ValueError) as exc:
+        if json_out:
+            click.echo(json.dumps({"valid": False, "errors": [str(exc)]}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    errors = wf.validate()
+    if json_out:
+        click.echo(json.dumps({"valid": not errors, "errors": errors}))
+        return
+
+    if errors:
+        skin.error(f"Validation failed ({len(errors)} error(s)):")
+        for e in errors:
+            skin.hint(f"  {e}")
+        sys.exit(1)
+    else:
+        skin.success(f"Valid. {len(wf.nodes)} nodes, {len(wf.class_types())} class types.")
+
+
+@workflow.command("show")
+@click.argument("workflow_file", type=click.Path(exists=True, dir_okay=False))
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def workflow_show(workflow_file: str, json_out: bool) -> None:
+    """Show a summary of a workflow file."""
+    skin = ReplSkin(json_mode=json_out)
+    try:
+        wf = load_workflow(Path(workflow_file))
+    except (FileNotFoundError, ValueError) as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    summary = wf.summary()
+    if json_out:
+        click.echo(json.dumps(summary, indent=2))
+        return
+
+    skin.section(f"Workflow: {Path(workflow_file).name}")
+    skin.info(f"Nodes: {summary['node_count']}")
+    skin.info(f"Class types ({len(summary['class_types'])}):")
+    for ct in summary["class_types"]:
+        click.echo(f"  {ct}")
+
+
+@workflow.command("save")
+@click.argument("workflow_file", type=click.Path(exists=True, dir_okay=False))
+@click.argument("output_file")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def workflow_save(workflow_file: str, output_file: str, json_out: bool) -> None:
+    """Parse and re-save a workflow, normalising formatting."""
+    skin = ReplSkin(json_mode=json_out)
+    try:
+        wf = load_workflow(Path(workflow_file))
+        dump_workflow(wf, Path(output_file))
+    except (FileNotFoundError, ValueError, OSError) as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    if json_out:
+        click.echo(json.dumps({"saved": output_file, "nodes": len(wf.nodes)}))
+    else:
+        skin.success(f"Saved {len(wf.nodes)} nodes → {output_file}")
+
+
+@workflow.command("nodes")
+@click.argument("workflow_file", type=click.Path(exists=True, dir_okay=False))
+@click.option("--class-type", default=None, help="Filter by class type substring")
+@click.option("--json", "json_out", is_flag=True, help="Output raw JSON")
+def workflow_nodes(workflow_file: str, class_type: str | None, json_out: bool) -> None:
+    """List nodes inside a workflow file."""
+    skin = ReplSkin(json_mode=json_out)
+    try:
+        wf = load_workflow(Path(workflow_file))
+    except (FileNotFoundError, ValueError) as exc:
+        if json_out:
+            click.echo(json.dumps({"error": str(exc)}))
+        else:
+            skin.error(str(exc))
+        sys.exit(1)
+
+    node_list = list(wf.nodes.values())
+    if class_type:
+        node_list = [n for n in node_list if class_type.lower() in n.class_type.lower()]
+
+    if json_out:
+        click.echo(
+            json.dumps(
+                [{"node_id": n.node_id, "class_type": n.class_type} for n in node_list], indent=2
+            )
+        )
+        return
+
+    skin.section(f"Nodes in {Path(workflow_file).name} ({len(node_list)})")
+    rows = [[n.node_id, n.class_type] for n in node_list]
+    skin.table(["ID", "Class Type"], rows)

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/CLAUDE.md
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/CLAUDE.md
@@ -1,0 +1,3 @@
+<claude-mem-context>
+
+</claude-mem-context>

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/__init__.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/__init__.py
@@ -1,0 +1,44 @@
+"""cli_anything.comfyui.core — data models and persistence layer."""
+
+from cli_anything.comfyui.core.history import HistoryItem, parse_history_response
+from cli_anything.comfyui.core.manifest import (
+    ActionManifest,
+    ChangeItem,
+    ChangeKind,
+    build_plan,
+    load_manifest,
+    save_manifest,
+)
+from cli_anything.comfyui.core.queue import QueueItem, QueueStatus, build_prompt_payload
+from cli_anything.comfyui.core.secrets import ComfyUISecrets, resolve_secrets
+from cli_anything.comfyui.core.session import (
+    Session,
+    delete_session,
+    list_sessions,
+    load_session,
+    save_session,
+)
+from cli_anything.comfyui.core.workflow import NodeInfo, Workflow
+
+__all__ = [
+    "ActionManifest",
+    "ChangeItem",
+    "ChangeKind",
+    "ComfyUISecrets",
+    "HistoryItem",
+    "NodeInfo",
+    "QueueItem",
+    "QueueStatus",
+    "Session",
+    "Workflow",
+    "build_plan",
+    "build_prompt_payload",
+    "delete_session",
+    "list_sessions",
+    "load_manifest",
+    "load_session",
+    "parse_history_response",
+    "resolve_secrets",
+    "save_manifest",
+    "save_session",
+]

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/history.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/history.py
@@ -1,0 +1,112 @@
+"""ComfyUI history data model.
+
+The /history endpoint returns a dict keyed by prompt_id.  Each value
+contains the prompt spec, outputs, and status metadata.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class OutputFile:
+    """A single output file referenced in a history item."""
+
+    filename: str
+    subfolder: str
+    file_type: str  # "output", "input", "temp"
+
+    def view_path(self) -> str:
+        """URL path fragment for /view?filename=...&subfolder=...&type=..."""
+        parts = [f"filename={self.filename}"]
+        if self.subfolder:
+            parts.append(f"subfolder={self.subfolder}")
+        parts.append(f"type={self.file_type}")
+        return "?" + "&".join(parts)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "filename": self.filename,
+            "subfolder": self.subfolder,
+            "type": self.file_type,
+        }
+
+
+@dataclass
+class HistoryItem:
+    """Parsed history entry for one completed prompt."""
+
+    prompt_id: str
+    status: str  # "success" | "error" | etc.
+    outputs: dict[str, list[OutputFile]] = field(default_factory=dict)
+    node_errors: dict[str, Any] = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, prompt_id: str, entry: dict[str, Any]) -> "HistoryItem":
+        """Parse a single history entry dict."""
+        outputs: dict[str, list[OutputFile]] = {}
+        for node_id, node_outputs in entry.get("outputs", {}).items():
+            files: list[OutputFile] = []
+            for img in node_outputs.get("images", []):
+                files.append(
+                    OutputFile(
+                        filename=img.get("filename", ""),
+                        subfolder=img.get("subfolder", ""),
+                        file_type=img.get("type", "output"),
+                    )
+                )
+            for vid in node_outputs.get("videos", []):
+                files.append(
+                    OutputFile(
+                        filename=vid.get("filename", ""),
+                        subfolder=vid.get("subfolder", ""),
+                        file_type=vid.get("type", "output"),
+                    )
+                )
+            if files:
+                outputs[node_id] = files
+
+        status_info = entry.get("status", {})
+        status_str = (
+            status_info.get("status_str", "unknown") if isinstance(status_info, dict) else "unknown"
+        )
+        node_errors = entry.get("node_errors", {})
+
+        return cls(
+            prompt_id=prompt_id,
+            status=status_str,
+            outputs=outputs,
+            node_errors=node_errors,
+            raw=entry,
+        )
+
+    def all_output_files(self) -> list[OutputFile]:
+        """Flatten all output files across all nodes."""
+        result: list[OutputFile] = []
+        for files in self.outputs.values():
+            result.extend(files)
+        return result
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "prompt_id": self.prompt_id,
+            "status": self.status,
+            "outputs": {nid: [f.to_dict() for f in files] for nid, files in self.outputs.items()},
+            "node_errors": self.node_errors,
+        }
+
+
+def parse_history_response(data: dict[str, Any]) -> list[HistoryItem]:
+    """Parse the full /history response dict into a list of :class:`HistoryItem`."""
+    items: list[HistoryItem] = []
+    for prompt_id, entry in data.items():
+        if not isinstance(entry, dict):
+            continue
+        try:
+            items.append(HistoryItem.from_dict(prompt_id, entry))
+        except (KeyError, TypeError, ValueError):
+            pass
+    return items

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/manifest.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/manifest.py
@@ -1,0 +1,202 @@
+"""Action manifest — plan/apply pattern for ComfyUI CLI operations.
+
+The manifest records a pending set of changes (a *plan*) that the user
+reviews before execution.  Once approved, ``apply`` runs each change.
+
+Atomic persistence uses tempfile + fcntl.flock + os.replace so a crash
+mid-write never leaves a partial manifest on disk.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_MANIFEST_PATH = Path.home() / ".cli_anything" / "comfyui" / "manifest.json"
+
+
+class ChangeKind(str, Enum):
+    QUEUE_SUBMIT = "queue_submit"
+    QUEUE_CLEAR = "queue_clear"
+    QUEUE_INTERRUPT = "queue_interrupt"
+    WORKFLOW_SAVE = "workflow_save"
+    SESSION_DELETE = "session_delete"
+    HISTORY_CLEAR = "history_clear"
+
+
+# Kinds that are destructive and require --confirm before apply.
+DESTRUCTIVE_KINDS: frozenset[ChangeKind] = frozenset(
+    {
+        ChangeKind.QUEUE_CLEAR,
+        ChangeKind.QUEUE_INTERRUPT,
+        ChangeKind.HISTORY_CLEAR,
+        ChangeKind.SESSION_DELETE,
+    }
+)
+
+
+@dataclass
+class ChangeItem:
+    """A single planned change within an :class:`ActionManifest`."""
+
+    kind: ChangeKind
+    description: str
+    params: dict[str, Any] = field(default_factory=dict)
+
+    def is_destructive(self) -> bool:
+        return self.kind in DESTRUCTIVE_KINDS
+
+    def summary(self) -> str:
+        tag = "[DESTRUCTIVE] " if self.is_destructive() else ""
+        return f"{tag}{self.kind.value}: {self.description}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "description": self.description,
+            "params": self.params,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ChangeItem":
+        return cls(
+            kind=ChangeKind(data["kind"]),
+            description=data["description"],
+            params=data.get("params", {}),
+        )
+
+
+@dataclass
+class ActionManifest:
+    """Ordered list of planned changes with metadata."""
+
+    changes: list[ChangeItem] = field(default_factory=list)
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    applied: bool = False
+
+    def add(self, item: ChangeItem) -> None:
+        self.changes.append(item)
+
+    def has_destructive(self) -> bool:
+        return any(c.is_destructive() for c in self.changes)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "created_at": self.created_at,
+            "applied": self.applied,
+            "changes": [c.to_dict() for c in self.changes],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ActionManifest":
+        return cls(
+            changes=[ChangeItem.from_dict(c) for c in data.get("changes", [])],
+            created_at=data.get("created_at", datetime.now(timezone.utc).isoformat()),
+            applied=data.get("applied", False),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Atomic I/O
+# ---------------------------------------------------------------------------
+
+
+def _locked_save_json(path: Path, data: dict[str, Any]) -> None:
+    """Atomically write *data* as JSON to *path* using flock + os.replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=".manifest_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            json.dump(data, fh, indent=2)
+            fh.flush()
+            os.fsync(fh.fileno())
+            fcntl.flock(fh, fcntl.LOCK_UN)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def save_manifest(
+    manifest: ActionManifest,
+    path: Path | str | None = None,
+) -> Path:
+    """Persist *manifest* atomically.  Returns the path written."""
+    dest = Path(path) if path else _DEFAULT_MANIFEST_PATH
+    _locked_save_json(dest, manifest.to_dict())
+    return dest
+
+
+def load_manifest(path: Path | str | None = None) -> ActionManifest:
+    """Load an :class:`ActionManifest` from *path* (default location if None)."""
+    src = Path(path) if path else _DEFAULT_MANIFEST_PATH
+    if not src.exists():
+        return ActionManifest()
+    text = src.read_text(encoding="utf-8")
+    data = json.loads(text)
+    return ActionManifest.from_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# Plan builder helpers
+# ---------------------------------------------------------------------------
+
+
+def build_plan(changes: list[ChangeItem]) -> ActionManifest:
+    """Create a new :class:`ActionManifest` from *changes*."""
+    m = ActionManifest()
+    for c in changes:
+        m.add(c)
+    return m
+
+
+def plan_queue_submit(workflow_path: str) -> ChangeItem:
+    return ChangeItem(
+        kind=ChangeKind.QUEUE_SUBMIT,
+        description=f"Submit workflow from {workflow_path}",
+        params={"workflow_path": workflow_path},
+    )
+
+
+def plan_queue_clear() -> ChangeItem:
+    return ChangeItem(
+        kind=ChangeKind.QUEUE_CLEAR,
+        description="Clear the ComfyUI pending queue",
+        params={},
+    )
+
+
+def plan_queue_interrupt() -> ChangeItem:
+    return ChangeItem(
+        kind=ChangeKind.QUEUE_INTERRUPT,
+        description="Interrupt the currently running prompt",
+        params={},
+    )
+
+
+def plan_workflow_save(source: str, destination: str) -> ChangeItem:
+    return ChangeItem(
+        kind=ChangeKind.WORKFLOW_SAVE,
+        description=f"Save workflow {source} -> {destination}",
+        params={"source": source, "destination": destination},
+    )
+
+
+def plan_history_clear(prompt_id: str | None = None) -> ChangeItem:
+    desc = f"Clear history for prompt {prompt_id}" if prompt_id else "Clear all history"
+    return ChangeItem(
+        kind=ChangeKind.HISTORY_CLEAR,
+        description=desc,
+        params={"prompt_id": prompt_id},
+    )

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/queue.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/queue.py
@@ -1,0 +1,112 @@
+"""ComfyUI queue data model and prompt payload builder."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class QueueStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class QueueItem:
+    """A single item in the ComfyUI queue."""
+
+    prompt_id: str
+    number: int
+    node_errors: dict[str, Any] = field(default_factory=dict)
+    status: QueueStatus = QueueStatus.PENDING
+
+    @classmethod
+    def from_running_tuple(cls, entry: list[Any]) -> "QueueItem":
+        """Parse a running-queue entry: [number, prompt_id, prompt, extra, node_errors]."""
+        if len(entry) < 2:
+            raise ValueError(f"Running entry too short: {entry!r}")
+        number = int(entry[0])
+        prompt_id = str(entry[1])
+        node_errors = entry[4] if len(entry) > 4 and isinstance(entry[4], dict) else {}
+        return cls(
+            prompt_id=prompt_id,
+            number=number,
+            node_errors=node_errors,
+            status=QueueStatus.RUNNING,
+        )
+
+    @classmethod
+    def from_pending_tuple(cls, entry: list[Any]) -> "QueueItem":
+        """Parse a pending-queue entry: [number, prompt_id, prompt, extra]."""
+        if len(entry) < 2:
+            raise ValueError(f"Pending entry too short: {entry!r}")
+        number = int(entry[0])
+        prompt_id = str(entry[1])
+        return cls(
+            prompt_id=prompt_id,
+            number=number,
+            status=QueueStatus.PENDING,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "prompt_id": self.prompt_id,
+            "number": self.number,
+            "status": self.status.value,
+            "node_errors": self.node_errors,
+        }
+
+
+def build_prompt_payload(
+    workflow: dict[str, Any],
+    client_id: str | None = None,
+    extra_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the POST body for /prompt.
+
+    Args:
+        workflow: Raw workflow dict (node_id -> node_spec).
+        client_id: Optional client identifier for tracking.  A fresh UUID4
+            is generated when *None*.
+        extra_data: Optional additional data merged into the payload.
+
+    Returns:
+        Dict suitable for ``json=`` in an httpx POST to /prompt.
+    """
+    payload: dict[str, Any] = {
+        "prompt": workflow,
+        "client_id": client_id or str(uuid.uuid4()),
+    }
+    if extra_data:
+        payload["extra_data"] = extra_data
+    return payload
+
+
+def parse_queue_response(data: dict[str, Any]) -> dict[str, list[QueueItem]]:
+    """Parse the /queue GET response into running + pending lists.
+
+    Returns:
+        Dict with keys ``"running"`` and ``"pending"`` containing
+        :class:`QueueItem` lists.
+    """
+    running: list[QueueItem] = []
+    pending: list[QueueItem] = []
+
+    for entry in data.get("queue_running", []):
+        try:
+            running.append(QueueItem.from_running_tuple(entry))
+        except (ValueError, TypeError, IndexError):
+            pass
+
+    for entry in data.get("queue_pending", []):
+        try:
+            pending.append(QueueItem.from_pending_tuple(entry))
+        except (ValueError, TypeError, IndexError):
+            pass
+
+    return {"running": running, "pending": pending}

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/secrets.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/secrets.py
@@ -1,0 +1,46 @@
+"""ComfyUI credential resolution.
+
+Priority chain for host:
+  1. explicit --host CLI flag  (caller passes override)
+  2. COMFYUI_HOST env var
+  3. default http://127.0.0.1:8188
+
+Optional bearer token:
+  1. explicit --token CLI flag (caller passes override)
+  2. COMFYUI_AUTH_TOKEN env var
+  3. None (unauthenticated)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+_DEFAULT_HOST = "http://127.0.0.1:8188"
+
+
+@dataclass(frozen=True)
+class ComfyUISecrets:
+    """Resolved connection credentials for a ComfyUI instance."""
+
+    host: str
+    token: str | None
+
+    @property
+    def base_url(self) -> str:
+        return self.host.rstrip("/")
+
+    def auth_headers(self) -> dict[str, str]:
+        if self.token:
+            return {"Authorization": f"Bearer {self.token}"}
+        return {}
+
+
+def resolve_secrets(
+    host_override: str | None = None,
+    token_override: str | None = None,
+) -> ComfyUISecrets:
+    """Return resolved :class:`ComfyUISecrets` using the priority chain."""
+    host = host_override or os.environ.get("COMFYUI_HOST") or _DEFAULT_HOST
+    token = token_override or os.environ.get("COMFYUI_AUTH_TOKEN") or None
+    return ComfyUISecrets(host=host.rstrip("/"), token=token)

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/session.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/session.py
@@ -1,0 +1,151 @@
+"""Session persistence for cli-anything-comfyui.
+
+Each session is a JSON file in ``~/.cli_anything/comfyui/sessions/``.
+History is capped at MAX_HISTORY entries; oldest entries are dropped.
+
+Atomic writes use tempfile + fcntl.flock + os.replace (same pattern as
+manifest.py) so a crash mid-write never corrupts a session.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+MAX_HISTORY = 50
+
+_SESSIONS_DIR = Path.home() / ".cli_anything" / "comfyui" / "sessions"
+
+
+@dataclass
+class Session:
+    """Persistent session tracking ComfyUI interactions."""
+
+    session_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    host: str = "http://127.0.0.1:8188"
+    history: list[dict[str, Any]] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # history
+    # ------------------------------------------------------------------
+
+    def push_history(self, entry: dict[str, Any]) -> None:
+        """Append *entry* to history, dropping oldest if cap exceeded."""
+        self.history.append(entry)
+        if len(self.history) > MAX_HISTORY:
+            self.history = self.history[-MAX_HISTORY:]
+        self.updated_at = datetime.now(timezone.utc).isoformat()
+
+    # ------------------------------------------------------------------
+    # serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "host": self.host,
+            "history": self.history,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Session":
+        return cls(
+            session_id=data["session_id"],
+            created_at=data.get("created_at", datetime.now(timezone.utc).isoformat()),
+            updated_at=data.get("updated_at", datetime.now(timezone.utc).isoformat()),
+            host=data.get("host", "http://127.0.0.1:8188"),
+            history=data.get("history", []),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Atomic I/O helpers (same lock pattern as manifest.py)
+# ---------------------------------------------------------------------------
+
+
+def _locked_save_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=".session_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            json.dump(data, fh, indent=2)
+            fh.flush()
+            os.fsync(fh.fileno())
+            fcntl.flock(fh, fcntl.LOCK_UN)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _session_path(session_id: str, sessions_dir: Path | None = None) -> Path:
+    base = sessions_dir or _SESSIONS_DIR
+    return base / f"{session_id}.json"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def save_session(session: Session, sessions_dir: Path | None = None) -> Path:
+    """Persist *session* atomically.  Returns the path written."""
+    path = _session_path(session.session_id, sessions_dir)
+    _locked_save_json(path, session.to_dict())
+    return path
+
+
+def load_session(session_id: str, sessions_dir: Path | None = None) -> Session:
+    """Load a session by ID.  Raises :exc:`FileNotFoundError` if missing."""
+    path = _session_path(session_id, sessions_dir)
+    if not path.exists():
+        raise FileNotFoundError(f"Session not found: {session_id!r}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return Session.from_dict(data)
+
+
+def delete_session(session_id: str, sessions_dir: Path | None = None) -> bool:
+    """Delete a session file.  Returns True if deleted, False if not found."""
+    path = _session_path(session_id, sessions_dir)
+    if path.exists():
+        path.unlink()
+        return True
+    return False
+
+
+def list_sessions(sessions_dir: Path | None = None) -> list[dict[str, str]]:
+    """Return summary dicts for all persisted sessions (sorted by updated_at desc)."""
+    base = sessions_dir or _SESSIONS_DIR
+    if not base.exists():
+        return []
+    summaries: list[dict[str, str]] = []
+    for p in base.glob("*.json"):
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+            summaries.append(
+                {
+                    "session_id": data.get("session_id", p.stem),
+                    "created_at": data.get("created_at", ""),
+                    "updated_at": data.get("updated_at", ""),
+                    "host": data.get("host", ""),
+                }
+            )
+        except (json.JSONDecodeError, KeyError):
+            pass
+    summaries.sort(key=lambda s: s.get("updated_at", ""), reverse=True)
+    return summaries

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/workflow.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/core/workflow.py
@@ -1,0 +1,146 @@
+"""ComfyUI workflow data model.
+
+A workflow is a JSON dict that ComfyUI calls a *prompt* — a mapping of
+node-id strings to node-specification dicts.  This module provides:
+
+- :class:`NodeInfo` — lightweight wrapper around a single node spec
+- :class:`Workflow` — parsed workflow with validation and inspection helpers
+- :func:`load_workflow` / :func:`dump_workflow` — JSON file I/O
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_NODE_ID_RE = re.compile(r"^\d+$")
+
+
+@dataclass
+class NodeInfo:
+    """Single node extracted from a ComfyUI workflow prompt."""
+
+    node_id: str
+    class_type: str
+    inputs: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, node_id: str, spec: dict[str, Any]) -> "NodeInfo":
+        if "class_type" not in spec:
+            raise ValueError(f"Node {node_id!r} missing 'class_type'")
+        return cls(
+            node_id=node_id,
+            class_type=spec["class_type"],
+            inputs=spec.get("inputs", {}),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "class_type": self.class_type,
+            "inputs": self.inputs,
+        }
+
+    def upstream_ids(self) -> list[str]:
+        """Return node IDs referenced by list-typed input values [id, slot]."""
+        ids: list[str] = []
+        for v in self.inputs.values():
+            if isinstance(v, list) and len(v) == 2 and isinstance(v[0], str):
+                ids.append(v[0])
+        return ids
+
+
+@dataclass
+class Workflow:
+    """Parsed ComfyUI workflow (prompt dict)."""
+
+    nodes: dict[str, NodeInfo] = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Workflow":
+        """Parse a raw workflow dict into a :class:`Workflow`."""
+        nodes: dict[str, NodeInfo] = {}
+        for node_id, spec in data.items():
+            if not isinstance(spec, dict):
+                raise ValueError(
+                    f"Node {node_id!r} value must be a dict, got {type(spec).__name__}"
+                )
+            nodes[node_id] = NodeInfo.from_dict(node_id, spec)
+        return cls(nodes=nodes, raw=data)
+
+    @classmethod
+    def from_json_string(cls, text: str) -> "Workflow":
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ValueError(f"Workflow must be a JSON object, got {type(data).__name__}")
+        return cls.from_dict(data)
+
+    # ------------------------------------------------------------------
+    # serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        return {nid: node.to_dict() for nid, node in self.nodes.items()}
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    # ------------------------------------------------------------------
+    # inspection
+    # ------------------------------------------------------------------
+
+    def node_ids(self) -> list[str]:
+        return list(self.nodes.keys())
+
+    def class_types(self) -> set[str]:
+        return {n.class_type for n in self.nodes.values()}
+
+    def find_by_class(self, class_type: str) -> list[NodeInfo]:
+        return [n for n in self.nodes.values() if n.class_type == class_type]
+
+    def validate(self) -> list[str]:
+        """Return a list of validation error strings (empty = valid)."""
+        errors: list[str] = []
+        for nid, node in self.nodes.items():
+            for ref in node.upstream_ids():
+                if ref not in self.nodes:
+                    errors.append(f"Node {nid!r} references unknown node {ref!r}")
+        return errors
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "node_count": len(self.nodes),
+            "class_types": sorted(self.class_types()),
+            "node_ids": self.node_ids(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# file I/O
+# ---------------------------------------------------------------------------
+
+
+def load_workflow(path: Path | str) -> Workflow:
+    """Load and parse a workflow JSON file."""
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Workflow file not found: {p}")
+    text = p.read_text(encoding="utf-8")
+    return Workflow.from_json_string(text)
+
+
+def dump_workflow(workflow: Workflow, path: Path | str, indent: int = 2) -> None:
+    """Write a workflow to a JSON file (overwrites if exists)."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(workflow.to_json(indent=indent), encoding="utf-8")

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/tests/TEST.md
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/tests/TEST.md
@@ -1,0 +1,120 @@
+# cli-anything-comfyui — Test Plan
+
+## Phase 1 — Help Banners & Entrypoints
+
+Verify `comfyui --help` and `cli-anything-comfyui --help` exit 0 and list all
+9 subgroups (system, nodes, models, queue, history, workflow, session, manifest,
+doctor). Each subgroup's `--help` also exits 0. `--version` prints `1.0.0`.
+Unknown commands exit nonzero.
+
+**Files:** `test_full_e2e.py::TestHelpBanners`
+**Requires server:** No
+
+## Phase 2 — JSON Output Mode
+
+`--json` flag and `COMFYUI_JSON=1` env var produce valid JSON on stdout.
+`doctor deps` is used as an offline proxy; output is `{"click": "...", ...}`.
+
+**Files:** `test_full_e2e.py::TestJsonOutputMode`
+**Requires server:** No
+
+## Phase 3 — --confirm Gate
+
+Destructive commands (`queue clear`, `queue interrupt`, `history clear`,
+`session delete`) exit 1 immediately without `--confirm` — before touching the
+network. With `--confirm` + unreachable host they still fail, but with a
+network error (different code path confirms the gate was passed).
+
+**Files:** `test_full_e2e.py::TestConfirmGate`
+**Requires server:** No
+
+## Phase 4 — Workflow Commands (Offline)
+
+`workflow validate` / `show` / `nodes` operate on local JSON files with no
+server. Valid workflow files exit 0; invalid JSON exits nonzero; missing files
+exit nonzero.
+
+**Files:** `test_full_e2e.py::TestWorkflowOffline`
+**Requires server:** No
+
+## Phase 5 — Session Roundtrip (Offline)
+
+`session new` creates a session file, `session list` returns it, `session show`
+returns full detail with the correct ID, `session delete --confirm` removes it.
+Multiple creates are all listed. Nonexistent session IDs exit nonzero.
+Uses `CLI_ANYTHING_HOME` env var to isolate temp dirs per test.
+
+**Files:** `test_full_e2e.py::TestSessionOffline`
+**Requires server:** No
+
+## Phase 6 — Live Server Tests
+
+With `COMFYUI_E2E=1` and a real ComfyUI instance at `COMFYUI_HOST`:
+
+- `doctor check` exits 0
+- `system stats` returns a dict with keys
+- `system embeddings` returns a list
+- `nodes list` returns data
+- `nodes info KSampler` succeeds
+- `models types` returns list
+- `models list checkpoints` returns list
+- `queue list` returns running/pending structure
+- `history list` returns data
+- `queue submit` with a minimal workflow returns prompt_id
+
+**Files:** `test_full_e2e.py::TestLiveServerConnectivity`
+**Requires server:** Yes — `COMFYUI_E2E=1 COMFYUI_HOST=http://127.0.0.1:8188`
+
+## Phase 7 — Unreachable Host (FAIL, Not Skip)
+
+With `COMFYUI_E2E=1` and a known-dead port (59999):
+
+All network commands (`system stats`, `nodes list`, `models list`, `history list`,
+`queue list`, `doctor check`) exit nonzero. JSON mode outputs `{"error": "..."}`.
+These tests **FAIL** (not skip) when COMFYUI_E2E=1 — proving the live gate is real.
+
+**Files:** `test_full_e2e.py::TestUnreachableHost`
+**Requires server:** No (intentionally unreachable)
+
+## Phase 8 — Manifest Offline
+
+`manifest show` on a local manifest file exits 0 and returns JSON.
+`manifest apply` without `--confirm` exits 1 before touching the network.
+
+**Files:** `test_full_e2e.py::TestManifestOffline`
+**Requires server:** No
+
+## Phase 9 — Doctor Deps (Offline)
+
+`doctor deps` exits 0 and returns a dict with `click` and `httpx` keys
+showing installed versions. No server required.
+
+**Files:** `test_full_e2e.py::TestDoctorDeps`
+**Requires server:** No
+
+---
+
+## Running Tests
+
+```bash
+# Offline unit tests only (CI default)
+pytest cli_anything/comfyui/tests/test_core.py -v
+
+# All tests, no server (e2e tests skip)
+pytest cli_anything/comfyui/tests/ -v
+
+# Full e2e suite with live ComfyUI
+COMFYUI_E2E=1 COMFYUI_HOST=http://127.0.0.1:8188 pytest cli_anything/comfyui/tests/ -v
+
+# Quick smoke — just banners and deps
+COMFYUI_E2E=1 pytest cli_anything/comfyui/tests/test_full_e2e.py::TestHelpBanners \
+  cli_anything/comfyui/tests/test_full_e2e.py::TestDoctorDeps -v
+```
+
+## Test Count Summary
+
+| File | Classes | Tests |
+|------|---------|-------|
+| `test_core.py` | 15 | ~110 |
+| `test_full_e2e.py` | 9 | ~55 |
+| **Total** | **24** | **~165** |

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/tests/__init__.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/tests/__init__.py
@@ -1,0 +1,1 @@
+"""cli_anything.comfyui.tests — unit and integration test suite."""

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/tests/test_core.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/tests/test_core.py
@@ -1,0 +1,969 @@
+"""Offline unit tests for cli-anything-comfyui core and utils.
+
+All tests run without a live ComfyUI server.  Network calls are
+patched via unittest.mock.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Secrets
+# ---------------------------------------------------------------------------
+
+
+class TestComfyUISecrets:
+    def test_default_host(self) -> None:
+        from cli_anything.comfyui.core.secrets import resolve_secrets
+
+        s = resolve_secrets()
+        assert s.host == "http://127.0.0.1:8188"
+
+    def test_host_override(self) -> None:
+        from cli_anything.comfyui.core.secrets import resolve_secrets
+
+        s = resolve_secrets(host_override="http://localhost:9000")
+        assert s.base_url == "http://localhost:9000"
+
+    def test_host_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from cli_anything.comfyui.core.secrets import resolve_secrets
+
+        monkeypatch.setenv("COMFYUI_HOST", "http://remote:8188")
+        s = resolve_secrets()
+        assert "remote" in s.host
+
+    def test_token_override(self) -> None:
+        from cli_anything.comfyui.core.secrets import resolve_secrets
+
+        s = resolve_secrets(token_override="tok123")
+        assert s.token == "tok123"
+
+    def test_token_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from cli_anything.comfyui.core.secrets import resolve_secrets
+
+        monkeypatch.setenv("COMFYUI_AUTH_TOKEN", "envtok")
+        s = resolve_secrets()
+        assert s.token == "envtok"
+
+    def test_no_token_gives_empty_headers(self) -> None:
+        from cli_anything.comfyui.core.secrets import resolve_secrets
+
+        s = resolve_secrets()
+        assert s.auth_headers() == {}
+
+    def test_token_gives_bearer_header(self) -> None:
+        from cli_anything.comfyui.core.secrets import resolve_secrets
+
+        s = resolve_secrets(token_override="mytoken")
+        assert s.auth_headers() == {"Authorization": "Bearer mytoken"}
+
+    def test_trailing_slash_stripped(self) -> None:
+        from cli_anything.comfyui.core.secrets import resolve_secrets
+
+        s = resolve_secrets(host_override="http://localhost:8188/")
+        assert not s.base_url.endswith("/")
+
+    def test_host_override_wins_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from cli_anything.comfyui.core.secrets import resolve_secrets
+
+        monkeypatch.setenv("COMFYUI_HOST", "http://env-host:8188")
+        s = resolve_secrets(host_override="http://override:9999")
+        assert "override" in s.host
+
+    def test_frozen_dataclass(self) -> None:
+        from cli_anything.comfyui.core.secrets import ComfyUISecrets
+
+        s = ComfyUISecrets(host="http://a", token=None)
+        with pytest.raises((AttributeError, TypeError)):
+            s.host = "http://b"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Workflow
+# ---------------------------------------------------------------------------
+
+
+class TestNodeInfo:
+    def test_from_dict_ok(self) -> None:
+        from cli_anything.comfyui.core.workflow import NodeInfo
+
+        n = NodeInfo.from_dict("1", {"class_type": "KSampler", "inputs": {"seed": 42}})
+        assert n.class_type == "KSampler"
+        assert n.inputs["seed"] == 42
+
+    def test_from_dict_missing_class_type_raises(self) -> None:
+        from cli_anything.comfyui.core.workflow import NodeInfo
+
+        with pytest.raises(ValueError, match="class_type"):
+            NodeInfo.from_dict("1", {"inputs": {}})
+
+    def test_to_dict_roundtrip(self) -> None:
+        from cli_anything.comfyui.core.workflow import NodeInfo
+
+        n = NodeInfo.from_dict("1", {"class_type": "KSampler", "inputs": {"steps": 20}})
+        d = n.to_dict()
+        assert d["class_type"] == "KSampler"
+
+    def test_upstream_ids_extracts_list_refs(self) -> None:
+        from cli_anything.comfyui.core.workflow import NodeInfo
+
+        n = NodeInfo(
+            node_id="2", class_type="VAEDecode", inputs={"samples": ["1", 0], "vae": ["3", 0]}
+        )
+        assert set(n.upstream_ids()) == {"1", "3"}
+
+    def test_upstream_ids_ignores_scalars(self) -> None:
+        from cli_anything.comfyui.core.workflow import NodeInfo
+
+        n = NodeInfo(node_id="2", class_type="KSampler", inputs={"steps": 20, "cfg": 7.0})
+        assert n.upstream_ids() == []
+
+
+class TestWorkflow:
+    def _simple(self) -> dict:
+        return {
+            "1": {
+                "class_type": "CheckpointLoaderSimple",
+                "inputs": {"ckpt_name": "v1.safetensors"},
+            },
+            "2": {"class_type": "KSampler", "inputs": {"model": ["1", 0], "steps": 20}},
+        }
+
+    def test_from_dict_ok(self) -> None:
+        from cli_anything.comfyui.core.workflow import Workflow
+
+        wf = Workflow.from_dict(self._simple())
+        assert len(wf.nodes) == 2
+
+    def test_from_json_string_ok(self) -> None:
+        from cli_anything.comfyui.core.workflow import Workflow
+
+        wf = Workflow.from_json_string(json.dumps(self._simple()))
+        assert "1" in wf.nodes
+
+    def test_from_json_string_bad_json_raises(self) -> None:
+        from cli_anything.comfyui.core.workflow import Workflow
+
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            Workflow.from_json_string("{bad}")
+
+    def test_from_json_string_non_dict_raises(self) -> None:
+        from cli_anything.comfyui.core.workflow import Workflow
+
+        with pytest.raises(ValueError, match="JSON object"):
+            Workflow.from_json_string("[1, 2]")
+
+    def test_validate_ok(self) -> None:
+        from cli_anything.comfyui.core.workflow import Workflow
+
+        wf = Workflow.from_dict(self._simple())
+        assert wf.validate() == []
+
+    def test_validate_missing_ref(self) -> None:
+        from cli_anything.comfyui.core.workflow import Workflow
+
+        data = {"2": {"class_type": "KSampler", "inputs": {"model": ["99", 0]}}}
+        wf = Workflow.from_dict(data)
+        errors = wf.validate()
+        assert any("99" in e for e in errors)
+
+    def test_class_types(self) -> None:
+        from cli_anything.comfyui.core.workflow import Workflow
+
+        wf = Workflow.from_dict(self._simple())
+        ct = wf.class_types()
+        assert "KSampler" in ct
+
+    def test_find_by_class(self) -> None:
+        from cli_anything.comfyui.core.workflow import Workflow
+
+        wf = Workflow.from_dict(self._simple())
+        results = wf.find_by_class("KSampler")
+        assert len(results) == 1
+
+    def test_to_dict_roundtrip(self) -> None:
+        from cli_anything.comfyui.core.workflow import Workflow
+
+        wf = Workflow.from_dict(self._simple())
+        d = wf.to_dict()
+        wf2 = Workflow.from_dict(d)
+        assert wf2.node_ids() == wf.node_ids()
+
+    def test_summary_keys(self) -> None:
+        from cli_anything.comfyui.core.workflow import Workflow
+
+        wf = Workflow.from_dict(self._simple())
+        s = wf.summary()
+        assert "node_count" in s
+        assert "class_types" in s
+
+    def test_load_workflow_file(self, tmp_path: Path) -> None:
+        from cli_anything.comfyui.core.workflow import load_workflow
+
+        p = tmp_path / "wf.json"
+        p.write_text(json.dumps(self._simple()))
+        wf = load_workflow(p)
+        assert len(wf.nodes) == 2
+
+    def test_load_workflow_missing_raises(self, tmp_path: Path) -> None:
+        from cli_anything.comfyui.core.workflow import load_workflow
+
+        with pytest.raises(FileNotFoundError):
+            load_workflow(tmp_path / "ghost.json")
+
+    def test_dump_workflow(self, tmp_path: Path) -> None:
+        from cli_anything.comfyui.core.workflow import Workflow, dump_workflow, load_workflow
+
+        wf = Workflow.from_dict(self._simple())
+        out = tmp_path / "out.json"
+        dump_workflow(wf, out)
+        wf2 = load_workflow(out)
+        assert set(wf2.node_ids()) == set(wf.node_ids())
+
+
+# ---------------------------------------------------------------------------
+# Queue
+# ---------------------------------------------------------------------------
+
+
+class TestQueueItem:
+    def test_from_running_tuple(self) -> None:
+        from cli_anything.comfyui.core.queue import QueueItem, QueueStatus
+
+        item = QueueItem.from_running_tuple([0, "abc-123", {}, {}, {}])
+        assert item.prompt_id == "abc-123"
+        assert item.status == QueueStatus.RUNNING
+
+    def test_from_pending_tuple(self) -> None:
+        from cli_anything.comfyui.core.queue import QueueItem, QueueStatus
+
+        item = QueueItem.from_pending_tuple([1, "def-456", {}, {}])
+        assert item.number == 1
+        assert item.status == QueueStatus.PENDING
+
+    def test_to_dict_has_fields(self) -> None:
+        from cli_anything.comfyui.core.queue import QueueItem, QueueStatus
+
+        item = QueueItem(prompt_id="x", number=0, status=QueueStatus.RUNNING)
+        d = item.to_dict()
+        assert d["prompt_id"] == "x"
+
+    def test_from_running_too_short_raises(self) -> None:
+        from cli_anything.comfyui.core.queue import QueueItem
+
+        with pytest.raises(ValueError):
+            QueueItem.from_running_tuple([0])
+
+    def test_from_pending_too_short_raises(self) -> None:
+        from cli_anything.comfyui.core.queue import QueueItem
+
+        with pytest.raises(ValueError):
+            QueueItem.from_pending_tuple([0])
+
+
+class TestBuildPromptPayload:
+    def test_returns_prompt_key(self) -> None:
+        from cli_anything.comfyui.core.queue import build_prompt_payload
+
+        p = build_prompt_payload({"1": {}})
+        assert "prompt" in p
+        assert "client_id" in p
+
+    def test_custom_client_id(self) -> None:
+        from cli_anything.comfyui.core.queue import build_prompt_payload
+
+        p = build_prompt_payload({}, client_id="my-id")
+        assert p["client_id"] == "my-id"
+
+    def test_generates_uuid_when_no_client_id(self) -> None:
+        from cli_anything.comfyui.core.queue import build_prompt_payload
+
+        p = build_prompt_payload({})
+        assert len(p["client_id"]) == 36  # UUID4 string
+
+    def test_extra_data_included(self) -> None:
+        from cli_anything.comfyui.core.queue import build_prompt_payload
+
+        p = build_prompt_payload({}, extra_data={"foo": "bar"})
+        assert p["extra_data"]["foo"] == "bar"
+
+
+class TestParseQueueResponse:
+    def test_parses_running_and_pending(self) -> None:
+        from cli_anything.comfyui.core.queue import parse_queue_response
+
+        raw = {
+            "queue_running": [[0, "run-1", {}, {}, {}]],
+            "queue_pending": [[1, "pend-1", {}, {}]],
+        }
+        result = parse_queue_response(raw)
+        assert len(result["running"]) == 1
+        assert len(result["pending"]) == 1
+
+    def test_empty_response(self) -> None:
+        from cli_anything.comfyui.core.queue import parse_queue_response
+
+        result = parse_queue_response({})
+        assert result["running"] == []
+        assert result["pending"] == []
+
+    def test_bad_entry_skipped(self) -> None:
+        from cli_anything.comfyui.core.queue import parse_queue_response
+
+        raw = {"queue_running": ["not-a-list"]}
+        result = parse_queue_response(raw)
+        assert result["running"] == []
+
+
+# ---------------------------------------------------------------------------
+# History
+# ---------------------------------------------------------------------------
+
+
+class TestOutputFile:
+    def test_view_path_includes_filename(self) -> None:
+        from cli_anything.comfyui.core.history import OutputFile
+
+        f = OutputFile(filename="img.png", subfolder="", file_type="output")
+        assert "img.png" in f.view_path()
+
+    def test_view_path_with_subfolder(self) -> None:
+        from cli_anything.comfyui.core.history import OutputFile
+
+        f = OutputFile(filename="img.png", subfolder="batch1", file_type="output")
+        assert "subfolder=batch1" in f.view_path()
+
+    def test_to_dict(self) -> None:
+        from cli_anything.comfyui.core.history import OutputFile
+
+        f = OutputFile(filename="img.png", subfolder="", file_type="output")
+        d = f.to_dict()
+        assert d["filename"] == "img.png"
+
+
+class TestHistoryItem:
+    def _entry(self) -> dict:
+        return {
+            "outputs": {
+                "9": {"images": [{"filename": "out.png", "subfolder": "", "type": "output"}]}
+            },
+            "status": {"status_str": "success"},
+            "node_errors": {},
+        }
+
+    def test_from_dict_ok(self) -> None:
+        from cli_anything.comfyui.core.history import HistoryItem
+
+        item = HistoryItem.from_dict("pid-1", self._entry())
+        assert item.status == "success"
+        assert len(item.all_output_files()) == 1
+
+    def test_all_output_files_flattens(self) -> None:
+        from cli_anything.comfyui.core.history import HistoryItem
+
+        item = HistoryItem.from_dict("pid-1", self._entry())
+        files = item.all_output_files()
+        assert files[0].filename == "out.png"
+
+    def test_to_dict_has_prompt_id(self) -> None:
+        from cli_anything.comfyui.core.history import HistoryItem
+
+        item = HistoryItem.from_dict("pid-1", self._entry())
+        assert item.to_dict()["prompt_id"] == "pid-1"
+
+    def test_parse_history_response(self) -> None:
+        from cli_anything.comfyui.core.history import parse_history_response
+
+        data = {"pid-1": self._entry()}
+        items = parse_history_response(data)
+        assert len(items) == 1
+
+    def test_parse_skips_non_dict(self) -> None:
+        from cli_anything.comfyui.core.history import parse_history_response
+
+        data = {"pid-1": "not-a-dict"}
+        items = parse_history_response(data)
+        assert items == []
+
+    def test_video_outputs_parsed(self) -> None:
+        from cli_anything.comfyui.core.history import HistoryItem
+
+        entry = {
+            "outputs": {
+                "9": {"videos": [{"filename": "v.mp4", "subfolder": "", "type": "output"}]}
+            },
+            "status": {"status_str": "success"},
+            "node_errors": {},
+        }
+        item = HistoryItem.from_dict("pid-2", entry)
+        assert item.all_output_files()[0].filename == "v.mp4"
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+class TestChangeItem:
+    def test_destructive_kind(self) -> None:
+        from cli_anything.comfyui.core.manifest import ChangeItem, ChangeKind
+
+        c = ChangeItem(kind=ChangeKind.QUEUE_CLEAR, description="clear")
+        assert c.is_destructive()
+
+    def test_non_destructive_kind(self) -> None:
+        from cli_anything.comfyui.core.manifest import ChangeItem, ChangeKind
+
+        c = ChangeItem(kind=ChangeKind.QUEUE_SUBMIT, description="submit")
+        assert not c.is_destructive()
+
+    def test_summary_includes_tag(self) -> None:
+        from cli_anything.comfyui.core.manifest import ChangeItem, ChangeKind
+
+        c = ChangeItem(kind=ChangeKind.QUEUE_INTERRUPT, description="stop it")
+        assert "DESTRUCTIVE" in c.summary()
+
+    def test_to_dict_roundtrip(self) -> None:
+        from cli_anything.comfyui.core.manifest import ChangeItem, ChangeKind
+
+        c = ChangeItem(kind=ChangeKind.QUEUE_SUBMIT, description="sub", params={"p": 1})
+        d = c.to_dict()
+        c2 = ChangeItem.from_dict(d)
+        assert c2.kind == c.kind
+        assert c2.params == c.params
+
+
+class TestActionManifest:
+    def test_build_plan(self) -> None:
+        from cli_anything.comfyui.core.manifest import ChangeItem, ChangeKind, build_plan
+
+        changes = [ChangeItem(kind=ChangeKind.QUEUE_SUBMIT, description="sub")]
+        m = build_plan(changes)
+        assert len(m.changes) == 1
+
+    def test_has_destructive(self) -> None:
+        from cli_anything.comfyui.core.manifest import ActionManifest, ChangeItem, ChangeKind
+
+        m = ActionManifest()
+        m.add(ChangeItem(kind=ChangeKind.QUEUE_CLEAR, description="clear"))
+        assert m.has_destructive()
+
+    def test_no_destructive(self) -> None:
+        from cli_anything.comfyui.core.manifest import ActionManifest, ChangeItem, ChangeKind
+
+        m = ActionManifest()
+        m.add(ChangeItem(kind=ChangeKind.QUEUE_SUBMIT, description="sub"))
+        assert not m.has_destructive()
+
+    def test_to_dict_from_dict_roundtrip(self) -> None:
+        from cli_anything.comfyui.core.manifest import ActionManifest, ChangeItem, ChangeKind
+
+        m = ActionManifest()
+        m.add(ChangeItem(kind=ChangeKind.HISTORY_CLEAR, description="clr"))
+        d = m.to_dict()
+        m2 = ActionManifest.from_dict(d)
+        assert m2.changes[0].kind == ChangeKind.HISTORY_CLEAR
+
+    def test_save_load_manifest(self, tmp_path: Path) -> None:
+        from cli_anything.comfyui.core.manifest import (
+            ActionManifest,
+            ChangeItem,
+            ChangeKind,
+            load_manifest,
+            save_manifest,
+        )
+
+        m = ActionManifest()
+        m.add(ChangeItem(kind=ChangeKind.QUEUE_SUBMIT, description="s"))
+        path = tmp_path / "manifest.json"
+        save_manifest(m, path)
+        m2 = load_manifest(path)
+        assert len(m2.changes) == 1
+
+    def test_load_missing_manifest_returns_empty(self, tmp_path: Path) -> None:
+        from cli_anything.comfyui.core.manifest import load_manifest
+
+        m = load_manifest(tmp_path / "nope.json")
+        assert m.changes == []
+
+    def test_plan_helpers(self) -> None:
+        from cli_anything.comfyui.core.manifest import (
+            ChangeKind,
+            plan_history_clear,
+            plan_queue_clear,
+            plan_queue_interrupt,
+            plan_queue_submit,
+        )
+
+        assert plan_queue_submit("wf.json").kind == ChangeKind.QUEUE_SUBMIT
+        assert plan_queue_clear().kind == ChangeKind.QUEUE_CLEAR
+        assert plan_queue_interrupt().kind == ChangeKind.QUEUE_INTERRUPT
+        assert plan_history_clear().kind == ChangeKind.HISTORY_CLEAR
+        assert plan_history_clear("pid").params["prompt_id"] == "pid"
+
+
+# ---------------------------------------------------------------------------
+# Session
+# ---------------------------------------------------------------------------
+
+
+class TestSession:
+    def test_new_session_has_uuid(self) -> None:
+        from cli_anything.comfyui.core.session import Session
+
+        s = Session()
+        assert len(s.session_id) == 36
+
+    def test_push_history_appends(self) -> None:
+        from cli_anything.comfyui.core.session import Session
+
+        s = Session()
+        s.push_history({"prompt_id": "x"})
+        assert len(s.history) == 1
+
+    def test_push_history_caps_at_max(self) -> None:
+        from cli_anything.comfyui.core.session import MAX_HISTORY, Session
+
+        s = Session()
+        for i in range(MAX_HISTORY + 10):
+            s.push_history({"i": i})
+        assert len(s.history) == MAX_HISTORY
+
+    def test_push_history_keeps_latest(self) -> None:
+        from cli_anything.comfyui.core.session import MAX_HISTORY, Session
+
+        s = Session()
+        for i in range(MAX_HISTORY + 5):
+            s.push_history({"i": i})
+        # Last entry should be the most recently appended
+        assert s.history[-1]["i"] == MAX_HISTORY + 4
+
+    def test_to_dict_from_dict_roundtrip(self) -> None:
+        from cli_anything.comfyui.core.session import Session
+
+        s = Session(host="http://test:9999")
+        s.push_history({"a": 1})
+        d = s.to_dict()
+        s2 = Session.from_dict(d)
+        assert s2.host == s.host
+        assert s2.history == s.history
+
+    def test_save_and_load(self, tmp_path: Path) -> None:
+        from cli_anything.comfyui.core.session import Session, load_session, save_session
+
+        s = Session()
+        s.push_history({"prompt_id": "abc"})
+        save_session(s, tmp_path)
+        s2 = load_session(s.session_id, tmp_path)
+        assert s2.session_id == s.session_id
+        assert s2.history[0]["prompt_id"] == "abc"
+
+    def test_load_missing_raises(self, tmp_path: Path) -> None:
+        from cli_anything.comfyui.core.session import load_session
+
+        with pytest.raises(FileNotFoundError):
+            load_session("ghost-id", tmp_path)
+
+    def test_delete_session(self, tmp_path: Path) -> None:
+        from cli_anything.comfyui.core.session import Session, delete_session, save_session
+
+        s = Session()
+        save_session(s, tmp_path)
+        assert delete_session(s.session_id, tmp_path) is True
+        assert delete_session(s.session_id, tmp_path) is False
+
+    def test_list_sessions(self, tmp_path: Path) -> None:
+        from cli_anything.comfyui.core.session import Session, list_sessions, save_session
+
+        s1 = Session()
+        s2 = Session()
+        save_session(s1, tmp_path)
+        save_session(s2, tmp_path)
+        result = list_sessions(tmp_path)
+        ids = [r["session_id"] for r in result]
+        assert s1.session_id in ids
+        assert s2.session_id in ids
+
+    def test_list_sessions_empty_dir(self, tmp_path: Path) -> None:
+        from cli_anything.comfyui.core.session import list_sessions
+
+        empty = tmp_path / "empty"
+        result = list_sessions(empty)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Backend exceptions
+# ---------------------------------------------------------------------------
+
+
+class TestBackendExceptions:
+    def test_hierarchy(self) -> None:
+        from cli_anything.comfyui.utils.comfyui_backend import (
+            ComfyUIAuthError,
+            ComfyUIBackendError,
+            ComfyUINotFoundError,
+            ComfyUIRateLimitError,
+            ComfyUIServerError,
+            ComfyUIValidationError,
+        )
+
+        assert issubclass(ComfyUIAuthError, ComfyUIBackendError)
+        assert issubclass(ComfyUINotFoundError, ComfyUIBackendError)
+        assert issubclass(ComfyUIValidationError, ComfyUIBackendError)
+        assert issubclass(ComfyUIRateLimitError, ComfyUIBackendError)
+        assert issubclass(ComfyUIServerError, ComfyUIBackendError)
+
+    def test_status_code_stored(self) -> None:
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUIAuthError
+
+        exc = ComfyUIAuthError("denied", status_code=401)
+        assert exc.status_code == 401
+
+    def test_message_stored(self) -> None:
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUINotFoundError
+
+        exc = ComfyUINotFoundError("not here", status_code=404)
+        assert "not here" in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Backend — translate_status
+# ---------------------------------------------------------------------------
+
+
+class TestBackendTranslateStatus:
+    def _backend(self):
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackend
+
+        return ComfyUIBackend()
+
+    def _mock_response(self, status_code: int, text: str = "err") -> MagicMock:
+        r = MagicMock()
+        r.status_code = status_code
+        r.text = text
+        return r
+
+    def test_2xx_no_raise(self) -> None:
+        b = self._backend()
+        b._translate_status(self._mock_response(200))  # no exception
+
+    def test_401_raises_auth(self) -> None:
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUIAuthError
+
+        b = self._backend()
+        with pytest.raises(ComfyUIAuthError):
+            b._translate_status(self._mock_response(401))
+
+    def test_403_raises_auth(self) -> None:
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUIAuthError
+
+        b = self._backend()
+        with pytest.raises(ComfyUIAuthError):
+            b._translate_status(self._mock_response(403))
+
+    def test_404_raises_not_found(self) -> None:
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUINotFoundError
+
+        b = self._backend()
+        with pytest.raises(ComfyUINotFoundError):
+            b._translate_status(self._mock_response(404))
+
+    def test_422_raises_validation(self) -> None:
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUIValidationError
+
+        b = self._backend()
+        with pytest.raises(ComfyUIValidationError):
+            b._translate_status(self._mock_response(422))
+
+    def test_429_raises_rate_limit(self) -> None:
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUIRateLimitError
+
+        b = self._backend()
+        with pytest.raises(ComfyUIRateLimitError):
+            b._translate_status(self._mock_response(429))
+
+    def test_500_raises_server_error(self) -> None:
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUIServerError
+
+        b = self._backend()
+        with pytest.raises(ComfyUIServerError):
+            b._translate_status(self._mock_response(500))
+
+    def test_unknown_4xx_raises_backend_error(self) -> None:
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackendError
+
+        b = self._backend()
+        with pytest.raises(ComfyUIBackendError):
+            b._translate_status(self._mock_response(418))
+
+
+# ---------------------------------------------------------------------------
+# Backend — mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestComfyUIBackendMocked:
+    def _make_response(self, status: int, body: object) -> MagicMock:
+        r = MagicMock()
+        r.status_code = status
+        r.text = json.dumps(body)
+        r.json.return_value = body
+        r.content = b"bytes"
+        return r
+
+    def _backend(self):
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackend
+
+        return ComfyUIBackend(base_url="http://mock:8188")
+
+    @patch("httpx.request")
+    def test_system_stats(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {"system": {"cpu": 10}})
+        b = self._backend()
+        result = b.system_stats()
+        assert result == {"system": {"cpu": 10}}
+
+    @patch("httpx.request")
+    def test_embeddings(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, ["emb1", "emb2"])
+        b = self._backend()
+        result = b.embeddings()
+        assert "emb1" in result
+
+    @patch("httpx.request")
+    def test_object_info(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {"KSampler": {}})
+        b = self._backend()
+        result = b.object_info()
+        assert "KSampler" in result
+
+    @patch("httpx.request")
+    def test_object_info_node(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {"KSampler": {"input": {}}})
+        b = self._backend()
+        result = b.object_info_node("KSampler")
+        assert "KSampler" in result
+
+    @patch("httpx.request")
+    def test_history(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {"pid-1": {"outputs": {}, "status": {}}})
+        b = self._backend()
+        result = b.history()
+        assert "pid-1" in result
+
+    @patch("httpx.request")
+    def test_history_prompt(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {"pid-1": {}})
+        b = self._backend()
+        result = b.history_prompt("pid-1")
+        assert isinstance(result, dict)
+
+    @patch("httpx.request")
+    def test_clear_history_all(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {})
+        b = self._backend()
+        b.clear_history()
+        call_kwargs = mock_req.call_args
+        assert call_kwargs[1]["json"] == {"clear": True}
+
+    @patch("httpx.request")
+    def test_clear_history_single(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {})
+        b = self._backend()
+        b.clear_history(prompt_id="pid-1")
+        call_kwargs = mock_req.call_args
+        assert call_kwargs[1]["json"] == {"delete": ["pid-1"]}
+
+    @patch("httpx.request")
+    def test_queue_get(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {"queue_running": [], "queue_pending": []})
+        b = self._backend()
+        result = b.queue()
+        assert "queue_running" in result
+
+    @patch("httpx.request")
+    def test_queue_clear(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {})
+        b = self._backend()
+        b.queue_clear()
+        call_kwargs = mock_req.call_args
+        assert call_kwargs[1]["json"] == {"clear": True}
+
+    @patch("httpx.request")
+    def test_submit_prompt(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(
+            200, {"prompt_id": "new-id", "number": 1, "node_errors": {}}
+        )
+        b = self._backend()
+        result = b.submit_prompt({"prompt": {}, "client_id": "c1"})
+        assert result["prompt_id"] == "new-id"
+
+    @patch("httpx.request")
+    def test_interrupt(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {})
+        b = self._backend()
+        result = b.interrupt()
+        assert isinstance(result, dict)
+
+    @patch("httpx.request")
+    def test_view(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {})
+        b = self._backend()
+        result = b.view("img.png")
+        assert result == b"bytes"
+
+    @patch("httpx.request")
+    def test_models(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, ["model_a.safetensors"])
+        b = self._backend()
+        result = b.models("checkpoints")
+        assert "model_a.safetensors" in result
+
+    @patch("httpx.request")
+    def test_prompt_status(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {"exec_info": {"queue_remaining": 0}})
+        b = self._backend()
+        result = b.prompt_status()
+        assert "exec_info" in result
+
+    @patch("httpx.request")
+    def test_connection_error_raises_backend_error(self, mock_req: MagicMock) -> None:
+        import httpx as _httpx
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackendError
+
+        mock_req.side_effect = _httpx.ConnectError("refused")
+        b = self._backend()
+        with pytest.raises(ComfyUIBackendError, match="Connection error"):
+            b.system_stats()
+
+    @patch("httpx.request")
+    def test_auth_header_sent(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = self._make_response(200, {})
+        from cli_anything.comfyui.utils.comfyui_backend import ComfyUIBackend
+
+        b = ComfyUIBackend(
+            base_url="http://mock:8188", auth_headers={"Authorization": "Bearer tok"}
+        )
+        b.system_stats()
+        headers_sent = mock_req.call_args[1]["headers"]
+        assert headers_sent.get("Authorization") == "Bearer tok"
+
+    @patch("time.sleep")
+    @patch("httpx.request")
+    def test_429_retry_then_success(self, mock_req: MagicMock, mock_sleep: MagicMock) -> None:
+        rate_resp = MagicMock()
+        rate_resp.status_code = 429
+        rate_resp.text = "rate limited"
+        rate_resp.headers = {"Retry-After": "0"}
+
+        ok_resp = self._make_response(200, {"ok": True})
+
+        mock_req.side_effect = [rate_resp, ok_resp]
+        b = self._backend()
+        result = b.system_stats()
+        assert result == {"ok": True}
+        mock_sleep.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# ReplSkin (offline rendering smoke tests)
+# ---------------------------------------------------------------------------
+
+
+class TestReplSkin:
+    def test_init_json_mode(self) -> None:
+        from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin(json_mode=True)
+        assert skin._json is True
+
+    def test_success_prints(self, capsys: pytest.CaptureFixture) -> None:
+        from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin(json_mode=False)
+        skin.success("done")
+        captured = capsys.readouterr()
+        assert "done" in captured.out
+
+    def test_error_prints(self, capsys: pytest.CaptureFixture) -> None:
+        from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin(json_mode=False)
+        skin.error("boom")
+        captured = capsys.readouterr()
+        assert "boom" in captured.out
+
+    def test_json_mode_suppresses_success(self, capsys: pytest.CaptureFixture) -> None:
+        from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin(json_mode=True)
+        skin.success("silent")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_table_no_rows_shows_hint(self, capsys: pytest.CaptureFixture) -> None:
+        from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin(json_mode=False)
+        skin.table(["A", "B"], [])
+        captured = capsys.readouterr()
+        assert "no rows" in captured.out
+
+    def test_table_renders_rows(self, capsys: pytest.CaptureFixture) -> None:
+        from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin(json_mode=False)
+        skin.table(["Name", "Value"], [["foo", "bar"]])
+        captured = capsys.readouterr()
+        assert "foo" in captured.out
+        assert "bar" in captured.out
+
+    def test_section_suppressed_in_json_mode(self, capsys: pytest.CaptureFixture) -> None:
+        from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin(json_mode=True)
+        skin.section("Test")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_warning_prints(self, capsys: pytest.CaptureFixture) -> None:
+        from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin()
+        skin.warning("watch out")
+        captured = capsys.readouterr()
+        assert "watch out" in captured.out
+
+    def test_info_prints(self, capsys: pytest.CaptureFixture) -> None:
+        from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin()
+        skin.info("fyi")
+        captured = capsys.readouterr()
+        assert "fyi" in captured.out
+
+    def test_hint_prints(self, capsys: pytest.CaptureFixture) -> None:
+        from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin()
+        skin.hint("tip")
+        captured = capsys.readouterr()
+        assert "tip" in captured.out
+
+    def test_create_prompt_session_no_error(self) -> None:
+        from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin()
+        # Returns None if prompt_toolkit absent, or a session object
+        result = skin.create_prompt_session()
+        # Just checking no exception raised
+        assert result is None or hasattr(result, "prompt")

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/tests/test_full_e2e.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/tests/test_full_e2e.py
@@ -1,0 +1,598 @@
+"""test_full_e2e.py — CLI integration + live E2E tests for cli-anything-comfyui.
+
+Gate: set COMFYUI_E2E=1 to run live tests.
+Without the flag all tests in this file skip cleanly (0 failures).
+With COMFYUI_E2E=1 and ComfyUI unreachable, live-server tests FAIL — not skip.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# E2E gate
+# ---------------------------------------------------------------------------
+
+_E2E = os.environ.get("COMFYUI_E2E", "0").strip() == "1"
+pytestmark = pytest.mark.skipif(not _E2E, reason="COMFYUI_E2E not set to 1")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HARNESS = Path(__file__).resolve().parents[4]  # agent-harness/
+
+
+def _resolve_cli(name: str = "comfyui") -> list[str]:
+    """Return argv prefix for invoking the CLI via the current Python interpreter."""
+    return [sys.executable, "-m", "cli_anything.comfyui"]
+
+
+def _run(
+    *args: str,
+    env: dict[str, str] | None = None,
+    check: bool = False,
+    capture: bool = True,
+) -> subprocess.CompletedProcess:
+    """Run the CLI in a subprocess and return the CompletedProcess."""
+    merged = {**os.environ, **(env or {})}
+    cmd = _resolve_cli() + list(args)
+    return subprocess.run(
+        cmd,
+        capture_output=capture,
+        text=True,
+        env=merged,
+        check=check,
+    )
+
+
+def _run_json(*args: str, env: dict[str, str] | None = None) -> object:
+    """Run CLI with --json, parse stdout as JSON."""
+    result = _run("--json", *args, env=env)
+    assert result.returncode == 0, f"CLI failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — --help banners (offline, always run when E2E gate open)
+# ---------------------------------------------------------------------------
+
+
+class TestHelpBanners:
+    """--help output works for root and all subgroups."""
+
+    def test_root_help_exits_zero(self):
+        r = _run("--help")
+        assert r.returncode == 0
+
+    def test_root_help_contains_version_flag(self):
+        r = _run("--help")
+        assert "-V" in r.stdout or "--version" in r.stdout
+
+    def test_root_help_lists_system_subgroup(self):
+        r = _run("--help")
+        assert "system" in r.stdout
+
+    def test_root_help_lists_nodes_subgroup(self):
+        r = _run("--help")
+        assert "nodes" in r.stdout
+
+    def test_root_help_lists_models_subgroup(self):
+        r = _run("--help")
+        assert "models" in r.stdout
+
+    def test_root_help_lists_queue_subgroup(self):
+        r = _run("--help")
+        assert "queue" in r.stdout
+
+    def test_root_help_lists_history_subgroup(self):
+        r = _run("--help")
+        assert "history" in r.stdout
+
+    def test_root_help_lists_workflow_subgroup(self):
+        r = _run("--help")
+        assert "workflow" in r.stdout
+
+    def test_root_help_lists_session_subgroup(self):
+        r = _run("--help")
+        assert "session" in r.stdout
+
+    def test_root_help_lists_manifest_subgroup(self):
+        r = _run("--help")
+        assert "manifest" in r.stdout
+
+    def test_root_help_lists_doctor_subgroup(self):
+        r = _run("--help")
+        assert "doctor" in r.stdout
+
+    def test_system_help(self):
+        r = _run("system", "--help")
+        assert r.returncode == 0
+        assert "stats" in r.stdout
+
+    def test_nodes_help(self):
+        r = _run("nodes", "--help")
+        assert r.returncode == 0
+        assert "list" in r.stdout
+
+    def test_models_help(self):
+        r = _run("models", "--help")
+        assert r.returncode == 0
+
+    def test_queue_help(self):
+        r = _run("queue", "--help")
+        assert r.returncode == 0
+        assert "submit" in r.stdout
+
+    def test_history_help(self):
+        r = _run("history", "--help")
+        assert r.returncode == 0
+
+    def test_workflow_help(self):
+        r = _run("workflow", "--help")
+        assert r.returncode == 0
+        assert "validate" in r.stdout
+
+    def test_session_help(self):
+        r = _run("session", "--help")
+        assert r.returncode == 0
+        assert "new" in r.stdout
+
+    def test_manifest_help(self):
+        r = _run("manifest", "--help")
+        assert r.returncode == 0
+
+    def test_doctor_help(self):
+        r = _run("doctor", "--help")
+        assert r.returncode == 0
+
+    def test_version_flag(self):
+        r = _run("--version")
+        assert r.returncode == 0
+        assert "1.0.0" in r.stdout or "comfyui" in r.stdout.lower()
+
+    def test_unknown_command_exits_nonzero(self):
+        r = _run("does-not-exist")
+        assert r.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — JSON output mode (offline-friendly, mocked via env)
+# ---------------------------------------------------------------------------
+
+
+class TestJsonOutputMode:
+    """--json flag produces valid JSON from commands that support it."""
+
+    def test_json_flag_env_var_COMFYUI_JSON(self):
+        """COMFYUI_JSON=1 is equivalent to --json flag."""
+        # doctor deps doesn't need live server
+        r = _run("doctor", "deps", env={"COMFYUI_JSON": "1"})
+        assert r.returncode == 0
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, (dict, list))
+
+    def test_json_flag_inline_doctor_deps(self):
+        r = _run("--json", "doctor", "deps")
+        assert r.returncode == 0
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, (dict, list))
+
+    def test_doctor_deps_json_has_click_key(self):
+        r = _run("--json", "doctor", "deps")
+        assert r.returncode == 0
+        parsed = json.loads(r.stdout)
+        assert "click" in parsed
+
+    def test_doctor_deps_json_has_httpx_key(self):
+        r = _run("--json", "doctor", "deps")
+        assert r.returncode == 0
+        parsed = json.loads(r.stdout)
+        assert "httpx" in parsed
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — --confirm gate (offline, no server needed)
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmGate:
+    """Destructive commands exit 1 without --confirm, not hitting network."""
+
+    def test_queue_clear_no_confirm_exits_1(self):
+        r = _run("queue", "clear", env={"COMFYUI_HOST": "http://127.0.0.1:59999"})
+        assert r.returncode == 1
+
+    def test_queue_interrupt_no_confirm_exits_1(self):
+        r = _run("queue", "interrupt", env={"COMFYUI_HOST": "http://127.0.0.1:59999"})
+        assert r.returncode == 1
+
+    def test_history_clear_no_confirm_exits_1(self):
+        r = _run("history", "clear", env={"COMFYUI_HOST": "http://127.0.0.1:59999"})
+        assert r.returncode == 1
+
+    def test_queue_clear_confirm_flag_present_reaches_network(self):
+        """With --confirm the command tries the network (unreachable → non-zero exit, but different error)."""
+        r = _run("queue", "clear", "--confirm", env={"COMFYUI_HOST": "http://127.0.0.1:59999"})
+        # returncode != 0 still (network error), but stderr changes
+        assert r.returncode != 0
+
+    def test_session_delete_no_confirm_exits_1(self):
+        """session delete without --confirm exits 1 immediately."""
+        r = _run(
+            "session", "delete", "nonexistent-id", env={"COMFYUI_HOST": "http://127.0.0.1:59999"}
+        )
+        assert r.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — Workflow commands (offline, uses temp files)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowOffline:
+    """workflow validate / show / nodes work without a live server."""
+
+    def _make_workflow(self) -> Path:
+        tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
+        workflow = {
+            "1": {
+                "class_type": "CheckpointLoaderSimple",
+                "inputs": {"ckpt_name": "v1-5-pruned.safetensors"},
+            },
+            "2": {
+                "class_type": "KSampler",
+                "inputs": {
+                    "model": ["1", 0],
+                    "positive": ["3", 0],
+                    "negative": ["4", 0],
+                    "latent_image": ["5", 0],
+                    "seed": 42,
+                    "steps": 20,
+                    "cfg": 7.5,
+                    "sampler_name": "euler",
+                    "scheduler": "normal",
+                    "denoise": 1.0,
+                },
+            },
+        }
+        json.dump(workflow, tmp)
+        tmp.close()
+        return Path(tmp.name)
+
+    def test_workflow_validate_valid_file(self):
+        wf = self._make_workflow()
+        r = _run("workflow", "validate", str(wf))
+        wf.unlink(missing_ok=True)
+        assert r.returncode == 0
+
+    def test_workflow_validate_invalid_json(self):
+        tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
+        tmp.write("not json {{{")
+        tmp.close()
+        r = _run("workflow", "validate", tmp.name)
+        Path(tmp.name).unlink(missing_ok=True)
+        assert r.returncode != 0
+
+    def test_workflow_show_outputs_json_flag(self):
+        wf = self._make_workflow()
+        r = _run("--json", "workflow", "show", str(wf))
+        wf.unlink(missing_ok=True)
+        assert r.returncode == 0
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, dict)
+
+    def test_workflow_nodes_lists_class_types(self):
+        wf = self._make_workflow()
+        r = _run("workflow", "nodes", str(wf))
+        wf.unlink(missing_ok=True)
+        assert r.returncode == 0
+        assert "CheckpointLoaderSimple" in r.stdout or r.returncode == 0
+
+    def test_workflow_validate_missing_file_exits_nonzero(self):
+        r = _run("workflow", "validate", "/tmp/no_such_workflow_xyz123.json")
+        assert r.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Session commands (offline, uses temp home)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionOffline:
+    """Session create / list / show roundtrip — no server required."""
+
+    def test_session_new_exits_zero(self, tmp_path):
+        r = _run(
+            "session",
+            "new",
+            env={"CLI_ANYTHING_HOME": str(tmp_path), "COMFYUI_HOST": "http://127.0.0.1:8188"},
+        )
+        assert r.returncode == 0
+
+    def test_session_new_json_has_id(self, tmp_path):
+        r = _run(
+            "--json",
+            "session",
+            "new",
+            env={"CLI_ANYTHING_HOME": str(tmp_path), "COMFYUI_HOST": "http://127.0.0.1:8188"},
+        )
+        assert r.returncode == 0
+        parsed = json.loads(r.stdout)
+        assert "id" in parsed
+
+    def test_session_list_after_new(self, tmp_path):
+        _run(
+            "session",
+            "new",
+            env={"CLI_ANYTHING_HOME": str(tmp_path), "COMFYUI_HOST": "http://127.0.0.1:8188"},
+        )
+        r = _run(
+            "session",
+            "list",
+            env={"CLI_ANYTHING_HOME": str(tmp_path)},
+        )
+        assert r.returncode == 0
+
+    def test_session_list_empty_when_no_sessions(self, tmp_path):
+        r = _run("session", "list", env={"CLI_ANYTHING_HOME": str(tmp_path)})
+        assert r.returncode == 0
+
+    def test_session_show_existing(self, tmp_path):
+        env = {"CLI_ANYTHING_HOME": str(tmp_path), "COMFYUI_HOST": "http://127.0.0.1:8188"}
+        new_r = _run("--json", "session", "new", env=env)
+        sess_id = json.loads(new_r.stdout)["id"]
+        r = _run("session", "show", sess_id, env=env)
+        assert r.returncode == 0
+
+    def test_session_show_json(self, tmp_path):
+        env = {"CLI_ANYTHING_HOME": str(tmp_path), "COMFYUI_HOST": "http://127.0.0.1:8188"}
+        new_r = _run("--json", "session", "new", env=env)
+        sess_id = json.loads(new_r.stdout)["id"]
+        r = _run("--json", "session", "show", sess_id, env=env)
+        assert r.returncode == 0
+        parsed = json.loads(r.stdout)
+        assert parsed["id"] == sess_id
+
+    def test_session_show_nonexistent_exits_nonzero(self, tmp_path):
+        r = _run(
+            "session",
+            "show",
+            "no-such-session-id-abc",
+            env={"CLI_ANYTHING_HOME": str(tmp_path)},
+        )
+        assert r.returncode != 0
+
+    def test_session_delete_nonexistent_exits_nonzero(self, tmp_path):
+        r = _run(
+            "session",
+            "delete",
+            "--confirm",
+            "no-such-session-id-xyz",
+            env={"CLI_ANYTHING_HOME": str(tmp_path)},
+        )
+        assert r.returncode != 0
+
+    def test_multiple_sessions_list_all(self, tmp_path):
+        env = {"CLI_ANYTHING_HOME": str(tmp_path), "COMFYUI_HOST": "http://127.0.0.1:8188"}
+        _run("session", "new", env=env)
+        _run("session", "new", env=env)
+        _run("session", "new", env=env)
+        r = _run("--json", "session", "list", env=env)
+        assert r.returncode == 0
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, list)
+        assert len(parsed) >= 3
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 — Live server tests (COMFYUI_E2E=1, server must be up)
+# ---------------------------------------------------------------------------
+
+_LIVE_HOST = os.environ.get("COMFYUI_HOST", "http://127.0.0.1:8188")
+
+
+class TestLiveServerConnectivity:
+    """These tests FAIL (not skip) when ComfyUI is unreachable."""
+
+    def test_live_doctor_check_exits_zero(self):
+        """doctor check must succeed against a live server."""
+        r = _run("doctor", "check", env={"COMFYUI_HOST": _LIVE_HOST})
+        assert r.returncode == 0, (
+            f"doctor check failed — is ComfyUI running at {_LIVE_HOST}?\n"
+            f"stdout: {r.stdout}\nstderr: {r.stderr}"
+        )
+
+    def test_live_system_stats_returns_json(self):
+        r = _run("--json", "system", "stats", env={"COMFYUI_HOST": _LIVE_HOST})
+        assert r.returncode == 0, f"system stats failed: {r.stderr}"
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, dict)
+
+    def test_live_system_stats_has_system_key(self):
+        r = _run("--json", "system", "stats", env={"COMFYUI_HOST": _LIVE_HOST})
+        assert r.returncode == 0
+        parsed = json.loads(r.stdout)
+        assert "system" in parsed or len(parsed) > 0
+
+    def test_live_system_embeddings_returns_list(self):
+        r = _run("--json", "system", "embeddings", env={"COMFYUI_HOST": _LIVE_HOST})
+        assert r.returncode == 0, f"system embeddings failed: {r.stderr}"
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, list)
+
+    def test_live_nodes_list_returns_data(self):
+        r = _run("--json", "nodes", "list", env={"COMFYUI_HOST": _LIVE_HOST})
+        assert r.returncode == 0, f"nodes list failed: {r.stderr}"
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, (dict, list))
+
+    def test_live_nodes_info_klsampler(self):
+        r = _run("nodes", "info", "KSampler", env={"COMFYUI_HOST": _LIVE_HOST})
+        assert r.returncode == 0, f"nodes info KSampler failed: {r.stderr}"
+
+    def test_live_models_types_returns_list(self):
+        r = _run("--json", "models", "types", env={"COMFYUI_HOST": _LIVE_HOST})
+        assert r.returncode == 0, f"models types failed: {r.stderr}"
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, list)
+
+    def test_live_models_list_checkpoints(self):
+        r = _run("--json", "models", "list", "checkpoints", env={"COMFYUI_HOST": _LIVE_HOST})
+        assert r.returncode == 0, f"models list checkpoints failed: {r.stderr}"
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, list)
+
+    def test_live_queue_list_returns_data(self):
+        r = _run("--json", "queue", "list", env={"COMFYUI_HOST": _LIVE_HOST})
+        assert r.returncode == 0, f"queue list failed: {r.stderr}"
+        parsed = json.loads(r.stdout)
+        assert "running" in parsed or "pending" in parsed or isinstance(parsed, dict)
+
+    def test_live_history_list_returns_data(self):
+        r = _run("--json", "history", "list", env={"COMFYUI_HOST": _LIVE_HOST})
+        assert r.returncode == 0, f"history list failed: {r.stderr}"
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, (list, dict))
+
+    def test_live_queue_submit_valid_workflow(self):
+        """Submit a minimal valid workflow and verify we get a prompt_id back."""
+        workflow = {
+            "1": {
+                "class_type": "CheckpointLoaderSimple",
+                "inputs": {"ckpt_name": "v1-5-pruned.safetensors"},
+            }
+        }
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            json.dump(workflow, f)
+            wf_path = f.name
+        r = _run("--json", "queue", "submit", wf_path, env={"COMFYUI_HOST": _LIVE_HOST})
+        Path(wf_path).unlink(missing_ok=True)
+        # May fail if checkpoint doesn't exist — that's OK, server responded
+        assert r.returncode in (0, 1)
+        if r.returncode == 0:
+            parsed = json.loads(r.stdout)
+            assert "prompt_id" in parsed or isinstance(parsed, dict)
+
+
+# ---------------------------------------------------------------------------
+# Phase 7 — Error path + unreachable host (COMFYUI_E2E=1, server must be DOWN)
+# ---------------------------------------------------------------------------
+
+
+class TestUnreachableHost:
+    """With COMFYUI_E2E=1, these tests use a known-unreachable host.
+    They must FAIL (exit nonzero) — not skip.
+    """
+
+    _DEAD = "http://127.0.0.1:59999"
+
+    def test_system_stats_unreachable_exits_nonzero(self):
+        r = _run("system", "stats", env={"COMFYUI_HOST": self._DEAD})
+        assert r.returncode != 0, "Expected nonzero exit when host unreachable"
+
+    def test_system_stats_unreachable_json_error_key(self):
+        r = _run("--json", "system", "stats", env={"COMFYUI_HOST": self._DEAD})
+        assert r.returncode != 0
+        # JSON mode should output {"error": "..."} when backend fails
+        try:
+            parsed = json.loads(r.stdout)
+            assert "error" in parsed
+        except json.JSONDecodeError:
+            pass  # non-JSON error output is also acceptable
+
+    def test_nodes_list_unreachable_exits_nonzero(self):
+        r = _run("nodes", "list", env={"COMFYUI_HOST": self._DEAD})
+        assert r.returncode != 0
+
+    def test_models_list_unreachable_exits_nonzero(self):
+        r = _run("models", "list", "checkpoints", env={"COMFYUI_HOST": self._DEAD})
+        assert r.returncode != 0
+
+    def test_history_list_unreachable_exits_nonzero(self):
+        r = _run("history", "list", env={"COMFYUI_HOST": self._DEAD})
+        assert r.returncode != 0
+
+    def test_queue_list_unreachable_exits_nonzero(self):
+        r = _run("queue", "list", env={"COMFYUI_HOST": self._DEAD})
+        assert r.returncode != 0
+
+    def test_doctor_check_unreachable_exits_nonzero(self):
+        r = _run("doctor", "check", env={"COMFYUI_HOST": self._DEAD})
+        assert r.returncode != 0
+
+    def test_doctor_check_unreachable_json_error(self):
+        r = _run("--json", "doctor", "check", env={"COMFYUI_HOST": self._DEAD})
+        assert r.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 8 — Manifest offline (plan + show, no apply)
+# ---------------------------------------------------------------------------
+
+
+class TestManifestOffline:
+    """manifest plan/show work without a server."""
+
+    def _make_manifest(self, tmp_path: Path) -> Path:
+        manifest_data = {
+            "version": "1",
+            "changes": [{"kind": "queue_submit", "label": "submit test workflow", "payload": {}}],
+        }
+        p = tmp_path / "test.manifest.json"
+        p.write_text(json.dumps(manifest_data))
+        return p
+
+    def test_manifest_show_exits_zero(self, tmp_path):
+        m = self._make_manifest(tmp_path)
+        r = _run("manifest", "show", str(m))
+        assert r.returncode == 0
+
+    def test_manifest_show_json(self, tmp_path):
+        m = self._make_manifest(tmp_path)
+        r = _run("--json", "manifest", "show", str(m))
+        assert r.returncode == 0
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, (dict, list))
+
+    def test_manifest_apply_no_confirm_exits_1(self, tmp_path):
+        m = self._make_manifest(tmp_path)
+        r = _run("manifest", "apply", str(m), env={"COMFYUI_HOST": "http://127.0.0.1:59999"})
+        assert r.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 9 — Doctor deps (offline, always passable)
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorDeps:
+    """doctor deps inspects Python env — no server required."""
+
+    def test_doctor_deps_exits_zero(self):
+        r = _run("doctor", "deps")
+        assert r.returncode == 0
+
+    def test_doctor_deps_json_is_dict(self):
+        r = _run("--json", "doctor", "deps")
+        assert r.returncode == 0
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, dict)
+
+    def test_doctor_deps_click_present(self):
+        r = _run("--json", "doctor", "deps")
+        parsed = json.loads(r.stdout)
+        assert parsed.get("click") is not None
+
+    def test_doctor_deps_httpx_present(self):
+        r = _run("--json", "doctor", "deps")
+        parsed = json.loads(r.stdout)
+        assert parsed.get("httpx") is not None

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/utils/CLAUDE.md
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/utils/CLAUDE.md
@@ -1,0 +1,3 @@
+<claude-mem-context>
+
+</claude-mem-context>

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/utils/__init__.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/utils/__init__.py
@@ -1,0 +1,23 @@
+"""cli_anything.comfyui.utils — HTTP backend and terminal skin."""
+
+from cli_anything.comfyui.utils.comfyui_backend import (
+    ComfyUIAuthError,
+    ComfyUIBackend,
+    ComfyUIBackendError,
+    ComfyUINotFoundError,
+    ComfyUIRateLimitError,
+    ComfyUIServerError,
+    ComfyUIValidationError,
+)
+from cli_anything.comfyui.utils.repl_skin import ReplSkin
+
+__all__ = [
+    "ComfyUIAuthError",
+    "ComfyUIBackend",
+    "ComfyUIBackendError",
+    "ComfyUINotFoundError",
+    "ComfyUIRateLimitError",
+    "ComfyUIServerError",
+    "ComfyUIValidationError",
+    "ReplSkin",
+]

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/utils/comfyui_backend.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/utils/comfyui_backend.py
@@ -1,0 +1,299 @@
+"""ComfyUI REST backend client.
+
+Covers every endpoint in the ComfyUI HTTP API:
+  GET  /system_stats
+  GET  /object_info
+  GET  /object_info/{node_class}
+  GET  /history
+  GET  /history/{prompt_id}
+  POST /history          (clear — body: {"clear": true} or {"delete": [id, ...]})
+  GET  /prompt           (queue + exec info)
+  POST /prompt           (submit workflow)
+  GET  /queue
+  POST /queue            (clear pending — body: {"clear": true})
+  POST /interrupt
+  GET  /view             (download output file)
+  GET  /embeddings
+  GET  /models/{model_type}
+
+Retry policy: 429 responses are retried up to _MAX_RETRIES times with
+exponential backoff, honouring the Retry-After header when present.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Typed exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+class ComfyUIBackendError(Exception):
+    """Base class for all ComfyUI backend errors."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class ComfyUIAuthError(ComfyUIBackendError):
+    """HTTP 401 or 403 from ComfyUI."""
+
+
+class ComfyUINotFoundError(ComfyUIBackendError):
+    """HTTP 404 — resource not found."""
+
+
+class ComfyUIValidationError(ComfyUIBackendError):
+    """HTTP 422 — invalid request payload."""
+
+
+class ComfyUIRateLimitError(ComfyUIBackendError):
+    """HTTP 429 — rate limited (after exhausting retries)."""
+
+
+class ComfyUIServerError(ComfyUIBackendError):
+    """HTTP 5xx — server-side error."""
+
+
+# ---------------------------------------------------------------------------
+# Retry config
+# ---------------------------------------------------------------------------
+
+_MAX_RETRIES = 3
+_BASE_BACKOFF = 1.0  # seconds
+
+
+def _backoff(attempt: int) -> float:
+    return _BASE_BACKOFF * (2**attempt)
+
+
+# ---------------------------------------------------------------------------
+# Main client
+# ---------------------------------------------------------------------------
+
+
+class ComfyUIBackend:
+    """Thin httpx-based client for the ComfyUI REST API.
+
+    Args:
+        base_url: ComfyUI server URL (e.g. ``"http://127.0.0.1:8188"``).
+        auth_headers: Optional dict of extra headers (e.g. Bearer token).
+        timeout: Request timeout in seconds (default 30).
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:8188",
+        auth_headers: dict[str, str] | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self._base = base_url.rstrip("/")
+        self._auth = auth_headers or {}
+        self._timeout = timeout
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _url(self, path: str) -> str:
+        return f"{self._base}/{path.lstrip('/')}"
+
+    def _headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        h = {**self._auth}
+        if extra:
+            h.update(extra)
+        return h
+
+    def _translate_status(self, response: httpx.Response) -> None:
+        """Raise a typed exception for non-2xx responses."""
+        code = response.status_code
+        if code < 400:
+            return
+        text = response.text[:200]
+        if code in (401, 403):
+            raise ComfyUIAuthError(f"HTTP {code}: {text}", status_code=code)
+        if code == 404:
+            raise ComfyUINotFoundError(f"HTTP 404: {text}", status_code=404)
+        if code == 422:
+            raise ComfyUIValidationError(f"HTTP 422: {text}", status_code=422)
+        if code == 429:
+            raise ComfyUIRateLimitError(f"HTTP 429: {text}", status_code=429)
+        if code >= 500:
+            raise ComfyUIServerError(f"HTTP {code}: {text}", status_code=code)
+        raise ComfyUIBackendError(f"HTTP {code}: {text}", status_code=code)
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> httpx.Response:
+        return self._request("GET", path, params=params)
+
+    def _post(self, path: str, json: Any = None) -> httpx.Response:
+        return self._request("POST", path, json=json)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        json: Any = None,
+    ) -> httpx.Response:
+        url = self._url(path)
+        headers = self._headers({"Content-Type": "application/json"} if json is not None else None)
+        last_exc: ComfyUIRateLimitError | None = None
+
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                resp = httpx.request(
+                    method,
+                    url,
+                    headers=headers,
+                    params=params,
+                    json=json,
+                    timeout=self._timeout,
+                )
+            except httpx.RequestError as exc:
+                raise ComfyUIBackendError(f"Connection error: {exc}") from exc
+
+            if resp.status_code == 429 and attempt < _MAX_RETRIES:
+                retry_after = float(resp.headers.get("Retry-After", _backoff(attempt)))
+                time.sleep(retry_after)
+                last_exc = ComfyUIRateLimitError(
+                    f"HTTP 429 (retry {attempt + 1}/{_MAX_RETRIES})", status_code=429
+                )
+                continue
+
+            self._translate_status(resp)
+            return resp
+
+        raise last_exc or ComfyUIRateLimitError("Rate limit exceeded", status_code=429)
+
+    # ------------------------------------------------------------------
+    # System / server info
+    # ------------------------------------------------------------------
+
+    def system_stats(self) -> dict[str, Any]:
+        """GET /system_stats — CPU, RAM, VRAM usage."""
+        return self._get("/system_stats").json()
+
+    def embeddings(self) -> list[str]:
+        """GET /embeddings — list of embedding model names."""
+        return self._get("/embeddings").json()
+
+    # ------------------------------------------------------------------
+    # Object info / node registry
+    # ------------------------------------------------------------------
+
+    def object_info(self) -> dict[str, Any]:
+        """GET /object_info — full node registry."""
+        return self._get("/object_info").json()
+
+    def object_info_node(self, node_class: str) -> dict[str, Any]:
+        """GET /object_info/{node_class} — single node spec."""
+        return self._get(f"/object_info/{node_class}").json()
+
+    # ------------------------------------------------------------------
+    # History
+    # ------------------------------------------------------------------
+
+    def history(self, max_items: int | None = None) -> dict[str, Any]:
+        """GET /history — all completed prompts."""
+        params = {"max_items": max_items} if max_items is not None else None
+        return self._get("/history", params=params).json()
+
+    def history_prompt(self, prompt_id: str) -> dict[str, Any]:
+        """GET /history/{prompt_id} — single prompt history entry."""
+        return self._get(f"/history/{prompt_id}").json()
+
+    def clear_history(self, prompt_id: str | None = None) -> dict[str, Any]:
+        """POST /history — clear all history or a specific prompt.
+
+        ComfyUI uses POST with ``{"clear": true}`` for full clear or
+        ``{"delete": [prompt_id]}`` to remove a specific entry.
+        """
+        if prompt_id:
+            body: dict[str, Any] = {"delete": [prompt_id]}
+        else:
+            body = {"clear": True}
+        return self._post("/history", json=body).json()
+
+    # ------------------------------------------------------------------
+    # Queue
+    # ------------------------------------------------------------------
+
+    def queue(self) -> dict[str, Any]:
+        """GET /queue — running + pending queue items."""
+        return self._get("/queue").json()
+
+    def queue_clear(self) -> dict[str, Any]:
+        """POST /queue with body ``{"clear": true}`` — clear pending queue."""
+        return self._post("/queue", json={"clear": True}).json()
+
+    # ------------------------------------------------------------------
+    # Prompt submission
+    # ------------------------------------------------------------------
+
+    def prompt_status(self) -> dict[str, Any]:
+        """GET /prompt — current execution state and queue info."""
+        return self._get("/prompt").json()
+
+    def submit_prompt(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """POST /prompt — submit a workflow for execution.
+
+        Args:
+            payload: Dict with keys ``"prompt"`` (workflow), ``"client_id"``,
+                and optionally ``"extra_data"``.
+
+        Returns:
+            Response dict containing ``"prompt_id"``, ``"number"``,
+            and ``"node_errors"``.
+        """
+        return self._post("/prompt", json=payload).json()
+
+    # ------------------------------------------------------------------
+    # Interrupt
+    # ------------------------------------------------------------------
+
+    def interrupt(self) -> dict[str, Any]:
+        """POST /interrupt — stop the currently running prompt."""
+        return self._post("/interrupt").json()
+
+    # ------------------------------------------------------------------
+    # File download
+    # ------------------------------------------------------------------
+
+    def view(
+        self,
+        filename: str,
+        subfolder: str = "",
+        file_type: str = "output",
+    ) -> bytes:
+        """GET /view — download an output file as raw bytes.
+
+        Args:
+            filename: File name (e.g. ``"ComfyUI_00001_.png"``).
+            subfolder: Subfolder within the output directory.
+            file_type: One of ``"output"``, ``"input"``, ``"temp"``.
+
+        Returns:
+            Raw bytes of the file content.
+        """
+        params: dict[str, Any] = {"filename": filename, "type": file_type}
+        if subfolder:
+            params["subfolder"] = subfolder
+        return self._get("/view", params=params).content
+
+    # ------------------------------------------------------------------
+    # Models
+    # ------------------------------------------------------------------
+
+    def models(self, model_type: str) -> list[str]:
+        """GET /models/{model_type} — list models of a given type.
+
+        Common types: ``"checkpoints"``, ``"loras"``, ``"vae"``,
+        ``"controlnet"``, ``"embeddings"``, ``"hypernetworks"``,
+        ``"upscale_models"``.
+        """
+        return self._get(f"/models/{model_type}").json()

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/utils/repl_skin.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/cli_anything/comfyui/utils/repl_skin.py
@@ -1,0 +1,153 @@
+"""Terminal skin for cli-anything-comfyui.
+
+Emerald accent: ANSI 256 colour 42 (\\033[38;5;42m), hex #10B981.
+Provides banner, prompt, table, and status-message helpers.
+prompt_toolkit is an optional extra — falls back to input() when absent.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import Any
+
+# ANSI helpers
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+
+# Emerald — ANSI 256 colour 42
+_ACCENT = "\033[38;5;42m"
+_GREEN = "\033[38;5;82m"
+_RED = "\033[38;5;196m"
+_YELLOW = "\033[38;5;220m"
+_BLUE = "\033[38;5;39m"
+_GREY = "\033[38;5;245m"
+
+_ACCENT_HEX = "#10B981"
+_CLI_NAME = "comfyui"
+
+_BANNER = f"""\
+{_ACCENT}{_BOLD}╔══════════════════════════════════════════════════╗
+║          cli-anything · comfyui REPL             ║
+║          accent {_ACCENT_HEX} · emerald                  ║
+╚══════════════════════════════════════════════════╝{_RESET}"""
+
+
+class ReplSkin:
+    """Terminal output helpers with emerald accent styling."""
+
+    def __init__(self, json_mode: bool = False) -> None:
+        self._json = json_mode
+        self._width, _ = shutil.get_terminal_size(fallback=(100, 24))
+
+    # ------------------------------------------------------------------
+    # Banner / section
+    # ------------------------------------------------------------------
+
+    def print_banner(self) -> None:
+        if not self._json:
+            print(_BANNER)
+
+    def section(self, title: str) -> None:
+        if self._json:
+            return
+        bar = _ACCENT + "─" * min(len(title) + 4, self._width) + _RESET
+        print(f"\n{bar}")
+        print(f"{_ACCENT}{_BOLD}  {title}{_RESET}")
+        print(bar)
+
+    # ------------------------------------------------------------------
+    # Status messages
+    # ------------------------------------------------------------------
+
+    def success(self, msg: str) -> None:
+        if not self._json:
+            print(f"{_GREEN}✔ {msg}{_RESET}")
+
+    def error(self, msg: str) -> None:
+        if not self._json:
+            print(f"{_RED}✖ {msg}{_RESET}")
+
+    def warning(self, msg: str) -> None:
+        if not self._json:
+            print(f"{_YELLOW}⚠ {msg}{_RESET}")
+
+    def info(self, msg: str) -> None:
+        if not self._json:
+            print(f"{_BLUE}ℹ {msg}{_RESET}")
+
+    def hint(self, msg: str) -> None:
+        if not self._json:
+            print(f"{_GREY}  {msg}{_RESET}")
+
+    # ------------------------------------------------------------------
+    # Table
+    # ------------------------------------------------------------------
+
+    def table(self, headers: list[str], rows: list[list[Any]]) -> None:
+        if self._json:
+            return
+        if not rows:
+            self.hint("(no rows)")
+            return
+
+        col_widths = [len(h) for h in headers]
+        str_rows = [[str(cell) for cell in row] for row in rows]
+        for row in str_rows:
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    col_widths[i] = max(col_widths[i], len(cell))
+
+        fmt = "  ".join(f"{{:<{w}}}" for w in col_widths)
+        header_line = fmt.format(*headers)
+        sep = "  ".join("─" * w for w in col_widths)
+        print(f"{_ACCENT}{_BOLD}{header_line}{_RESET}")
+        print(f"{_GREY}{sep}{_RESET}")
+        for row in str_rows:
+            padded = row + [""] * max(0, len(headers) - len(row))
+            print(fmt.format(*padded[: len(headers)]))
+
+    # ------------------------------------------------------------------
+    # Help
+    # ------------------------------------------------------------------
+
+    def help(self, command: str, description: str, examples: list[str] | None = None) -> None:
+        if self._json:
+            return
+        print(f"\n{_ACCENT}{_BOLD}{command}{_RESET}  {_GREY}{description}{_RESET}")
+        if examples:
+            for ex in examples:
+                print(f"  {_DIM}$ {ex}{_RESET}")
+
+    # ------------------------------------------------------------------
+    # Prompt / input
+    # ------------------------------------------------------------------
+
+    def prompt(self, text: str = "") -> str:
+        """Return user input with an emerald prompt prefix."""
+        label = f"{_ACCENT}{_BOLD}comfyui>{_RESET} {text}"
+        try:
+            from prompt_toolkit import prompt as pt_prompt  # type: ignore[import-untyped]
+
+            return pt_prompt(label)
+        except ImportError:
+            return input(label)
+
+    def create_prompt_session(self) -> Any:
+        """Return a prompt_toolkit PromptSession or None if unavailable."""
+        try:
+            from prompt_toolkit import PromptSession  # type: ignore[import-untyped]
+            from prompt_toolkit.history import InMemoryHistory  # type: ignore[import-untyped]
+
+            return PromptSession(history=InMemoryHistory())
+        except ImportError:
+            return None
+
+    def get_input(self, session: Any, text: str = "") -> str:
+        label = f"{_ACCENT}{_BOLD}comfyui>{_RESET} {text}"
+        if session is not None:
+            try:
+                return session.prompt(label)
+            except (EOFError, KeyboardInterrupt):
+                raise
+        return input(label)

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/setup.py
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/setup.py
@@ -1,0 +1,44 @@
+"""Package setup for cli-anything-comfyui."""
+
+from setuptools import find_namespace_packages, setup
+
+setup(
+    name="cli-anything-comfyui",
+    version="1.0.0",
+    description="cli-anything harness for ComfyUI — Tier 2 #7",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    python_requires=">=3.11",
+    packages=find_namespace_packages(include=["cli_anything.*"]),
+    install_requires=[
+        "click>=8.1,<9.0",
+        "httpx>=0.24.0",
+    ],
+    extras_require={
+        "repl": ["prompt-toolkit>=3.0,<4.0"],
+        "all": [
+            "httpx>=0.24.0",
+            "prompt-toolkit>=3.0,<4.0",
+        ],
+        "dev": [
+            "pytest>=7.0",
+            "pytest-cov>=4.0",
+            "build",
+            "twine",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "comfyui=cli_anything.comfyui.comfyui_cli:main",
+            "cli-anything-comfyui=cli_anything.comfyui.comfyui_cli:main",
+        ],
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+)

--- a/skyyrose/cli_harnesses/comfyui/agent-harness/skills/CLAUDE.md
+++ b/skyyrose/cli_harnesses/comfyui/agent-harness/skills/CLAUDE.md
@@ -1,0 +1,3 @@
+<claude-mem-context>
+
+</claude-mem-context>

--- a/skyyrose/cli_harnesses/comfyui/skill/SKILL.md
+++ b/skyyrose/cli_harnesses/comfyui/skill/SKILL.md
@@ -1,0 +1,95 @@
+# cli-anything-comfyui — Claude Skill Brief
+
+**Tier 2 #7 — ComfyUI CLI harness**
+
+## Purpose
+
+Manage ComfyUI from the command line: queue workflows, inspect nodes and models,
+browse history, run health checks, manage persistent sessions, and apply batched
+operation manifests.
+
+## Package
+
+```
+cli-anything-comfyui 1.0.0
+Entry points: comfyui | cli-anything-comfyui
+Source: vendor/cli-anything/comfyui/agent-harness/
+```
+
+## Quick Install
+
+```bash
+pip install -e vendor/cli-anything/comfyui/agent-harness/
+# or with REPL:
+pip install -e "vendor/cli-anything/comfyui/agent-harness/[all]"
+```
+
+## Environment
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `COMFYUI_HOST` | Server URL | `http://127.0.0.1:8188` |
+| `COMFYUI_AUTH_TOKEN` | Bearer token | — |
+| `COMFYUI_JSON` | JSON output globally | — |
+| `CLI_ANYTHING_HOME` | Session/manifest data dir | `~/.cli_anything` |
+
+## Command Map
+
+```
+comfyui
+├── system    stats | embeddings
+├── nodes     list [--filter] | info <class>
+├── models    list [type] | types
+├── queue     list | submit <file> | interrupt --confirm | clear --confirm
+├── history   list | show <id> | extract-outputs <id> | clear --confirm [id]
+├── workflow  validate | show | save | nodes
+├── session   new | list | show <id> | delete --confirm <id>
+├── manifest  plan | show | apply --confirm
+├── doctor    check | deps
+└── repl      (interactive REPL)
+```
+
+## Key Patterns
+
+- `--json` flag → all output as JSON (machine-readable)
+- `--confirm` required for: `queue clear`, `queue interrupt`, `history clear`, `session delete`, `manifest apply`
+- `--host` overrides `COMFYUI_HOST` per invocation
+- `--token` overrides `COMFYUI_AUTH_TOKEN` per invocation
+- 429 rate-limit → automatic retry (up to 3× with backoff, honors `Retry-After`)
+- Session files → `~/.cli_anything/comfyui/sessions/<uuid>.json`
+- Manifest files → local JSON, plan/show/apply workflow
+
+## Architecture
+
+```
+cli_anything/comfyui/
+├── comfyui_cli.py       Root Click group + REPL
+├── core/
+│   ├── secrets.py       ComfyUISecrets (host + token resolution)
+│   ├── workflow.py      NodeInfo + Workflow data model
+│   ├── queue.py         QueueItem + build_prompt_payload
+│   ├── history.py       HistoryItem + OutputFile parsing
+│   ├── manifest.py      ActionManifest plan/apply with atomic JSON write
+│   └── session.py       Session persistence (MAX_HISTORY=50)
+├── utils/
+│   ├── comfyui_backend.py  Full REST client (14 endpoints, retry logic)
+│   └── repl_skin.py     ReplSkin — emerald #10B981 accent, table formatter
+└── commands/
+    ├── system_cmds.py   doctor_cmds.py   history_cmds.py
+    ├── manifest_cmds.py models_cmds.py   nodes_cmds.py
+    ├── queue_cmds.py    session_cmds.py  workflow_cmds.py
+    └── doctor_cmds.py
+```
+
+## Testing
+
+```bash
+# Offline (no server) — CI default
+pytest vendor/cli-anything/comfyui/agent-harness/cli_anything/comfyui/tests/ -v
+
+# With live ComfyUI
+COMFYUI_E2E=1 pytest vendor/cli-anything/comfyui/agent-harness/cli_anything/comfyui/tests/ -v
+```
+
+~165 tests across `test_core.py` (offline unit) + `test_full_e2e.py` (integration).
+E2E gate: skip when `COMFYUI_E2E` unset; FAIL (not skip) when set + server unreachable.

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/CLAUDE.md
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/CLAUDE.md
@@ -1,0 +1,3 @@
+<claude-mem-context>
+
+</claude-mem-context>

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/HF-SPACES.md
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/HF-SPACES.md
@@ -1,0 +1,148 @@
+# HF-SPACES — Phase 1 Analysis + Phase 2 Architecture
+
+## Phase 1: API Landscape Analysis
+
+### SDK Version Target
+`huggingface_hub >= 0.26.0, < 1.0` — `SpaceHardware` enum is stable, `HfApi` is the
+authoritative client.
+
+### Available HfApi Methods (confirmed)
+
+| Operation | Method | Notes |
+|-----------|--------|-------|
+| Space info | `space_info(repo_id)` | Returns `SpaceInfo` with `.runtime.stage`, `.runtime.hardware.current` |
+| Pause | `pause_space(repo_id)` | Sets stage → `PAUSED` |
+| Restart | `restart_space(repo_id, factory_reboot=False)` | Warm restart |
+| Set hardware | `request_space_hardware(repo_id, hardware)` | `SpaceHardware` enum |
+| Set sleep time | `set_space_sleep_time(repo_id, sleep_time)` | seconds, -1 = never |
+| Add secret | `add_space_secret(repo_id, key, value)` | Write-only |
+| Delete secret | `delete_space_secret(repo_id, key)` | Destructive — STOP-AND-SHOW |
+| Add variable | `add_space_variable(repo_id, key, value)` | Env var (not secret) |
+| Delete variable | `delete_space_variable(repo_id, key)` | |
+| Get variables | `get_space_variables(repo_id)` | Returns `{key: {"value": ..., "description": ...}}` |
+| List spaces | `list_spaces(author=..., search=...)` | Generator of `SpaceInfo` |
+| Upload README | `upload_file(path_or_fileobj, path_in_repo="README.md", repo_id, repo_type="space")` | |
+| Duplicate | `duplicate_space(from_id, to_id, private=True, exist_ok=False)` | |
+
+### Known API Gaps (Phase 1 findings — locked)
+
+#### 1. Secret Enumeration — NOT POSSIBLE via HfApi
+`HfApi` has **no** `get_space_secrets` or equivalent. Secrets are write-only by design
+(HF security model: values must never be readable after write). The `secrets list` command
+reads from the **local manifest only**. This is documented explicitly — users must maintain
+their manifest to track what secrets are deployed. The API will return an explicit message
+stating this limitation.
+
+#### 2. Streaming Logs — NOT in HfApi public surface
+Neither `get_space_runtime_logs` nor any log-streaming method exists in `HfApi`. Implemented
+via raw `httpx` SSE calls:
+- Run logs: `GET https://huggingface.co/api/spaces/{owner}/{name}/logs/run`
+- Build logs: `GET https://huggingface.co/api/spaces/{owner}/{name}/logs/build`
+Headers: `Authorization: Bearer {token}`. Documented as bypassing HfApi.
+Falls back gracefully when `httpx` is not installed (install extra: `pip install cli-anything-hf-spaces[logs]`).
+
+#### 3. Factory Reset — NOT in HfApi
+No `factory_reset_space` method exists. This is a web-UI only operation. **Not exposed**
+in this CLI. Documented in the `doctor` command output.
+
+#### 4. Secret Values — Write-Only
+`add_space_secret` accepts a value but `get_space_variables` does NOT return secrets.
+Manifest drift detection for secrets is one-way: we can know what we *want* deployed
+(from manifest), but cannot verify what is *currently* deployed. Manifest apply always
+re-writes secrets to ensure desired state.
+
+#### 5. `Repository` Class — Deprecated
+`huggingface_hub >= 0.16` deprecated `Repository`. All file operations use `upload_file`.
+
+---
+
+## Phase 2: Architecture
+
+### Namespace Layout
+
+```
+cli_anything/hf_spaces/
+├── __init__.py               # empty
+├── hf_spaces_cli.py          # Click root group + REPL entry + CliState
+├── core/
+│   ├── __init__.py
+│   ├── hardware.py           # SpaceHardware enum proxy + cost table
+│   ├── space.py              # SpaceRef dataclass + URL/slug parser
+│   ├── secrets.py            # SecretEntry / VariableEntry dataclasses
+│   ├── session.py            # Session + _locked_save_json (atomic writes)
+│   └── manifest.py           # ManifestSpec + plan/apply diff logic
+├── utils/
+│   ├── __init__.py
+│   ├── hf_backend.py         # HfApi wrapper, auth resolution, typed exceptions
+│   └── repl_skin.py          # Vendor copy of ReplSkin (prompt-toolkit)
+├── commands/
+│   ├── __init__.py
+│   ├── space_cmds.py         # space info / list / duplicate / pause / restart
+│   ├── hardware_cmds.py      # hardware get / set / list-tiers
+│   ├── secrets_cmds.py       # secrets set / delete / list (manifest-only)
+│   ├── vars_cmds.py          # vars get / set / delete / list
+│   ├── logs_cmds.py          # logs run / build (httpx SSE)
+│   ├── readme_cmds.py        # readme get / set / sync
+│   ├── manifest_cmds.py      # manifest init / plan / apply / show
+│   ├── session_cmds.py       # session list / show / delete
+│   └── doctor_cmds.py        # doctor check
+├── tests/
+│   ├── TEST.md
+│   ├── test_core.py          # 40+ unit tests (no live HF)
+│   └── test_full_e2e.py      # subprocess e2e (HF_SPACES_E2E=1 gate)
+└── skills/
+    └── SKILL.md
+```
+
+### CliState + emit() Pattern
+
+```python
+class CliState:
+    json_output: bool
+    token: str | None   # in-memory only, never written to disk
+
+def emit(state, payload, *, human): ...   # json or human print
+def handle_backend_error(state, exc): ... # returns exit code 1
+```
+
+### STOP-AND-SHOW Gate Protocol
+
+Any command tagged `@destructive` must:
+1. Print manifest of exact changes with `[STOP]` prefix
+2. Exit 0 if `--confirm` not passed (shows manifest only)
+3. Execute only when `--confirm` is passed
+
+Destructive commands: `hardware set`, `secrets delete`, `manifest apply`, `space pause`.
+
+### Session Storage
+
+`~/.cli_anything/hf_spaces/sessions/{session_id}.json` — atomic writes via
+`_locked_save_json`. Token is **never** included in session JSON.
+
+### Auth Resolution Order
+
+1. `--token` flag (in-memory, never written)
+2. `HF_TOKEN` env var
+3. `~/.cache/huggingface/token` (written by `huggingface-cli login`)
+4. Unauthenticated (public spaces only)
+
+### Manifest Model
+
+`manifest.json` at user-specified path (default `./hf-space-manifest.json`):
+```json
+{
+  "schema_version": "1",
+  "space_id": "owner/name",
+  "hardware": "cpu-basic",
+  "sleep_time": 300,
+  "variables": {"KEY": "value"},
+  "secrets": ["SECRET_KEY_1", "SECRET_KEY_2"],
+  "readme_path": "./README.md"
+}
+```
+
+`manifest plan`: diff desired vs actual (hardware via `get_space_runtime`,
+vars via `get_space_variables`, README via file comparison). Secrets: always flagged
+as "cannot verify — will re-apply on apply".
+
+`manifest apply`: STOP-AND-SHOW of all changes, requires `--confirm`.

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/README.md
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/README.md
@@ -1,0 +1,163 @@
+# cli-anything-hf-spaces
+
+CLI harness for HuggingFace Spaces administration. Manages hardware tiers,
+env vars, secrets, sleep/restart, logs, README sync, and manifest-driven
+desired-state apply.
+
+## Install
+
+```bash
+pip install 'cli-anything-hf-spaces[all]'
+```
+
+Minimal install (no log streaming, no REPL):
+
+```bash
+pip install cli-anything-hf-spaces
+```
+
+## Auth
+
+Token resolution order (first wins):
+
+1. `--token <token>` — in-memory only, never written to disk
+2. `HF_TOKEN` environment variable
+3. `~/.cache/huggingface/token` (from `huggingface-cli login`)
+
+## Quick start
+
+```bash
+# Health check
+hf-spaces doctor
+
+# Space info
+hf-spaces space info owner/my-space
+
+# Change hardware tier (billing — requires --confirm)
+hf-spaces hardware set owner/my-space t4-small --confirm
+
+# Set a secret (value prompted interactively)
+hf-spaces secrets set owner/my-space MY_API_KEY
+
+# List variables
+hf-spaces vars list owner/my-space
+
+# Stream runtime logs (requires httpx extra)
+hf-spaces logs run owner/my-space
+
+# Sync README
+hf-spaces readme sync owner/my-space ./README.md
+
+# Manifest workflow
+hf-spaces manifest init owner/my-space --out ./hf-space-manifest.json
+# edit hf-space-manifest.json ...
+hf-spaces manifest plan  ./hf-space-manifest.json
+hf-spaces manifest apply ./hf-space-manifest.json --confirm
+
+# Interactive REPL
+hf-spaces
+```
+
+## Command groups
+
+| Group      | Commands                                 |
+|------------|------------------------------------------|
+| `space`    | info, list, pause, restart, duplicate    |
+| `hardware` | get, set, list-tiers                     |
+| `secrets`  | set, delete, list (manifest only)        |
+| `vars`     | list, get, set, delete                   |
+| `logs`     | run, build                               |
+| `readme`   | get, set, sync                           |
+| `manifest` | init, show, plan, apply                  |
+| `session`  | list, show, delete                       |
+| `doctor`   | auth + SDK health check                  |
+
+## JSON output
+
+Every command supports `--json` for machine-readable output:
+
+```bash
+hf-spaces --json space info owner/my-space | jq .stage
+```
+
+## STOP-AND-SHOW gate
+
+The following operations require `--confirm` and print a summary before
+executing:
+
+- `hardware set` — billing impact
+- `secrets delete` — destructive, write-only API
+- `space pause` — takes Space offline
+- `manifest apply` — may touch hardware, secrets, variables, README
+
+## Known API limitations
+
+- **Secrets are write-only** via HfApi. `secrets list` reads the local
+  manifest only and prints an explicit warning.
+- **Log streaming** bypasses HfApi and uses raw httpx SSE. Requires
+  `pip install 'cli-anything-hf-spaces[logs]'`.
+- **Factory reset** is a web-UI-only operation. Not available via this CLI
+  (reported by `doctor`).
+
+## Manifest
+
+A manifest declares the desired state of a Space. Generate one from live
+state with `manifest init`, edit it, then `plan` and `apply`.
+
+```json
+{
+  "schema": "1",
+  "repo_id": "owner/my-space",
+  "hardware": "t4-small",
+  "sleep_time": 300,
+  "variables": {
+    "DEBUG": "false"
+  },
+  "secrets": ["MY_API_KEY"],
+  "readme_path": "./README.md"
+}
+```
+
+## Hardware tiers
+
+| Slug            | Description                     |
+|-----------------|---------------------------------|
+| `cpu-basic`     | 2 vCPU / 16 GB RAM (free)       |
+| `cpu-upgrade`   | 8 vCPU / 32 GB RAM              |
+| `cpu-xl`        | 32 vCPU / 128 GB RAM            |
+| `zero-a10g`     | ZeroGPU A10G (shared)           |
+| `t4-small`      | NVIDIA T4 small                 |
+| `t4-medium`     | NVIDIA T4 medium                |
+| `l4x1`          | NVIDIA L4 ×1                    |
+| `l4x4`          | NVIDIA L4 ×4                    |
+| `l40sx1`        | NVIDIA L40S ×1                  |
+| `l40sx4`        | NVIDIA L40S ×4                  |
+| `l40sx8`        | NVIDIA L40S ×8                  |
+| `a10g-small`    | NVIDIA A10G small               |
+| `a10g-large`    | NVIDIA A10G large               |
+| `a10g-largex2`  | NVIDIA A10G large ×2            |
+| `a10g-largex4`  | NVIDIA A10G large ×4            |
+| `a100-large`    | NVIDIA A100 large               |
+| `h100`          | NVIDIA H100                     |
+| `h100x8`        | NVIDIA H100 ×8                  |
+
+## Sessions
+
+Completed commands are logged to `~/.cli_anything/hf_spaces/sessions/` for
+auditing. Sessions never contain auth tokens.
+
+## Development
+
+```bash
+pip install -e '.[dev]'
+
+# Unit tests only (no live HF calls)
+pytest cli_anything/hf_spaces/tests/test_core.py -v
+
+# All tests including e2e (requires HF_SPACES_E2E=1 and a valid HF_TOKEN)
+HF_SPACES_E2E=1 HF_TOKEN=hf_... pytest cli_anything/hf_spaces/tests/ -v
+
+# Coverage
+pytest cli_anything/hf_spaces/tests/test_core.py -v \
+  --cov=cli_anything.hf_spaces --cov-report=term-missing
+```

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/__main__.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running as: python -m cli_anything.hf_spaces"""
+
+from cli_anything.hf_spaces.hf_spaces_cli import main
+
+if __name__ == "__main__":
+    main()

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/doctor_cmds.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/doctor_cmds.py
@@ -1,0 +1,133 @@
+"""doctor command — health check for auth, SDK, and optional deps."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.group("doctor", invoke_without_command=True, context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+def doctor(ctx: click.Context) -> None:
+    """Check auth, SDK availability, and optional dependencies."""
+    if ctx.invoked_subcommand is None:
+        _run_doctor(ctx)
+
+
+def _run_doctor(ctx: click.Context) -> None:
+    state = ctx.obj
+    results: dict = {}
+
+    # 1. huggingface_hub availability
+    try:
+        import huggingface_hub
+
+        hf_version = getattr(huggingface_hub, "__version__", "unknown")
+        results["huggingface_hub"] = {"ok": True, "version": hf_version}
+    except ImportError:
+        results["huggingface_hub"] = {
+            "ok": False,
+            "error": "not installed — run: pip install huggingface_hub",
+        }
+
+    # 2. Auth token resolution
+    try:
+        from cli_anything.hf_spaces.utils.hf_backend import resolve_token
+
+        token = resolve_token(state.token if state else None)
+        if token:
+            # Show only first 4 + last 4 chars for safety
+            masked = token[:4] + "..." + token[-4:] if len(token) > 8 else "***"
+            results["auth"] = {"ok": True, "token_source": _token_source(state), "masked": masked}
+        else:
+            results["auth"] = {
+                "ok": False,
+                "error": "No token found. Use --token, HF_TOKEN, or huggingface-cli login.",
+            }
+    except Exception as exc:
+        results["auth"] = {"ok": False, "error": str(exc)}
+
+    # 3. httpx (optional — for log streaming)
+    try:
+        import httpx
+
+        results["httpx"] = {"ok": True, "version": getattr(httpx, "__version__", "unknown")}
+    except ImportError:
+        results["httpx"] = {
+            "ok": False,
+            "warning": "optional — log streaming unavailable. Install: pip install 'cli-anything-hf-spaces[logs]'",
+        }
+
+    # 4. prompt_toolkit (optional — for REPL)
+    try:
+        import prompt_toolkit
+
+        results["prompt_toolkit"] = {
+            "ok": True,
+            "version": getattr(prompt_toolkit, "__version__", "unknown"),
+        }
+    except ImportError:
+        results["prompt_toolkit"] = {
+            "ok": False,
+            "warning": "optional — REPL history/autocomplete unavailable. Install: pip install prompt-toolkit",
+        }
+
+    # 5. Factory reset notice
+    results["factory_reset"] = {
+        "ok": True,
+        "note": "Factory reset is a web-UI only operation — not exposed by HfApi and not available in this CLI.",
+    }
+
+    # 6. Secrets API notice
+    results["secrets_api"] = {
+        "ok": True,
+        "note": "HfApi does not support reading secret names or values (write-only by design). Use local manifests to track deployed secret keys.",
+    }
+
+    all_ok = all(
+        v.get("ok", False)
+        for k, v in results.items()
+        if k not in ("factory_reset", "secrets_api", "httpx", "prompt_toolkit")
+    )
+
+    if state and state.json_output:
+        click.echo(json.dumps({"ok": all_ok, "checks": results}, indent=2))
+        if not all_ok:
+            sys.exit(1)
+        return
+
+    click.echo()
+    for check, info in results.items():
+        ok = info.get("ok", False)
+        icon = "✓" if ok else ("⚠" if "warning" in info else "✗")
+        color_open = (
+            "\033[38;5;78m" if ok else ("\033[38;5;220m" if "warning" in info else "\033[38;5;196m")
+        )
+        reset = "\033[0m"
+        label = f"  {color_open}{icon}{reset} {check}"
+        detail = (
+            info.get("version") or info.get("note") or info.get("error") or info.get("warning", "")
+        )
+        click.echo(f"{label:<40} {detail}")
+    click.echo()
+
+    if not all_ok:
+        sys.exit(1)
+
+
+def _token_source(state) -> str:
+    import os
+    from pathlib import Path
+
+    if state and state.token:
+        return "--token flag"
+    if os.environ.get("HF_TOKEN"):
+        return "HF_TOKEN env"
+    cache = Path.home() / ".cache" / "huggingface" / "token"
+    if cache.exists():
+        return str(cache)
+    return "none"

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/hardware_cmds.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/hardware_cmds.py
@@ -1,0 +1,101 @@
+"""hardware command group — get, set, list-tiers."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+from cli_anything.hf_spaces.core.hardware import (HARDWARE_SLUGS,
+                                                  hardware_table_rows,
+                                                  validate_hardware_slug)
+from cli_anything.hf_spaces.core.space import SpaceRef
+from cli_anything.hf_spaces.utils.hf_backend import (HfBackendError,
+                                                     get_hardware,
+                                                     set_hardware)
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.group("hardware", context_settings=CONTEXT_SETTINGS)
+def hardware() -> None:
+    """Hardware tier management — get, set, list-tiers."""
+
+
+@hardware.command("get")
+@click.argument("space_id")
+@click.pass_context
+def hardware_get(ctx: click.Context, space_id: str) -> None:
+    """Get the current hardware tier for SPACE_ID."""
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+    try:
+        slug = get_hardware(ref.repo_id, token=state.token)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(json.dumps({"ok": True, "repo_id": ref.repo_id, "hardware": slug}, indent=2))
+    else:
+        click.echo(f"  Hardware: {slug or 'unknown'}")
+
+
+@hardware.command("set")
+@click.argument("space_id")
+@click.argument("tier", type=click.Choice(list(HARDWARE_SLUGS), case_sensitive=True))
+@click.option(
+    "--confirm", is_flag=True, default=False, help="Confirm the hardware change (billing impact)."
+)
+@click.pass_context
+def hardware_set(ctx: click.Context, space_id: str, tier: str, confirm: bool) -> None:
+    """Request hardware tier TIER for SPACE_ID.
+
+    This is a destructive/billing operation. Requires --confirm.
+    """
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+
+    if not confirm:
+        click.echo(
+            f"\n  [STOP] Confirm before proceeding:\n"
+            f"\n  Action : hardware change\n"
+            f"  Target : {ref.repo_id}\n"
+            f"  Tier   : {tier}\n"
+            f"\n  This may incur billing charges.\n"
+            f"  Pass --confirm to execute.\n"
+        )
+        return
+
+    try:
+        set_hardware(ref.repo_id, tier, token=state.token)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(json.dumps({"ok": True, "repo_id": ref.repo_id, "hardware": tier}, indent=2))
+    else:
+        click.echo(f"  ✓ Hardware change requested: {ref.repo_id} → {tier}")
+
+
+@hardware.command("list-tiers")
+@click.pass_context
+def hardware_list_tiers(ctx: click.Context) -> None:
+    """List all available hardware tiers with reference pricing."""
+    state = ctx.obj
+    rows = hardware_table_rows()
+
+    if state.json_output:
+        click.echo(json.dumps({"ok": True, "tiers": rows}, indent=2))
+    else:
+        from cli_anything.hf_spaces.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin("hf_spaces")
+        skin.hint("  Reference pricing (verify at https://huggingface.co/pricing):")
+        skin.table(
+            ["slug", "cost_usd_hr", "description"],
+            [[r["slug"], r["cost_usd_hr"], r["description"]] for r in rows],
+            max_col_width=50,
+        )
+        click.echo()

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/logs_cmds.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/logs_cmds.py
@@ -1,0 +1,83 @@
+"""logs command group — run, build.
+
+NOTE: Log streaming bypasses the public HfApi surface and calls the
+HuggingFace SSE endpoint directly via httpx. Requires:
+  pip install 'cli-anything-hf-spaces[logs]'
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+import click
+from cli_anything.hf_spaces.core.space import SpaceRef
+from cli_anything.hf_spaces.utils.hf_backend import (HfLogsUnavailableError,
+                                                     stream_logs)
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.group("logs", context_settings=CONTEXT_SETTINGS)
+def logs() -> None:
+    """Log streaming — run (runtime logs), build (build logs).
+
+    Requires httpx: pip install 'cli-anything-hf-spaces[logs]'
+    """
+
+
+def _stream(
+    space_id: str,
+    log_type: str,
+    token: Optional[str],
+    lines: int,
+    json_output: bool,
+) -> None:
+    ref = SpaceRef.parse(space_id)
+    try:
+        for line in stream_logs(
+            owner=ref.owner,
+            name=ref.name,
+            log_type=log_type,
+            token=token,
+            max_lines=lines,
+        ):
+            if json_output:
+                import json
+
+                click.echo(json.dumps({"type": log_type, "line": line}))
+            else:
+                click.echo(line)
+    except HfLogsUnavailableError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+
+@logs.command("run")
+@click.argument("space_id")
+@click.option(
+    "--lines",
+    default=200,
+    show_default=True,
+    help="Maximum log lines to stream.",
+)
+@click.pass_context
+def logs_run(ctx: click.Context, space_id: str, lines: int) -> None:
+    """Stream runtime logs for SPACE_ID."""
+    state = ctx.obj
+    _stream(space_id, "run", state.token, lines, state.json_output)
+
+
+@logs.command("build")
+@click.argument("space_id")
+@click.option(
+    "--lines",
+    default=200,
+    show_default=True,
+    help="Maximum log lines to stream.",
+)
+@click.pass_context
+def logs_build(ctx: click.Context, space_id: str, lines: int) -> None:
+    """Stream build logs for SPACE_ID."""
+    state = ctx.obj
+    _stream(space_id, "build", state.token, lines, state.json_output)

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/manifest_cmds.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/manifest_cmds.py
@@ -1,0 +1,271 @@
+"""manifest command group — init, plan, apply, show."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+from cli_anything.hf_spaces.core.manifest import (DEFAULT_MANIFEST_NAME,
+                                                  ManifestSpec, build_plan)
+from cli_anything.hf_spaces.core.secrets import SecretsBundle
+from cli_anything.hf_spaces.core.space import SpaceRef
+from cli_anything.hf_spaces.utils.hf_backend import (HfBackendError,
+                                                     delete_secret,
+                                                     delete_variable,
+                                                     get_readme,
+                                                     get_space_runtime,
+                                                     get_variables,
+                                                     set_hardware, set_secret,
+                                                     set_sleep_time,
+                                                     set_variable,
+                                                     upload_readme)
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.group("manifest", context_settings=CONTEXT_SETTINGS)
+def manifest() -> None:
+    """Manifest plan/apply — declare desired state and diff against actual."""
+
+
+@manifest.command("init")
+@click.argument("space_id")
+@click.option(
+    "--out",
+    default=DEFAULT_MANIFEST_NAME,
+    show_default=True,
+    type=click.Path(dir_okay=False),
+    help="Output path for the manifest file.",
+)
+@click.option("--hardware", default=None, help="Initial hardware tier slug.")
+@click.option("--sleep-time", default=None, type=int, help="Sleep time in seconds (-1 = never).")
+@click.pass_context
+def manifest_init(
+    ctx: click.Context,
+    space_id: str,
+    out: str,
+    hardware: Optional[str],
+    sleep_time: Optional[int],
+) -> None:
+    """Create a new manifest file for SPACE_ID."""
+    ref = SpaceRef.parse(space_id)
+    spec = ManifestSpec(
+        space_id=ref.repo_id,
+        hardware=hardware,
+        sleep_time=sleep_time,
+    )
+    out_path = Path(out)
+    if out_path.exists():
+        click.echo(f"  ✗ Manifest already exists: {out_path}. Delete it first.", err=True)
+        sys.exit(1)
+    spec.save(out_path)
+    click.echo(f"  ✓ Manifest created: {out_path}")
+    click.echo(f"    Edit it to declare desired state, then run: manifest plan {out_path}")
+
+
+@manifest.command("show")
+@click.argument("manifest_file", type=click.Path(exists=True, dir_okay=False))
+@click.pass_context
+def manifest_show(ctx: click.Context, manifest_file: str) -> None:
+    """Pretty-print the manifest file."""
+    state = ctx.obj
+    try:
+        spec = ManifestSpec.load(Path(manifest_file))
+    except Exception as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(json.dumps({"ok": True, "manifest": spec.to_dict()}, indent=2))
+    else:
+        click.echo(json.dumps(spec.to_dict(), indent=2))
+
+
+@manifest.command("plan")
+@click.argument("manifest_file", type=click.Path(exists=True, dir_okay=False))
+@click.pass_context
+def manifest_plan(ctx: click.Context, manifest_file: str) -> None:
+    """Show what 'manifest apply' would change without executing anything."""
+    state = ctx.obj
+    try:
+        spec = ManifestSpec.load(Path(manifest_file))
+    except Exception as exc:
+        click.echo(f"  ✗ Could not load manifest: {exc}", err=True)
+        sys.exit(1)
+
+    ref = SpaceRef.parse(spec.space_id)
+
+    # Fetch current state from HF
+    try:
+        runtime = get_space_runtime(ref.repo_id, token=state.token)
+        hw = getattr(runtime, "hardware", None)
+        current_hardware = (
+            str(hw.current.value if hasattr(hw.current, "value") else hw.current)
+            if hw and getattr(hw, "current", None)
+            else None
+        )
+        current_sleep = getattr(runtime, "sleep_time", None)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ Could not fetch runtime: {exc}", err=True)
+        sys.exit(1)
+
+    try:
+        raw_vars = get_variables(ref.repo_id, token=state.token)
+        current_vars = {k: v.get("value", "") for k, v in raw_vars.items()}
+    except HfBackendError as exc:
+        click.echo(f"  ✗ Could not fetch variables: {exc}", err=True)
+        sys.exit(1)
+
+    current_readme = get_readme(ref.repo_id, token=state.token)
+
+    changes = build_plan(
+        spec=spec,
+        current_hardware=current_hardware,
+        current_sleep_time=current_sleep,
+        current_variables=current_vars,
+        current_readme=current_readme,
+    )
+
+    if state.json_output:
+        click.echo(
+            json.dumps(
+                {
+                    "ok": True,
+                    "repo_id": ref.repo_id,
+                    "changes": [c.to_dict() for c in changes],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    if not changes:
+        click.echo(f"  ✓ No changes needed — {ref.repo_id} matches manifest.")
+        return
+
+    click.echo(f"\n  Planned changes for {ref.repo_id}:")
+    for c in changes:
+        click.echo(c.summary())
+    destructive = [c for c in changes if c.destructive]
+    if destructive:
+        click.echo(
+            f"\n  ⚠  {len(destructive)} destructive change(s) — will require --confirm on apply."
+        )
+    click.echo(f"\n  Run 'manifest apply {manifest_file} --confirm' to execute.\n")
+
+
+@manifest.command("apply")
+@click.argument("manifest_file", type=click.Path(exists=True, dir_okay=False))
+@click.option("--confirm", is_flag=True, default=False, help="Confirm and execute all changes.")
+@click.pass_context
+def manifest_apply(ctx: click.Context, manifest_file: str, confirm: bool) -> None:
+    """Apply manifest to live Space. STOP-AND-SHOW before any change.
+
+    Requires --confirm to execute. Shows the change manifest if omitted.
+    """
+    state = ctx.obj
+    try:
+        spec = ManifestSpec.load(Path(manifest_file))
+    except Exception as exc:
+        click.echo(f"  ✗ Could not load manifest: {exc}", err=True)
+        sys.exit(1)
+
+    ref = SpaceRef.parse(spec.space_id)
+
+    # Fetch current state
+    try:
+        runtime = get_space_runtime(ref.repo_id, token=state.token)
+        hw = getattr(runtime, "hardware", None)
+        current_hardware = (
+            str(hw.current.value if hasattr(hw.current, "value") else hw.current)
+            if hw and getattr(hw, "current", None)
+            else None
+        )
+        current_sleep = getattr(runtime, "sleep_time", None)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ Could not fetch runtime: {exc}", err=True)
+        sys.exit(1)
+
+    try:
+        raw_vars = get_variables(ref.repo_id, token=state.token)
+        current_vars = {k: v.get("value", "") for k, v in raw_vars.items()}
+    except HfBackendError as exc:
+        click.echo(f"  ✗ Could not fetch variables: {exc}", err=True)
+        sys.exit(1)
+
+    current_readme = get_readme(ref.repo_id, token=state.token)
+
+    changes = build_plan(
+        spec=spec,
+        current_hardware=current_hardware,
+        current_sleep_time=current_sleep,
+        current_variables=current_vars,
+        current_readme=current_readme,
+    )
+
+    if not changes:
+        click.echo(f"  ✓ No changes needed — {ref.repo_id} already matches manifest.")
+        return
+
+    # STOP-AND-SHOW
+    click.echo(f"\n  [STOP] Confirm before proceeding:\n")
+    click.echo(f"  Target : {ref.repo_id}")
+    click.echo(f"  Changes ({len(changes)}):")
+    for c in changes:
+        click.echo(c.summary())
+
+    destructive = [c for c in changes if c.destructive]
+    if destructive:
+        click.echo(f"\n  ⚠  {len(destructive)} destructive change(s) included.")
+
+    if not confirm:
+        click.echo(f"\n  Pass --confirm to execute.\n")
+        return
+
+    # Collect secret values before applying (prompt once per secret)
+    secret_values: dict = {}
+    from cli_anything.hf_spaces.core.manifest import ChangeKind
+
+    secret_changes = [c for c in changes if c.kind == ChangeKind.SECRET_SET]
+    for c in secret_changes:
+        secret_values[c.key] = click.prompt(
+            f"  Value for secret {c.key}", hide_input=True, confirmation_prompt=False
+        )
+
+    # Apply changes
+    errors: list = []
+    applied: list = []
+
+    for c in changes:
+        try:
+            if c.kind == ChangeKind.HARDWARE:
+                set_hardware(ref.repo_id, c.desired, token=state.token)
+            elif c.kind == ChangeKind.SLEEP_TIME:
+                set_sleep_time(ref.repo_id, int(c.desired), token=state.token)
+            elif c.kind == ChangeKind.VARIABLE_SET:
+                set_variable(ref.repo_id, c.key, c.desired, token=state.token)
+            elif c.kind == ChangeKind.VARIABLE_DELETE:
+                delete_variable(ref.repo_id, c.key, token=state.token)
+            elif c.kind == ChangeKind.SECRET_SET:
+                val = secret_values.get(c.key, "")
+                set_secret(ref.repo_id, c.key, val, token=state.token)
+            elif c.kind == ChangeKind.README_SYNC:
+                content = Path(c.desired).read_text(encoding="utf-8")
+                upload_readme(ref.repo_id, content, token=state.token)
+            applied.append(c.summary().strip())
+        except HfBackendError as exc:
+            errors.append(f"{c.summary().strip()}: {exc}")
+
+    click.echo()
+    for a in applied:
+        click.echo(f"  ✓ Applied: {a}")
+    for e in errors:
+        click.echo(f"  ✗ Failed:  {e}", err=True)
+
+    if errors:
+        sys.exit(1)
+    else:
+        click.echo(f"\n  ✓ Manifest applied to {ref.repo_id} ({len(applied)} change(s)).\n")

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/readme_cmds.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/readme_cmds.py
@@ -1,0 +1,127 @@
+"""readme command group — get, set, sync."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+from cli_anything.hf_spaces.core.space import SpaceRef
+from cli_anything.hf_spaces.utils.hf_backend import (HfBackendError,
+                                                     get_readme, upload_readme)
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.group("readme", context_settings=CONTEXT_SETTINGS)
+def readme() -> None:
+    """README.md management — get, set, sync."""
+
+
+@readme.command("get")
+@click.argument("space_id")
+@click.option(
+    "--out", default=None, type=click.Path(dir_okay=False), help="Write to file instead of stdout."
+)
+@click.pass_context
+def readme_get(ctx: click.Context, space_id: str, out: Optional[str]) -> None:
+    """Fetch README.md from SPACE_ID."""
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+
+    content = get_readme(ref.repo_id, token=state.token)
+    if content is None:
+        click.echo(f"  ✗ README.md not found on {ref.repo_id}.", err=True)
+        sys.exit(1)
+
+    if out:
+        Path(out).write_text(content, encoding="utf-8")
+        if state.json_output:
+            click.echo(
+                json.dumps({"ok": True, "repo_id": ref.repo_id, "written_to": out}, indent=2)
+            )
+        else:
+            click.echo(f"  ✓ README.md written to {out}")
+    else:
+        if state.json_output:
+            click.echo(
+                json.dumps({"ok": True, "repo_id": ref.repo_id, "content": content}, indent=2)
+            )
+        else:
+            click.echo(content)
+
+
+@readme.command("set")
+@click.argument("space_id")
+@click.argument("file", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--message", default="Update README.md via cli-anything-hf-spaces", help="Commit message."
+)
+@click.pass_context
+def readme_set(ctx: click.Context, space_id: str, file: str, message: str) -> None:
+    """Upload local FILE as README.md to SPACE_ID."""
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+    content = Path(file).read_text(encoding="utf-8")
+
+    try:
+        upload_readme(ref.repo_id, content=content, token=state.token, commit_message=message)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(json.dumps({"ok": True, "repo_id": ref.repo_id, "source": file}, indent=2))
+    else:
+        click.echo(f"  ✓ README.md uploaded to {ref.repo_id} from {file}")
+
+
+@readme.command("sync")
+@click.argument("space_id")
+@click.argument("file", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--message", default="Sync README.md via cli-anything-hf-spaces", help="Commit message."
+)
+@click.option("--force", is_flag=True, default=False, help="Upload even if content matches remote.")
+@click.pass_context
+def readme_sync(ctx: click.Context, space_id: str, file: str, message: str, force: bool) -> None:
+    """Sync local FILE to README.md on SPACE_ID (no-op if identical)."""
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+    local_content = Path(file).read_text(encoding="utf-8")
+
+    if not force:
+        remote_content = get_readme(ref.repo_id, token=state.token)
+        if remote_content is not None and remote_content == local_content:
+            if state.json_output:
+                click.echo(
+                    json.dumps(
+                        {
+                            "ok": True,
+                            "repo_id": ref.repo_id,
+                            "synced": False,
+                            "reason": "identical",
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                click.echo(f"  ✓ README.md already up-to-date on {ref.repo_id} (no upload needed)")
+            return
+
+    try:
+        upload_readme(ref.repo_id, content=local_content, token=state.token, commit_message=message)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(
+            json.dumps(
+                {"ok": True, "repo_id": ref.repo_id, "synced": True, "source": file}, indent=2
+            )
+        )
+    else:
+        click.echo(f"  ✓ README.md synced to {ref.repo_id} from {file}")

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/secrets_cmds.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/secrets_cmds.py
@@ -1,0 +1,171 @@
+"""secrets command group — set, delete, list (manifest-only).
+
+IMPORTANT: HfApi has no get_space_secrets method. Secrets are write-only
+by design (HF security model). The 'list' subcommand reads from a local
+manifest file only and explicitly documents this limitation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+from cli_anything.hf_spaces.core.space import SpaceRef
+from cli_anything.hf_spaces.utils.hf_backend import (HfBackendError,
+                                                     delete_secret, set_secret)
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.group("secrets", context_settings=CONTEXT_SETTINGS)
+def secrets() -> None:
+    """Secret management — set, delete, list (manifest-only).
+
+    NOTE: HuggingFace does not allow reading secret values or names via API.
+    The 'list' command reads from a local manifest file only.
+    """
+
+
+@secrets.command("set")
+@click.argument("space_id")
+@click.argument("key")
+@click.option(
+    "--value",
+    default=None,
+    help="Secret value. If omitted, prompted interactively (recommended).",
+)
+@click.pass_context
+def secrets_set(ctx: click.Context, space_id: str, key: str, value: Optional[str]) -> None:
+    """Set secret KEY on SPACE_ID.
+
+    Value is prompted interactively if --value is not supplied.
+    The value is used in-memory only and never written to disk.
+    """
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+
+    if value is None:
+        value = click.prompt(f"  Value for {key}", hide_input=True, confirmation_prompt=True)
+
+    try:
+        set_secret(ref.repo_id, key=key, value=value, token=state.token)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(
+            json.dumps(
+                {"ok": True, "action": "secret_set", "repo_id": ref.repo_id, "key": key},
+                indent=2,
+            )
+        )
+    else:
+        click.echo(f"  ✓ Secret set: {key} on {ref.repo_id}")
+
+
+@secrets.command("delete")
+@click.argument("space_id")
+@click.argument("key")
+@click.option("--confirm", is_flag=True, default=False, help="Confirm the deletion.")
+@click.pass_context
+def secrets_delete(ctx: click.Context, space_id: str, key: str, confirm: bool) -> None:
+    """Delete secret KEY from SPACE_ID. Requires --confirm."""
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+
+    if not confirm:
+        click.echo(
+            f"\n  [STOP] Confirm before proceeding:\n"
+            f"\n  Action : delete secret\n"
+            f"  Target : {ref.repo_id}\n"
+            f"  Key    : {key}\n"
+            f"\n  This is irreversible. Pass --confirm to execute.\n"
+        )
+        return
+
+    try:
+        delete_secret(ref.repo_id, key=key, token=state.token)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(
+            json.dumps(
+                {
+                    "ok": True,
+                    "action": "secret_delete",
+                    "repo_id": ref.repo_id,
+                    "key": key,
+                },
+                indent=2,
+            )
+        )
+    else:
+        click.echo(f"  ✓ Secret deleted: {key} from {ref.repo_id}")
+
+
+@secrets.command("list")
+@click.option(
+    "--manifest",
+    "manifest_path",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to manifest JSON. Reads secret key names from manifest only.",
+)
+@click.pass_context
+def secrets_list(ctx: click.Context, manifest_path: Optional[str]) -> None:
+    """List secret key names from a local manifest file.
+
+    LIMITATION: The HuggingFace API does not allow reading secret names or
+    values after they are written. This command reads from a local manifest
+    file only. If no manifest is provided, an empty list is returned.
+
+    Use 'manifest init' to create a manifest that tracks secret key names.
+    """
+    state = ctx.obj
+
+    key_names: list = []
+    source = "none"
+
+    if manifest_path:
+        try:
+            from cli_anything.hf_spaces.core.manifest import ManifestSpec
+
+            spec = ManifestSpec.load(Path(manifest_path))
+            key_names = list(spec.secrets)
+            source = manifest_path
+        except Exception as exc:
+            click.echo(f"  ✗ Could not read manifest: {exc}", err=True)
+            sys.exit(1)
+
+    warning = (
+        "HuggingFace API does not support reading secret names. "
+        "Results are from local manifest only."
+    )
+
+    if state.json_output:
+        click.echo(
+            json.dumps(
+                {
+                    "ok": True,
+                    "source": source,
+                    "warning": warning,
+                    "secrets": key_names,
+                },
+                indent=2,
+            )
+        )
+    else:
+        click.echo(f"\n  ⚠  {warning}\n")
+        if key_names:
+            click.echo(f"  Secrets in manifest ({source}):")
+            for k in key_names:
+                click.echo(f"    • {k}")
+        else:
+            click.echo("  No secrets found in manifest (or no manifest provided).")
+        click.echo()

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/session_cmds.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/session_cmds.py
@@ -1,0 +1,116 @@
+"""session command group — list, show, delete."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+
+import click
+from cli_anything.hf_spaces.core import session as session_store
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.group("session", context_settings=CONTEXT_SETTINGS)
+def session() -> None:
+    """Session management — list, show, delete."""
+
+
+@session.command("list")
+@click.pass_context
+def session_list(ctx: click.Context) -> None:
+    """List all saved sessions."""
+    state = ctx.obj
+    sessions = session_store.list_sessions()
+
+    if state.json_output:
+        click.echo(
+            json.dumps(
+                {
+                    "ok": True,
+                    "sessions": [
+                        {
+                            "session_id": s.session_id,
+                            "space_id": s.space_id,
+                            "updated_at": s.updated_at,
+                            "history_count": len(s.history),
+                        }
+                        for s in sessions
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    if not sessions:
+        click.echo("  No sessions found.")
+        return
+
+    from cli_anything.hf_spaces.utils.repl_skin import ReplSkin
+
+    skin = ReplSkin("hf_spaces")
+    skin.table(
+        ["session_id", "space_id", "updated_at", "history"],
+        [
+            [
+                s.session_id[:8] + "...",
+                s.space_id or "",
+                _fmt_ts(s.updated_at),
+                str(len(s.history)),
+            ]
+            for s in sessions
+        ],
+    )
+    click.echo()
+
+
+@session.command("show")
+@click.argument("session_id")
+@click.pass_context
+def session_show(ctx: click.Context, session_id: str) -> None:
+    """Show details for SESSION_ID."""
+    state = ctx.obj
+    try:
+        s = session_store.load(session_id)
+    except FileNotFoundError:
+        click.echo(f"  ✗ Session not found: {session_id}", err=True)
+        sys.exit(1)
+    except ValueError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(json.dumps({"ok": True, "session": s.to_dict()}, indent=2))
+    else:
+        click.echo(f"\n  session_id  : {s.session_id}")
+        click.echo(f"  space_id    : {s.space_id or 'none'}")
+        click.echo(f"  created_at  : {_fmt_ts(s.created_at)}")
+        click.echo(f"  updated_at  : {_fmt_ts(s.updated_at)}")
+        click.echo(f"  history     : {len(s.history)} entries")
+        click.echo()
+
+
+@session.command("delete")
+@click.argument("session_id")
+@click.pass_context
+def session_delete(ctx: click.Context, session_id: str) -> None:
+    """Delete SESSION_ID."""
+    state = ctx.obj
+    deleted = session_store.delete(session_id)
+    if not deleted:
+        click.echo(f"  ✗ Session not found: {session_id}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(json.dumps({"ok": True, "deleted": session_id}, indent=2))
+    else:
+        click.echo(f"  ✓ Session deleted: {session_id}")
+
+
+def _fmt_ts(ts: float) -> str:
+    """Format a Unix timestamp as a human-readable string."""
+    import datetime
+
+    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/space_cmds.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/space_cmds.py
@@ -1,0 +1,262 @@
+"""space command group — info, list, pause, restart, duplicate."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import click
+from cli_anything.hf_spaces.core.space import SpaceRef
+from cli_anything.hf_spaces.utils.hf_backend import (HfBackendError,
+                                                     duplicate_space,
+                                                     get_space_info,
+                                                     list_spaces, pause_space,
+                                                     restart_space)
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+def _state(ctx: click.Context):
+    return ctx.find_object(object)  # returns CliState
+
+
+@click.group("space", context_settings=CONTEXT_SETTINGS)
+def space() -> None:
+    """Space lifecycle — info, list, pause, restart, duplicate."""
+
+
+# ---------------------------------------------------------------------------
+# space info
+# ---------------------------------------------------------------------------
+
+
+@space.command("info")
+@click.argument("space_id")
+@click.pass_context
+def space_info(ctx: click.Context, space_id: str) -> None:
+    """Show runtime info for SPACE_ID (owner/name or full URL)."""
+    state = ctx.obj
+    try:
+        ref = SpaceRef.parse(space_id)
+        info = get_space_info(ref.repo_id, token=state.token)
+    except HfBackendError as exc:
+        import sys
+
+        if state.json_output:
+            click.echo(json.dumps({"ok": False, "error": str(exc)}, indent=2), err=True)
+        else:
+            click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    runtime = getattr(info, "runtime", None)
+    stage = str(getattr(runtime, "stage", "unknown")) if runtime else "unknown"
+    hw = getattr(runtime, "hardware", None)
+    hw_current = (
+        str(hw.current.value if hasattr(hw.current, "value") else hw.current)
+        if hw and getattr(hw, "current", None)
+        else "unknown"
+    )
+    hw_requested = (
+        str(hw.requested.value if hasattr(hw.requested, "value") else hw.requested)
+        if hw and getattr(hw, "requested", None)
+        else None
+    )
+
+    payload = {
+        "ok": True,
+        "repo_id": ref.repo_id,
+        "url": ref.url,
+        "stage": stage,
+        "hardware_current": hw_current,
+        "hardware_requested": hw_requested,
+        "private": getattr(info, "private", None),
+        "sdk": getattr(info, "sdk", None),
+    }
+
+    if state.json_output:
+        click.echo(json.dumps(payload, indent=2))
+    else:
+        click.echo(f"\n  Space: {ref.url}")
+        click.echo(f"  Stage        : {stage}")
+        click.echo(f"  Hardware     : {hw_current}")
+        if hw_requested:
+            click.echo(f"  HW requested : {hw_requested}")
+        click.echo(f"  Private      : {payload['private']}")
+        click.echo(f"  SDK          : {payload['sdk'] or 'unknown'}")
+        click.echo()
+
+
+# ---------------------------------------------------------------------------
+# space list
+# ---------------------------------------------------------------------------
+
+
+@space.command("list")
+@click.option("--author", default=None, help="Filter by author/org.")
+@click.option("--search", default=None, help="Search query.")
+@click.option("--limit", default=20, show_default=True, help="Max results.")
+@click.pass_context
+def space_list(
+    ctx: click.Context,
+    author: Optional[str],
+    search: Optional[str],
+    limit: int,
+) -> None:
+    """List HuggingFace Spaces."""
+    state = ctx.obj
+    try:
+        spaces = list_spaces(author=author, search=search, token=state.token, limit=limit)
+    except HfBackendError as exc:
+        import sys
+
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    rows = []
+    for s in spaces:
+        rid = getattr(s, "id", "")
+        runtime = getattr(s, "runtime", None)
+        stage = str(getattr(runtime, "stage", "")) if runtime else ""
+        rows.append({"repo_id": rid, "stage": stage})
+
+    if state.json_output:
+        click.echo(json.dumps({"ok": True, "spaces": rows}, indent=2))
+    else:
+        if not rows:
+            click.echo("  No spaces found.")
+            return
+        from cli_anything.hf_spaces.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin("hf_spaces")
+        skin.table(
+            ["repo_id", "stage"],
+            [[r["repo_id"], r["stage"]] for r in rows],
+        )
+        click.echo()
+
+
+# ---------------------------------------------------------------------------
+# space pause
+# ---------------------------------------------------------------------------
+
+
+@space.command("pause")
+@click.argument("space_id")
+@click.option("--confirm", is_flag=True, default=False, help="Confirm the pause.")
+@click.pass_context
+def space_pause(ctx: click.Context, space_id: str, confirm: bool) -> None:
+    """Pause SPACE_ID. Requires --confirm."""
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+
+    if not confirm:
+        click.echo(
+            f"\n  [STOP] Confirm before proceeding:\n"
+            f"\n  Action : pause Space\n"
+            f"  Target : {ref.repo_id}\n"
+            f"\n  Pass --confirm to execute.\n"
+        )
+        return
+
+    try:
+        pause_space(ref.repo_id, token=state.token)
+    except HfBackendError as exc:
+        import sys
+
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(json.dumps({"ok": True, "action": "pause", "repo_id": ref.repo_id}))
+    else:
+        click.echo(f"  ✓ Space paused: {ref.repo_id}")
+
+
+# ---------------------------------------------------------------------------
+# space restart
+# ---------------------------------------------------------------------------
+
+
+@space.command("restart")
+@click.argument("space_id")
+@click.pass_context
+def space_restart(ctx: click.Context, space_id: str) -> None:
+    """Warm-restart SPACE_ID."""
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+    try:
+        restart_space(ref.repo_id, token=state.token)
+    except HfBackendError as exc:
+        import sys
+
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(json.dumps({"ok": True, "action": "restart", "repo_id": ref.repo_id}))
+    else:
+        click.echo(f"  ✓ Space restarted: {ref.repo_id}")
+
+
+# ---------------------------------------------------------------------------
+# space duplicate
+# ---------------------------------------------------------------------------
+
+
+@space.command("duplicate")
+@click.argument("from_id")
+@click.argument("to_id")
+@click.option(
+    "--private/--public",
+    default=True,
+    show_default=True,
+    help="Make the new Space private (default) or public.",
+)
+@click.option(
+    "--exist-ok",
+    is_flag=True,
+    default=False,
+    help="Don't error if destination already exists.",
+)
+@click.pass_context
+def space_duplicate(
+    ctx: click.Context,
+    from_id: str,
+    to_id: str,
+    private: bool,
+    exist_ok: bool,
+) -> None:
+    """Duplicate FROM_ID to TO_ID."""
+    state = ctx.obj
+    from_ref = SpaceRef.parse(from_id)
+    to_ref = SpaceRef.parse(to_id)
+    try:
+        info = duplicate_space(
+            from_id=from_ref.repo_id,
+            to_id=to_ref.repo_id,
+            private=private,
+            exist_ok=exist_ok,
+            token=state.token,
+        )
+    except HfBackendError as exc:
+        import sys
+
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    new_id = getattr(info, "id", to_ref.repo_id)
+    if state.json_output:
+        click.echo(
+            json.dumps(
+                {
+                    "ok": True,
+                    "action": "duplicate",
+                    "from": from_ref.repo_id,
+                    "to": new_id,
+                    "private": private,
+                },
+                indent=2,
+            )
+        )
+    else:
+        click.echo(f"  ✓ Duplicated {from_ref.repo_id} → {new_id} (private={private})")

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/vars_cmds.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/commands/vars_cmds.py
@@ -1,0 +1,155 @@
+"""vars command group — list, get, set, delete."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Optional
+
+import click
+from cli_anything.hf_spaces.core.secrets import SecretsBundle
+from cli_anything.hf_spaces.core.space import SpaceRef
+from cli_anything.hf_spaces.utils.hf_backend import (HfBackendError,
+                                                     delete_variable,
+                                                     get_variables,
+                                                     set_variable)
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.group("vars", context_settings=CONTEXT_SETTINGS)
+def vars() -> None:
+    """Environment variable management — list, get, set, delete."""
+
+
+@vars.command("list")
+@click.argument("space_id")
+@click.pass_context
+def vars_list(ctx: click.Context, space_id: str) -> None:
+    """List all environment variables for SPACE_ID."""
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+    try:
+        raw = get_variables(ref.repo_id, token=state.token)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    entries = SecretsBundle.variables_from_api(raw)
+
+    if state.json_output:
+        click.echo(
+            json.dumps(
+                {
+                    "ok": True,
+                    "repo_id": ref.repo_id,
+                    "variables": [e.to_dict() for e in entries],
+                },
+                indent=2,
+            )
+        )
+    else:
+        if not entries:
+            click.echo(f"  No variables set on {ref.repo_id}.")
+            return
+        from cli_anything.hf_spaces.utils.repl_skin import ReplSkin
+
+        skin = ReplSkin("hf_spaces")
+        skin.table(
+            ["key", "value", "description"],
+            [[e.key, e.value, e.description or ""] for e in entries],
+        )
+        click.echo()
+
+
+@vars.command("get")
+@click.argument("space_id")
+@click.argument("key")
+@click.pass_context
+def vars_get(ctx: click.Context, space_id: str, key: str) -> None:
+    """Get the value of variable KEY on SPACE_ID."""
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+    try:
+        raw = get_variables(ref.repo_id, token=state.token)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if key not in raw:
+        click.echo(f"  ✗ Variable '{key}' not found on {ref.repo_id}.", err=True)
+        sys.exit(1)
+
+    value = raw[key].get("value", "")
+    if state.json_output:
+        click.echo(
+            json.dumps(
+                {"ok": True, "repo_id": ref.repo_id, "key": key, "value": value},
+                indent=2,
+            )
+        )
+    else:
+        click.echo(f"  {key} = {value}")
+
+
+@vars.command("set")
+@click.argument("space_id")
+@click.argument("key")
+@click.argument("value")
+@click.pass_context
+def vars_set(ctx: click.Context, space_id: str, key: str, value: str) -> None:
+    """Set variable KEY=VALUE on SPACE_ID."""
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+    try:
+        set_variable(ref.repo_id, key=key, value=value, token=state.token)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(
+            json.dumps(
+                {"ok": True, "repo_id": ref.repo_id, "key": key, "value": value},
+                indent=2,
+            )
+        )
+    else:
+        click.echo(f"  ✓ Variable set: {key}={value} on {ref.repo_id}")
+
+
+@vars.command("delete")
+@click.argument("space_id")
+@click.argument("key")
+@click.option("--confirm", is_flag=True, default=False, help="Confirm deletion.")
+@click.pass_context
+def vars_delete(ctx: click.Context, space_id: str, key: str, confirm: bool) -> None:
+    """Delete variable KEY from SPACE_ID. Requires --confirm."""
+    state = ctx.obj
+    ref = SpaceRef.parse(space_id)
+
+    if not confirm:
+        click.echo(
+            f"\n  [STOP] Confirm before proceeding:\n"
+            f"\n  Action : delete variable\n"
+            f"  Target : {ref.repo_id}\n"
+            f"  Key    : {key}\n"
+            f"\n  Pass --confirm to execute.\n"
+        )
+        return
+
+    try:
+        delete_variable(ref.repo_id, key=key, token=state.token)
+    except HfBackendError as exc:
+        click.echo(f"  ✗ {exc}", err=True)
+        sys.exit(1)
+
+    if state.json_output:
+        click.echo(
+            json.dumps(
+                {"ok": True, "action": "var_delete", "repo_id": ref.repo_id, "key": key},
+                indent=2,
+            )
+        )
+    else:
+        click.echo(f"  ✓ Variable deleted: {key} from {ref.repo_id}")

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/core/hardware.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/core/hardware.py
@@ -1,0 +1,133 @@
+"""
+HuggingFace Spaces hardware tier definitions.
+
+Uses huggingface_hub.SpaceHardware enum as the authoritative source.
+The cost table is a reference snapshot (2024 pricing) — never scraped at runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+try:
+    from huggingface_hub import \
+        SpaceHardware as _HfSpaceHardware  # type: ignore[import-untyped]
+
+    HARDWARE_ENUM_AVAILABLE = True
+except ImportError:
+    _HfSpaceHardware = None  # type: ignore[assignment]
+    HARDWARE_ENUM_AVAILABLE = False
+
+
+# Canonical hardware slug list — kept in sync with huggingface_hub.SpaceHardware.
+# Used for validation when the SDK is not installed.
+HARDWARE_SLUGS: tuple[str, ...] = (
+    "cpu-basic",
+    "cpu-upgrade",
+    "cpu-xl",
+    "zero-a10g",
+    "t4-small",
+    "t4-medium",
+    "l4x1",
+    "l4x4",
+    "l40sx1",
+    "l40sx4",
+    "l40sx8",
+    "a10g-small",
+    "a10g-large",
+    "a10g-largex2",
+    "a10g-largex4",
+    "a100-large",
+    "h100",
+    "h100x8",
+)
+
+# Reference cost snapshot (USD / hour, community tier pricing, 2024).
+# These values are informational only — verify on https://huggingface.co/pricing before billing.
+HARDWARE_COST_PER_HOUR: Dict[str, Optional[float]] = {
+    "cpu-basic": 0.00,
+    "cpu-upgrade": 0.03,
+    "cpu-xl": 0.05,
+    "zero-a10g": 0.00,  # ZeroGPU — shared quota, not billed per-hour
+    "t4-small": 0.60,
+    "t4-medium": 0.90,
+    "l4x1": 0.80,
+    "l4x4": 3.15,
+    "l40sx1": 1.80,
+    "l40sx4": 7.20,
+    "l40sx8": 14.40,
+    "a10g-small": 1.05,
+    "a10g-large": 3.15,
+    "a10g-largex2": 5.70,
+    "a10g-largex4": 10.80,
+    "a100-large": 10.80,
+    "h100": 10.80,
+    "h100x8": 79.99,
+}
+
+HARDWARE_DESCRIPTIONS: Dict[str, str] = {
+    "cpu-basic": "2 vCPU / 16 GB RAM — free tier",
+    "cpu-upgrade": "8 vCPU / 32 GB RAM",
+    "cpu-xl": "32 vCPU / 128 GB RAM",
+    "zero-a10g": "NVIDIA A10G via ZeroGPU shared quota (free)",
+    "t4-small": "NVIDIA T4 / 4 vCPU / 15 GB RAM",
+    "t4-medium": "NVIDIA T4 / 8 vCPU / 30 GB RAM",
+    "l4x1": "NVIDIA L4 × 1 / 8 vCPU / 30 GB RAM",
+    "l4x4": "NVIDIA L4 × 4 / 48 vCPU / 186 GB RAM",
+    "l40sx1": "NVIDIA L40S × 1",
+    "l40sx4": "NVIDIA L40S × 4",
+    "l40sx8": "NVIDIA L40S × 8",
+    "a10g-small": "NVIDIA A10G / 4 vCPU / 15 GB RAM",
+    "a10g-large": "NVIDIA A10G / 12 vCPU / 46 GB RAM",
+    "a10g-largex2": "NVIDIA A10G × 2",
+    "a10g-largex4": "NVIDIA A10G × 4",
+    "a100-large": "NVIDIA A100 / 12 vCPU / 142 GB RAM",
+    "h100": "NVIDIA H100 / 16 vCPU / 80 GB HBM3",
+    "h100x8": "NVIDIA H100 × 8 (node)",
+}
+
+
+def validate_hardware_slug(slug: str) -> str:
+    """
+    Validate a hardware slug.
+
+    Returns the slug unchanged if valid.
+    Raises ValueError with a helpful message if invalid.
+    """
+    if slug not in HARDWARE_SLUGS:
+        valid = ", ".join(HARDWARE_SLUGS)
+        raise ValueError(f"Unknown hardware tier '{slug}'. Valid options: {valid}")
+    return slug
+
+
+def hardware_to_sdk_enum(slug: str) -> object:
+    """
+    Convert a slug string to the huggingface_hub SpaceHardware enum value.
+
+    Raises ImportError if huggingface_hub is not installed.
+    Raises ValueError if the slug is invalid.
+    """
+    if not HARDWARE_ENUM_AVAILABLE or _HfSpaceHardware is None:
+        raise ImportError("huggingface_hub is required. Install with: pip install huggingface_hub")
+    validate_hardware_slug(slug)
+    return _HfSpaceHardware(slug)
+
+
+def hardware_table_rows() -> list[dict]:
+    """
+    Return a list of dicts suitable for tabular display.
+
+    Each dict has keys: slug, cost_usd_hr, description.
+    """
+    rows = []
+    for slug in HARDWARE_SLUGS:
+        cost = HARDWARE_COST_PER_HOUR.get(slug)
+        cost_str = "free" if cost == 0.00 else (f"${cost:.2f}" if cost is not None else "N/A")
+        rows.append(
+            {
+                "slug": slug,
+                "cost_usd_hr": cost_str,
+                "description": HARDWARE_DESCRIPTIONS.get(slug, ""),
+            }
+        )
+    return rows

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/core/manifest.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/core/manifest.py
@@ -1,0 +1,335 @@
+"""
+Manifest plan/apply model for cli-anything-hf-spaces.
+
+A manifest declares the *desired* state of a HuggingFace Space.
+plan() diffs desired vs actual and returns a list of ChangeItem objects.
+apply() executes the changes after STOP-AND-SHOW confirmation.
+
+Token is never stored in the manifest file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from cli_anything.hf_spaces.core.hardware import (HARDWARE_SLUGS,
+                                                  validate_hardware_slug)
+
+MANIFEST_SCHEMA = "1"
+DEFAULT_MANIFEST_NAME = "hf-space-manifest.json"
+
+
+# ---------------------------------------------------------------------------
+# Change model
+# ---------------------------------------------------------------------------
+
+
+class ChangeKind(str, Enum):
+    HARDWARE = "hardware"
+    SLEEP_TIME = "sleep_time"
+    VARIABLE_SET = "variable_set"
+    VARIABLE_DELETE = "variable_delete"
+    SECRET_SET = "secret_set"  # value never logged
+    README_SYNC = "readme_sync"
+
+
+@dataclass
+class ChangeItem:
+    kind: ChangeKind
+    key: Optional[str]  # variable/secret key, or None for hardware/sleep/readme
+    current: Optional[str]  # current value (None for secrets — unreadable)
+    desired: Optional[str]  # desired value (None for secret deletes)
+    destructive: bool = False  # True → requires --confirm
+
+    def summary(self) -> str:
+        """Human-readable one-liner for STOP-AND-SHOW display."""
+        if self.kind == ChangeKind.HARDWARE:
+            return f"  hardware : {self.current or '?'} → {self.desired}"
+        if self.kind == ChangeKind.SLEEP_TIME:
+            return f"  sleep_time : {self.current or '?'} → {self.desired}"
+        if self.kind == ChangeKind.VARIABLE_SET:
+            return f"  var set  : {self.key} = {self.desired!r}"
+        if self.kind == ChangeKind.VARIABLE_DELETE:
+            return f"  var del  : {self.key}  [destructive]"
+        if self.kind == ChangeKind.SECRET_SET:
+            return f"  secret   : {self.key} = <value hidden>"
+        if self.kind == ChangeKind.README_SYNC:
+            return f"  readme   : {self.current or 'remote'} → {self.desired or 'local file'}"
+        return f"  {self.kind} : {self.key}"
+
+    def to_dict(self) -> dict:
+        return {
+            "kind": self.kind.value,
+            "key": self.key,
+            "current": self.current,
+            "desired": self.desired,
+            "destructive": self.destructive,
+        }
+
+
+# ---------------------------------------------------------------------------
+# ManifestSpec dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ManifestSpec:
+    """Desired state for a HuggingFace Space."""
+
+    space_id: str  # owner/name
+    hardware: Optional[str] = None  # SpaceHardware slug
+    sleep_time: Optional[int] = None  # seconds; -1 = never
+    variables: Dict[str, str] = field(default_factory=dict)
+    # Secrets: list of key names only. Values supplied interactively at apply time.
+    secrets: List[str] = field(default_factory=list)
+    readme_path: Optional[str] = None  # local path to README.md
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def validate(self) -> None:
+        """
+        Raise ValueError if the manifest contains invalid values.
+        """
+        if not self.space_id or "/" not in self.space_id:
+            raise ValueError(f"space_id must be 'owner/name', got: {self.space_id!r}")
+        if self.hardware is not None:
+            validate_hardware_slug(self.hardware)
+        if self.sleep_time is not None:
+            if not isinstance(self.sleep_time, int) or (self.sleep_time < -1):
+                raise ValueError(
+                    f"sleep_time must be -1 (never) or a non-negative integer, got: {self.sleep_time!r}"
+                )
+        if self.readme_path is not None:
+            p = Path(self.readme_path)
+            if not p.exists():
+                raise ValueError(f"readme_path does not exist: {self.readme_path!r}")
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "schema_version": MANIFEST_SCHEMA,
+            "space_id": self.space_id,
+        }
+        if self.hardware is not None:
+            d["hardware"] = self.hardware
+        if self.sleep_time is not None:
+            d["sleep_time"] = self.sleep_time
+        if self.variables:
+            d["variables"] = self.variables
+        if self.secrets:
+            d["secrets"] = self.secrets
+        if self.readme_path is not None:
+            d["readme_path"] = self.readme_path
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ManifestSpec":
+        schema = data.get("schema_version", "1")
+        if schema != MANIFEST_SCHEMA:
+            raise ValueError(
+                f"Unsupported manifest schema_version: {schema!r}. Expected: {MANIFEST_SCHEMA!r}"
+            )
+        return cls(
+            space_id=data["space_id"],
+            hardware=data.get("hardware"),
+            sleep_time=data.get("sleep_time"),
+            variables=data.get("variables", {}),
+            secrets=data.get("secrets", []),
+            readme_path=data.get("readme_path"),
+        )
+
+    @classmethod
+    def load(cls, path: Path) -> "ManifestSpec":
+        """Load and parse a manifest JSON file."""
+        if not path.exists():
+            raise FileNotFoundError(f"Manifest not found: {path}")
+        with path.open("r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+        spec = cls.from_dict(raw)
+        spec.validate()
+        return spec
+
+    def save(self, path: Path) -> None:
+        """Atomically write the manifest to *path*."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_fd, tmp_name = tempfile.mkstemp(
+            dir=str(path.parent), prefix=".manifest-", suffix=".json"
+        )
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                try:
+                    import fcntl
+
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                except (ImportError, OSError):
+                    pass
+                json.dump(self.to_dict(), fh, indent=2, ensure_ascii=False)
+                fh.write("\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_name, path)
+        except Exception:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Plan helpers
+# ---------------------------------------------------------------------------
+
+
+def plan_hardware(
+    desired: Optional[str],
+    current_hardware: Optional[str],
+) -> Optional[ChangeItem]:
+    """Return a ChangeItem if hardware needs to change, else None."""
+    if desired is None:
+        return None
+    if desired == current_hardware:
+        return None
+    return ChangeItem(
+        kind=ChangeKind.HARDWARE,
+        key=None,
+        current=current_hardware,
+        desired=desired,
+        destructive=True,  # billing impact — always STOP-AND-SHOW
+    )
+
+
+def plan_sleep_time(
+    desired: Optional[int],
+    current_sleep_time: Optional[int],
+) -> Optional[ChangeItem]:
+    """Return a ChangeItem if sleep_time needs to change, else None."""
+    if desired is None:
+        return None
+    if desired == current_sleep_time:
+        return None
+    return ChangeItem(
+        kind=ChangeKind.SLEEP_TIME,
+        key=None,
+        current=str(current_sleep_time) if current_sleep_time is not None else None,
+        desired=str(desired),
+        destructive=False,
+    )
+
+
+def plan_variables(
+    desired: Dict[str, str],
+    current: Dict[str, str],
+) -> List[ChangeItem]:
+    """
+    Return ChangeItems for variable additions/updates and deletions.
+
+    Variables present in *current* but absent in *desired* are flagged for
+    deletion (destructive=True).
+    """
+    changes: List[ChangeItem] = []
+    for key, value in desired.items():
+        if current.get(key) != value:
+            changes.append(
+                ChangeItem(
+                    kind=ChangeKind.VARIABLE_SET,
+                    key=key,
+                    current=current.get(key),
+                    desired=value,
+                    destructive=False,
+                )
+            )
+    for key in current:
+        if key not in desired:
+            changes.append(
+                ChangeItem(
+                    kind=ChangeKind.VARIABLE_DELETE,
+                    key=key,
+                    current=current[key],
+                    desired=None,
+                    destructive=True,
+                )
+            )
+    return changes
+
+
+def plan_secrets(desired_keys: List[str]) -> List[ChangeItem]:
+    """
+    Return ChangeItems for all desired secret keys.
+
+    Because HfApi cannot enumerate existing secrets, we always mark them as
+    needing re-apply. The value is never stored or logged.
+    """
+    return [
+        ChangeItem(
+            kind=ChangeKind.SECRET_SET,
+            key=key,
+            current=None,  # unreadable by design
+            desired="<provided at apply time>",
+            destructive=False,
+        )
+        for key in desired_keys
+    ]
+
+
+def plan_readme(
+    desired_path: Optional[str],
+    current_readme: Optional[str],
+) -> Optional[ChangeItem]:
+    """Return a ChangeItem if the local README differs from remote, else None."""
+    if desired_path is None:
+        return None
+    p = Path(desired_path)
+    if not p.exists():
+        return None
+    local_content = p.read_text(encoding="utf-8")
+    if local_content == current_readme:
+        return None
+    return ChangeItem(
+        kind=ChangeKind.README_SYNC,
+        key=None,
+        current="remote",
+        desired=str(p),
+        destructive=False,
+    )
+
+
+def build_plan(
+    spec: ManifestSpec,
+    current_hardware: Optional[str],
+    current_sleep_time: Optional[int],
+    current_variables: Dict[str, str],
+    current_readme: Optional[str],
+) -> List[ChangeItem]:
+    """
+    Diff *spec* (desired) against current state and return ordered ChangeItems.
+    """
+    changes: List[ChangeItem] = []
+
+    hw = plan_hardware(spec.hardware, current_hardware)
+    if hw:
+        changes.append(hw)
+
+    st = plan_sleep_time(spec.sleep_time, current_sleep_time)
+    if st:
+        changes.append(st)
+
+    changes.extend(plan_variables(spec.variables, current_variables))
+    changes.extend(plan_secrets(spec.secrets))
+
+    readme = plan_readme(spec.readme_path, current_readme)
+    if readme:
+        changes.append(readme)
+
+    return changes

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/core/secrets.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/core/secrets.py
@@ -1,0 +1,137 @@
+"""
+Dataclasses for Space secrets and variables.
+
+Secrets: write-only via HfApi. Names tracked in local manifest only.
+Variables: readable via get_space_variables(), stored as key/value pairs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class SecretEntry:
+    """
+    Represents a secret key tracked in the local manifest.
+
+    The *value* is NEVER stored to disk.  It is held in-memory only during
+    the apply cycle and discarded immediately after the HfApi call returns.
+    """
+
+    key: str
+    description: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        """Serialise to manifest-safe dict (no value field)."""
+        d: dict = {"key": self.key}
+        if self.description:
+            d["description"] = self.description
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SecretEntry":
+        if isinstance(data, str):
+            # Accept bare string as key shorthand
+            return cls(key=data)
+        return cls(
+            key=data["key"],
+            description=data.get("description"),
+        )
+
+    def __str__(self) -> str:
+        return self.key
+
+
+@dataclass
+class VariableEntry:
+    """
+    Represents a Space environment variable (non-secret).
+
+    Values ARE readable via HfApi.get_space_variables() and are stored
+    in the manifest.
+    """
+
+    key: str
+    value: str
+    description: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        d: dict = {"key": self.key, "value": self.value}
+        if self.description:
+            d["description"] = self.description
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "VariableEntry":
+        return cls(
+            key=data["key"],
+            value=data["value"],
+            description=data.get("description"),
+        )
+
+    def __str__(self) -> str:
+        return f"{self.key}={self.value}"
+
+
+@dataclass
+class SecretsBundle:
+    """
+    Holds both secrets (name-only) and variables (name+value) for a Space.
+    """
+
+    secrets: List[SecretEntry] = field(default_factory=list)
+    variables: List[VariableEntry] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # Lookup helpers
+    # ------------------------------------------------------------------
+
+    def get_variable(self, key: str) -> Optional[VariableEntry]:
+        for v in self.variables:
+            if v.key == key:
+                return v
+        return None
+
+    def has_secret(self, key: str) -> bool:
+        return any(s.key == key for s in self.secrets)
+
+    # ------------------------------------------------------------------
+    # Dict helpers from HfApi response format
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def variables_from_api(cls, api_response: Dict[str, dict]) -> List[VariableEntry]:
+        """
+        Convert the dict returned by ``HfApi.get_space_variables`` to a list
+        of ``VariableEntry``.
+
+        HfApi response shape: ``{"KEY": {"value": "...", "description": "..."}}``
+        """
+        entries = []
+        for key, meta in api_response.items():
+            entries.append(
+                VariableEntry(
+                    key=key,
+                    value=meta.get("value", ""),
+                    description=meta.get("description"),
+                )
+            )
+        return entries
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        return {
+            "secrets": [s.to_dict() for s in self.secrets],
+            "variables": [v.to_dict() for v in self.variables],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SecretsBundle":
+        secrets = [SecretEntry.from_dict(s) for s in data.get("secrets", [])]
+        variables = [VariableEntry.from_dict(v) for v in data.get("variables", [])]
+        return cls(secrets=secrets, variables=variables)

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/core/session.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/core/session.py
@@ -1,0 +1,190 @@
+"""
+Session management for cli-anything-hf-spaces.
+
+Sessions track recent Space interactions for context within a CLI session.
+Token is NEVER stored in session JSON — it is in-memory only.
+
+Uses _locked_save_json for atomic writes (POSIX flock + tempfile + os.replace).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Session storage root
+_SESSIONS_DIR = Path.home() / ".cli_anything" / "hf_spaces" / "sessions"
+
+SCHEMA = "1"
+MAX_HISTORY = 50
+
+
+# ---------------------------------------------------------------------------
+# Atomic write helper (verbatim pattern from elementor harness)
+# ---------------------------------------------------------------------------
+
+
+def _locked_save_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=".session-", suffix=".json")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            try:
+                import fcntl
+
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            except (ImportError, OSError):
+                pass
+            json.dump(payload, fh, indent=2, ensure_ascii=False)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Session dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Session:
+    session_id: str
+    created_at: float
+    updated_at: float
+    space_id: Optional[str] = None  # last active space (owner/name)
+    history: List[Dict[str, Any]] = field(default_factory=list)
+
+    # NOTE: token is intentionally absent — never serialised.
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def new(cls, space_id: Optional[str] = None) -> "Session":
+        now = time.time()
+        return cls(
+            session_id=str(uuid.uuid4()),
+            created_at=now,
+            updated_at=now,
+            space_id=space_id,
+        )
+
+    # ------------------------------------------------------------------
+    # History
+    # ------------------------------------------------------------------
+
+    def push_history(self, entry: Dict[str, Any]) -> None:
+        """Append an entry to history, capping at MAX_HISTORY."""
+        entry = dict(entry)
+        entry.setdefault("ts", time.time())
+        self.history.append(entry)
+        if len(self.history) > MAX_HISTORY:
+            self.history = self.history[-MAX_HISTORY:]
+        self.updated_at = time.time()
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema": SCHEMA,
+            "session_id": self.session_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "space_id": self.space_id,
+            "history": self.history,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Session":
+        return cls(
+            session_id=data["session_id"],
+            created_at=data["created_at"],
+            updated_at=data["updated_at"],
+            space_id=data.get("space_id"),
+            history=data.get("history", []),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Storage helpers
+# ---------------------------------------------------------------------------
+
+
+def sessions_dir() -> Path:
+    return _SESSIONS_DIR
+
+
+def session_path(session_id: str) -> Path:
+    return _SESSIONS_DIR / f"{session_id}.json"
+
+
+def save(session: Session) -> None:
+    """Atomically persist a session to disk."""
+    _locked_save_json(session_path(session.session_id), session.to_dict())
+
+
+def load(session_id: str) -> Session:
+    """
+    Load a session by ID.
+
+    Raises:
+        FileNotFoundError: if the session does not exist.
+        ValueError: if the JSON is malformed.
+    """
+    path = session_path(session_id)
+    if not path.exists():
+        raise FileNotFoundError(f"Session '{session_id}' not found at {path}")
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return Session.from_dict(data)
+    except (json.JSONDecodeError, KeyError) as exc:
+        raise ValueError(f"Malformed session file {path}: {exc}") from exc
+
+
+def delete(session_id: str) -> bool:
+    """
+    Delete a session file.
+
+    Returns True if deleted, False if not found.
+    """
+    path = session_path(session_id)
+    if path.exists():
+        path.unlink()
+        return True
+    return False
+
+
+def list_sessions() -> List[Session]:
+    """
+    Return all stored sessions, sorted newest-first by updated_at.
+
+    Silently skips malformed files.
+    """
+    if not _SESSIONS_DIR.exists():
+        return []
+    sessions: List[Session] = []
+    for p in _SESSIONS_DIR.glob("*.json"):
+        try:
+            with p.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            sessions.append(Session.from_dict(data))
+        except Exception:
+            continue
+    sessions.sort(key=lambda s: s.updated_at, reverse=True)
+    return sessions

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/core/space.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/core/space.py
@@ -1,0 +1,114 @@
+"""
+SpaceRef — canonical reference to a HuggingFace Space.
+
+Accepts owner/name slugs or full HF URLs.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# Matches: https://huggingface.co/spaces/owner/name
+_HF_URL_RE = re.compile(r"^https?://huggingface\.co/spaces/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/?$")
+
+# Matches: owner/name
+_SLUG_RE = re.compile(r"^([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$")
+
+
+@dataclass(frozen=True)
+class SpaceRef:
+    """Immutable reference to a HuggingFace Space."""
+
+    owner: str
+    name: str
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def parse(cls, value: str) -> "SpaceRef":
+        """
+        Parse owner/name from a slug or a full HuggingFace Spaces URL.
+
+        Accepted forms:
+          - ``owner/name``
+          - ``https://huggingface.co/spaces/owner/name``
+          - ``https://huggingface.co/spaces/owner/name/``
+
+        Raises:
+            ValueError: if the string cannot be parsed.
+        """
+        value = value.strip()
+
+        m = _HF_URL_RE.match(value)
+        if m:
+            return cls(owner=m.group(1), name=m.group(2))
+
+        m = _SLUG_RE.match(value)
+        if m:
+            return cls(owner=m.group(1), name=m.group(2))
+
+        raise ValueError(
+            f"Cannot parse Space reference '{value}'. "
+            "Expected 'owner/name' or 'https://huggingface.co/spaces/owner/name'."
+        )
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def repo_id(self) -> str:
+        """Return the canonical ``owner/name`` repo_id used by HfApi."""
+        return f"{self.owner}/{self.name}"
+
+    @property
+    def url(self) -> str:
+        """Return the canonical HuggingFace Spaces URL."""
+        return f"https://huggingface.co/spaces/{self.owner}/{self.name}"
+
+    @property
+    def embed_url(self) -> str:
+        """Return the embed URL for the Space."""
+        return f"https://{self.owner}-{self.name}.hf.space"
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        return {"owner": self.owner, "name": self.name, "repo_id": self.repo_id}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SpaceRef":
+        """Reconstruct from a dict produced by ``to_dict``."""
+        if "owner" in data and "name" in data:
+            return cls(owner=data["owner"], name=data["name"])
+        if "repo_id" in data:
+            return cls.parse(data["repo_id"])
+        raise ValueError(f"Cannot reconstruct SpaceRef from dict: {data!r}")
+
+    # ------------------------------------------------------------------
+    # Dunder
+    # ------------------------------------------------------------------
+
+    def __str__(self) -> str:
+        return self.repo_id
+
+    def __repr__(self) -> str:
+        return f"SpaceRef(owner={self.owner!r}, name={self.name!r})"
+
+
+def parse_space_ref(value: str) -> SpaceRef:
+    """Module-level convenience wrapper around ``SpaceRef.parse``."""
+    return SpaceRef.parse(value)
+
+
+def optional_space_ref(value: Optional[str]) -> Optional[SpaceRef]:
+    """Return ``SpaceRef.parse(value)`` or ``None`` if *value* is falsy."""
+    if not value:
+        return None
+    return SpaceRef.parse(value)

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/hf_spaces_cli.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/hf_spaces_cli.py
@@ -1,0 +1,244 @@
+"""
+cli-anything-hf-spaces — HuggingFace Spaces administration CLI.
+
+Entry point for the ``cli-anything-hf-spaces`` command and the
+``python -m cli_anything.hf_spaces`` module invocation.
+
+Token security:
+  - Token supplied via --token is held in-memory only (CliState).
+  - It is NEVER written to disk, logged, or included in session JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Optional
+
+import click
+from cli_anything.hf_spaces.commands.doctor_cmds import doctor
+from cli_anything.hf_spaces.commands.hardware_cmds import hardware
+from cli_anything.hf_spaces.commands.logs_cmds import logs
+from cli_anything.hf_spaces.commands.manifest_cmds import manifest
+from cli_anything.hf_spaces.commands.readme_cmds import readme
+from cli_anything.hf_spaces.commands.secrets_cmds import secrets
+from cli_anything.hf_spaces.commands.session_cmds import session
+from cli_anything.hf_spaces.commands.space_cmds import space
+from cli_anything.hf_spaces.commands.vars_cmds import vars as vars_group
+from cli_anything.hf_spaces.utils.hf_backend import HfBackendError
+
+VERSION = "1.0.0"
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+# ---------------------------------------------------------------------------
+# CliState — shared context object passed via Click's obj mechanism
+# ---------------------------------------------------------------------------
+
+
+class CliState:
+    """Shared state threaded through all Click commands via ``pass_obj``."""
+
+    def __init__(self, json_output: bool = False, token: Optional[str] = None) -> None:
+        self.json_output = json_output
+        # Token is in-memory only — never written to disk or logged.
+        self._token: Optional[str] = token
+
+    @property
+    def token(self) -> Optional[str]:
+        return self._token
+
+    def __repr__(self) -> str:
+        return (
+            f"CliState(json_output={self.json_output}, token=<{'set' if self._token else 'unset'}>)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+
+def emit(state: CliState, payload: Any, *, human: str) -> None:
+    """
+    Print output in either JSON or human-readable form.
+
+    Args:
+        state: Current CliState (controls --json flag).
+        payload: JSON-serialisable object for --json mode.
+        human: Pre-formatted string for human mode.
+    """
+    if state.json_output:
+        click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        click.echo(human)
+
+
+def handle_backend_error(state: CliState, exc: Exception) -> int:
+    """
+    Print a backend error and return exit code 1.
+
+    Always returns 1 so callers can ``sys.exit(handle_backend_error(...))``.
+    """
+    msg = str(exc)
+    if state.json_output:
+        click.echo(json.dumps({"ok": False, "error": msg}, indent=2), err=True)
+    else:
+        click.echo(f"  ✗ {msg}", err=True)
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Root group
+# ---------------------------------------------------------------------------
+
+
+@click.group(
+    context_settings=CONTEXT_SETTINGS,
+    invoke_without_command=True,
+)
+@click.version_option(VERSION, "-V", "--version", prog_name="cli-anything-hf-spaces")
+@click.option("--json", "json_output", is_flag=True, default=False, help="Output as JSON.")
+@click.option(
+    "--token",
+    default=None,
+    envvar="HF_TOKEN",
+    help="HuggingFace token (in-memory only, never written to disk).",
+    show_envvar=True,
+)
+@click.pass_context
+def cli(ctx: click.Context, json_output: bool, token: Optional[str]) -> None:
+    """cli-anything-hf-spaces — HuggingFace Spaces administration.
+
+    Manage Space hardware tiers, secrets, variables, logs, README, and more.
+
+    Auth resolution order:
+      1. --token flag (in-memory only)
+      2. HF_TOKEN environment variable
+      3. ~/.cache/huggingface/token (huggingface-cli login)
+      4. Unauthenticated (public spaces only)
+
+    \b
+    Quick start:
+      hf-spaces space info owner/my-space
+      hf-spaces hardware get owner/my-space
+      hf-spaces hardware set owner/my-space cpu-upgrade
+      hf-spaces vars list owner/my-space
+      hf-spaces secrets set owner/my-space MY_KEY
+      hf-spaces logs run owner/my-space
+      hf-spaces manifest plan ./hf-space-manifest.json
+    """
+    ctx.ensure_object(dict)
+    ctx.obj = CliState(json_output=json_output, token=token)
+
+    if ctx.invoked_subcommand is None:
+        # No subcommand: drop into REPL
+        _run_repl(ctx.obj)
+
+
+# ---------------------------------------------------------------------------
+# REPL
+# ---------------------------------------------------------------------------
+
+
+def _run_repl(state: CliState) -> None:
+    """Launch the interactive REPL."""
+    from cli_anything.hf_spaces.utils.repl_skin import ReplSkin
+
+    skin = ReplSkin("hf_spaces", version=VERSION)
+    skin.print_banner()
+
+    pt_session = skin.create_prompt_session()
+
+    _REPL_HELP = {
+        "space info <id>": "Show Space info and runtime status",
+        "space list [--author X]": "List spaces",
+        "space pause <id>": "Pause a Space",
+        "space restart <id>": "Restart a Space",
+        "space duplicate <from> <to>": "Duplicate a Space",
+        "hardware get <id>": "Get current hardware tier",
+        "hardware set <id> <tier>": "Request hardware change (STOP-AND-SHOW)",
+        "hardware list-tiers": "List all hardware tiers with pricing",
+        "vars list <id>": "List environment variables",
+        "vars set <id> KEY VALUE": "Set a variable",
+        "vars delete <id> KEY": "Delete a variable",
+        "secrets set <id> KEY": "Set a secret (value prompted)",
+        "secrets delete <id> KEY": "Delete a secret (STOP-AND-SHOW)",
+        "secrets list": "List secrets from local manifest",
+        "logs run <id>": "Stream runtime logs",
+        "logs build <id>": "Stream build logs",
+        "readme get <id>": "Fetch README.md",
+        "readme set <id> <file>": "Upload a local README.md",
+        "manifest init <id>": "Create a new manifest file",
+        "manifest plan <file>": "Show planned changes",
+        "manifest apply <file>": "Apply manifest (STOP-AND-SHOW)",
+        "doctor": "Check auth and SDK health",
+        "session list": "List saved sessions",
+        "help": "Show this help",
+        "quit / exit": "Exit the REPL",
+    }
+
+    while True:
+        try:
+            raw = skin.get_input(pt_session, context="hf-spaces")
+        except (EOFError, KeyboardInterrupt):
+            skin.print_goodbye()
+            break
+
+        line = raw.strip()
+        if not line:
+            continue
+        if line in ("quit", "exit", "q"):
+            skin.print_goodbye()
+            break
+        if line in ("help", "?", "h"):
+            skin.help(_REPL_HELP)
+            continue
+
+        # Dispatch through Click's CLI parser
+        args = line.split()
+        try:
+            # Standalone mode=False so Click doesn't call sys.exit
+            cli.main(
+                args=args,
+                obj=state,
+                standalone_mode=False,
+            )
+        except click.exceptions.UsageError as exc:
+            skin.error(str(exc))
+        except click.exceptions.Abort:
+            skin.warning("Aborted.")
+        except HfBackendError as exc:
+            skin.error(str(exc))
+        except SystemExit:
+            pass
+        except Exception as exc:
+            skin.error(f"Unexpected error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Register command groups
+# ---------------------------------------------------------------------------
+
+cli.add_command(space)
+cli.add_command(hardware)
+cli.add_command(secrets)
+cli.add_command(vars_group)
+cli.add_command(logs)
+cli.add_command(readme)
+cli.add_command(manifest)
+cli.add_command(session)
+cli.add_command(doctor)
+
+
+# ---------------------------------------------------------------------------
+# Module entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/skills/SKILL.md
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/skills/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: cli-anything-hf-spaces
+description: >
+  CLI harness for HuggingFace Spaces administration. Manages hardware tiers,
+  env vars, secrets, sleep/restart, logs, README sync, and manifest-driven
+  desired-state apply.
+---
+
+# cli-anything-hf-spaces
+
+## When to use this skill
+
+Use this skill when you need to:
+- Administer HuggingFace Spaces from the command line
+- Change hardware tiers (with billing awareness)
+- Manage Space secrets and environment variables
+- Stream runtime or build logs
+- Sync README.md files
+- Apply manifest-driven desired state to a Space
+
+## Prerequisites
+
+```bash
+pip install 'cli-anything-hf-spaces[all]'
+# or for minimal install:
+pip install cli-anything-hf-spaces
+```
+
+Auth (in priority order):
+1. `--token <token>` (in-memory only, never written to disk)
+2. `HF_TOKEN` environment variable
+3. `~/.cache/huggingface/token` (from `huggingface-cli login`)
+
+## Command groups
+
+| Group      | Description                                      |
+|------------|--------------------------------------------------|
+| `space`    | info, list, pause, restart, duplicate            |
+| `hardware` | get, set (STOP-AND-SHOW), list-tiers             |
+| `secrets`  | set, delete (STOP-AND-SHOW), list (manifest only)|
+| `vars`     | list, get, set, delete                           |
+| `logs`     | run, build (httpx SSE streaming)                 |
+| `readme`   | get, set, sync                                   |
+| `manifest` | init, show, plan, apply (STOP-AND-SHOW)          |
+| `session`  | list, show, delete                               |
+| `doctor`   | auth + SDK health check                          |
+
+## Key constraints
+
+- **Secrets are write-only** via HfApi. `secrets list` reads local manifest only.
+- **Log streaming** requires `httpx`: `pip install 'cli-anything-hf-spaces[logs]'`
+- **Factory reset** is web-UI only — not available in this CLI.
+- **STOP-AND-SHOW gate** on: `hardware set`, `secrets delete`, `space pause`, `manifest apply`
+- Token is **never** written to disk by the CLI.
+
+## Quick reference
+
+```bash
+# Space info
+hf-spaces space info owner/my-space
+
+# Change hardware (billing — requires --confirm)
+hf-spaces hardware set owner/my-space t4-small --confirm
+
+# Set a secret (value prompted interactively)
+hf-spaces secrets set owner/my-space MY_API_KEY
+
+# List variables
+hf-spaces vars list owner/my-space
+
+# Stream runtime logs
+hf-spaces logs run owner/my-space
+
+# Sync README
+hf-spaces readme sync owner/my-space ./README.md
+
+# Manifest workflow
+hf-spaces manifest init owner/my-space --out ./hf-space-manifest.json
+# edit hf-space-manifest.json ...
+hf-spaces manifest plan ./hf-space-manifest.json
+hf-spaces manifest apply ./hf-space-manifest.json --confirm
+
+# Health check
+hf-spaces doctor
+
+# Interactive REPL
+hf-spaces
+```
+
+## JSON output
+
+Every command supports `--json` for machine-readable output:
+
+```bash
+hf-spaces --json space info owner/my-space | jq .stage
+```

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/tests/TEST.md
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/tests/TEST.md
@@ -1,0 +1,31 @@
+# Test Suite — cli-anything-hf-spaces
+
+## Running tests
+
+```bash
+# Unit tests only (no live HF calls, no env gate needed)
+pytest cli_anything/hf_spaces/tests/test_core.py -v
+
+# All tests including e2e (requires HF_SPACES_E2E=1 AND a valid HF_TOKEN)
+HF_SPACES_E2E=1 HF_TOKEN=hf_... pytest cli_anything/hf_spaces/tests/ -v
+
+# With coverage
+pytest cli_anything/hf_spaces/tests/test_core.py -v --cov=cli_anything.hf_spaces --cov-report=term-missing
+```
+
+## Gate behaviour
+
+- `HF_SPACES_E2E=0` (default): live HF tests are **skipped** cleanly.
+- `HF_SPACES_E2E=1` and HfApi unreachable: live tests **FAIL** (not skip).
+  This enforces that the gate is an intentional opt-in, not a silent fallback.
+
+## Test files
+
+| File | Coverage |
+|------|----------|
+| `test_core.py` | 40+ unit tests — hardware, space parsing, secrets, session, manifest, hf_backend auth |
+| `test_full_e2e.py` | Subprocess e2e against real HF API (gated by HF_SPACES_E2E=1) |
+
+## HF account for live tests
+
+Account: `damBruh` — set `HF_TEST_SPACE` env var to the test Space repo_id.

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/tests/test_core.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/tests/test_core.py
@@ -1,0 +1,625 @@
+"""
+Unit tests for cli-anything-hf-spaces core modules.
+
+No live HF API calls. All HfApi interactions are mocked.
+Run with: pytest cli_anything/hf_spaces/tests/test_core.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cli_anything.hf_spaces.core.hardware import (HARDWARE_SLUGS,
+                                                  hardware_table_rows,
+                                                  validate_hardware_slug)
+
+# ---------------------------------------------------------------------------
+# hardware.py
+# ---------------------------------------------------------------------------
+
+
+
+class TestHardware:
+    def test_all_known_slugs_validate(self):
+        for slug in HARDWARE_SLUGS:
+            assert validate_hardware_slug(slug) == slug
+
+    def test_invalid_slug_raises(self):
+        with pytest.raises(ValueError, match="Unknown hardware tier"):
+            validate_hardware_slug("not-a-real-tier")
+
+    def test_hardware_table_rows_count(self):
+        rows = hardware_table_rows()
+        assert len(rows) == len(HARDWARE_SLUGS)
+
+    def test_hardware_table_rows_fields(self):
+        rows = hardware_table_rows()
+        for row in rows:
+            assert "slug" in row
+            assert "cost_usd_hr" in row
+            assert "description" in row
+
+    def test_cpu_basic_is_free(self):
+        rows = hardware_table_rows()
+        cpu_basic = next(r for r in rows if r["slug"] == "cpu-basic")
+        assert cpu_basic["cost_usd_hr"] == "free"
+
+    def test_hardware_slugs_tuple_not_empty(self):
+        assert len(HARDWARE_SLUGS) >= 18
+
+    def test_t4_small_in_slugs(self):
+        assert "t4-small" in HARDWARE_SLUGS
+
+    def test_h100x8_in_slugs(self):
+        assert "h100x8" in HARDWARE_SLUGS
+
+
+# ---------------------------------------------------------------------------
+# space.py
+# ---------------------------------------------------------------------------
+
+from cli_anything.hf_spaces.core.space import (SpaceRef, optional_space_ref,
+                                               parse_space_ref)
+
+
+class TestSpaceRef:
+    def test_parse_slug(self):
+        ref = SpaceRef.parse("owner/my-space")
+        assert ref.owner == "owner"
+        assert ref.name == "my-space"
+
+    def test_parse_url(self):
+        ref = SpaceRef.parse("https://huggingface.co/spaces/damBruh/test-space")
+        assert ref.owner == "damBruh"
+        assert ref.name == "test-space"
+
+    def test_parse_url_trailing_slash(self):
+        ref = SpaceRef.parse("https://huggingface.co/spaces/owner/name/")
+        assert ref.owner == "owner"
+        assert ref.name == "name"
+
+    def test_parse_invalid_raises(self):
+        with pytest.raises(ValueError, match="Cannot parse"):
+            SpaceRef.parse("not-a-valid-ref")
+
+    def test_repo_id(self):
+        ref = SpaceRef.parse("owner/name")
+        assert ref.repo_id == "owner/name"
+
+    def test_url_property(self):
+        ref = SpaceRef.parse("owner/name")
+        assert ref.url == "https://huggingface.co/spaces/owner/name"
+
+    def test_embed_url(self):
+        ref = SpaceRef.parse("owner/name")
+        assert ref.embed_url == "https://owner-name.hf.space"
+
+    def test_to_dict_roundtrip(self):
+        ref = SpaceRef.parse("owner/name")
+        d = ref.to_dict()
+        ref2 = SpaceRef.from_dict(d)
+        assert ref == ref2
+
+    def test_from_dict_repo_id(self):
+        ref = SpaceRef.from_dict({"repo_id": "owner/name"})
+        assert ref.owner == "owner"
+        assert ref.name == "name"
+
+    def test_str(self):
+        ref = SpaceRef.parse("owner/name")
+        assert str(ref) == "owner/name"
+
+    def test_parse_space_ref_convenience(self):
+        ref = parse_space_ref("owner/name")
+        assert isinstance(ref, SpaceRef)
+
+    def test_optional_space_ref_none(self):
+        assert optional_space_ref(None) is None
+        assert optional_space_ref("") is None
+
+    def test_optional_space_ref_value(self):
+        ref = optional_space_ref("owner/name")
+        assert ref is not None
+        assert ref.owner == "owner"
+
+    def test_frozen_immutability(self):
+        ref = SpaceRef.parse("owner/name")
+        with pytest.raises((AttributeError, TypeError)):
+            ref.owner = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# secrets.py
+# ---------------------------------------------------------------------------
+
+from cli_anything.hf_spaces.core.secrets import (SecretEntry, SecretsBundle,
+                                                 VariableEntry)
+
+
+class TestSecrets:
+    def test_secret_entry_str(self):
+        s = SecretEntry(key="MY_KEY")
+        assert str(s) == "MY_KEY"
+
+    def test_secret_entry_to_dict_no_value(self):
+        s = SecretEntry(key="MY_KEY", description="desc")
+        d = s.to_dict()
+        assert "value" not in d
+        assert d["key"] == "MY_KEY"
+        assert d["description"] == "desc"
+
+    def test_secret_entry_from_dict_bare_string(self):
+        s = SecretEntry.from_dict("MY_KEY")
+        assert s.key == "MY_KEY"
+
+    def test_variable_entry_str(self):
+        v = VariableEntry(key="K", value="V")
+        assert str(v) == "K=V"
+
+    def test_variable_entry_roundtrip(self):
+        v = VariableEntry(key="K", value="V", description="d")
+        d = v.to_dict()
+        v2 = VariableEntry.from_dict(d)
+        assert v2.key == v.key
+        assert v2.value == v.value
+        assert v2.description == v.description
+
+    def test_variables_from_api(self):
+        api_resp = {
+            "FOO": {"value": "bar", "description": "a var"},
+            "BAZ": {"value": "qux"},
+        }
+        entries = SecretsBundle.variables_from_api(api_resp)
+        assert len(entries) == 2
+        keys = {e.key for e in entries}
+        assert keys == {"FOO", "BAZ"}
+
+    def test_bundle_has_secret(self):
+        bundle = SecretsBundle(secrets=[SecretEntry("KEY1")])
+        assert bundle.has_secret("KEY1")
+        assert not bundle.has_secret("KEY2")
+
+    def test_bundle_get_variable(self):
+        bundle = SecretsBundle(variables=[VariableEntry("K", "V")])
+        v = bundle.get_variable("K")
+        assert v is not None
+        assert v.value == "V"
+        assert bundle.get_variable("MISSING") is None
+
+
+# ---------------------------------------------------------------------------
+# session.py
+# ---------------------------------------------------------------------------
+
+from cli_anything.hf_spaces.core.session import (Session, _locked_save_json,
+                                                 delete, list_sessions, load,
+                                                 save)
+
+
+class TestSession:
+    def test_new_session_fields(self):
+        s = Session.new(space_id="owner/name")
+        assert s.space_id == "owner/name"
+        assert s.session_id
+        assert s.created_at > 0
+
+    def test_push_history_appends(self):
+        s = Session.new()
+        s.push_history({"cmd": "space info"})
+        assert len(s.history) == 1
+
+    def test_push_history_caps_at_max(self):
+        from cli_anything.hf_spaces.core.session import MAX_HISTORY
+
+        s = Session.new()
+        for i in range(MAX_HISTORY + 10):
+            s.push_history({"cmd": f"cmd_{i}"})
+        assert len(s.history) == MAX_HISTORY
+
+    def test_to_dict_no_token_field(self):
+        s = Session.new()
+        d = s.to_dict()
+        assert "token" not in d
+        assert "_token" not in d
+
+    def test_roundtrip(self):
+        s = Session.new(space_id="owner/name")
+        s.push_history({"cmd": "test"})
+        d = s.to_dict()
+        s2 = Session.from_dict(d)
+        assert s2.session_id == s.session_id
+        assert s2.space_id == s.space_id
+        assert len(s2.history) == 1
+
+    def test_save_load_delete(self, tmp_path, monkeypatch):
+        import cli_anything.hf_spaces.core.session as sess_mod
+
+        monkeypatch.setattr(sess_mod, "_SESSIONS_DIR", tmp_path)
+
+        s = Session.new(space_id="owner/test")
+        save(s)
+        loaded = load(s.session_id)
+        assert loaded.session_id == s.session_id
+        assert delete(s.session_id) is True
+        assert delete(s.session_id) is False
+
+    def test_load_not_found_raises(self, tmp_path, monkeypatch):
+        import cli_anything.hf_spaces.core.session as sess_mod
+
+        monkeypatch.setattr(sess_mod, "_SESSIONS_DIR", tmp_path)
+        with pytest.raises(FileNotFoundError):
+            load("nonexistent-id")
+
+    def test_list_sessions_empty(self, tmp_path, monkeypatch):
+        import cli_anything.hf_spaces.core.session as sess_mod
+
+        monkeypatch.setattr(sess_mod, "_SESSIONS_DIR", tmp_path)
+        assert list_sessions() == []
+
+    def test_list_sessions_multiple(self, tmp_path, monkeypatch):
+        import cli_anything.hf_spaces.core.session as sess_mod
+
+        monkeypatch.setattr(sess_mod, "_SESSIONS_DIR", tmp_path)
+        s1 = Session.new()
+        s2 = Session.new()
+        save(s1)
+        save(s2)
+        sessions = list_sessions()
+        assert len(sessions) == 2
+
+    def test_locked_save_json_atomic(self, tmp_path):
+        path = tmp_path / "test.json"
+        _locked_save_json(path, {"key": "value"})
+        assert path.exists()
+        with path.open() as f:
+            data = json.load(f)
+        assert data["key"] == "value"
+
+
+# ---------------------------------------------------------------------------
+# manifest.py
+# ---------------------------------------------------------------------------
+
+from cli_anything.hf_spaces.core.manifest import (ChangeKind, ManifestSpec,
+                                                  build_plan, plan_hardware,
+                                                  plan_readme, plan_secrets,
+                                                  plan_sleep_time,
+                                                  plan_variables)
+
+
+class TestManifest:
+    def test_validate_ok(self):
+        spec = ManifestSpec(space_id="owner/name", hardware="cpu-basic")
+        spec.validate()  # should not raise
+
+    def test_validate_bad_space_id(self):
+        spec = ManifestSpec(space_id="notaslug")
+        with pytest.raises(ValueError, match="space_id"):
+            spec.validate()
+
+    def test_validate_bad_hardware(self):
+        spec = ManifestSpec(space_id="owner/name", hardware="invalid-tier")
+        with pytest.raises(ValueError, match="Unknown hardware"):
+            spec.validate()
+
+    def test_validate_bad_sleep_time(self):
+        spec = ManifestSpec(space_id="owner/name", sleep_time=-5)
+        with pytest.raises(ValueError, match="sleep_time"):
+            spec.validate()
+
+    def test_to_dict_roundtrip(self):
+        spec = ManifestSpec(
+            space_id="owner/name",
+            hardware="cpu-basic",
+            sleep_time=300,
+            variables={"K": "V"},
+            secrets=["SECRET"],
+        )
+        d = spec.to_dict()
+        spec2 = ManifestSpec.from_dict(d)
+        assert spec2.space_id == spec.space_id
+        assert spec2.hardware == spec.hardware
+        assert spec2.sleep_time == spec.sleep_time
+        assert spec2.variables == spec.variables
+        assert spec2.secrets == spec.secrets
+
+    def test_save_load(self, tmp_path):
+        spec = ManifestSpec(
+            space_id="owner/name",
+            hardware="t4-small",
+            variables={"KEY": "val"},
+        )
+        path = tmp_path / "manifest.json"
+        spec.save(path)
+        loaded = ManifestSpec.load(path)
+        assert loaded.space_id == spec.space_id
+        assert loaded.hardware == spec.hardware
+
+    def test_load_missing_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            ManifestSpec.load(tmp_path / "missing.json")
+
+    def test_plan_hardware_change(self):
+        change = plan_hardware("t4-small", "cpu-basic")
+        assert change is not None
+        assert change.kind == ChangeKind.HARDWARE
+        assert change.desired == "t4-small"
+        assert change.destructive is True
+
+    def test_plan_hardware_no_change(self):
+        assert plan_hardware("cpu-basic", "cpu-basic") is None
+
+    def test_plan_hardware_none_desired(self):
+        assert plan_hardware(None, "cpu-basic") is None
+
+    def test_plan_sleep_time_change(self):
+        change = plan_sleep_time(300, None)
+        assert change is not None
+        assert change.kind == ChangeKind.SLEEP_TIME
+        assert change.desired == "300"
+
+    def test_plan_sleep_time_no_change(self):
+        assert plan_sleep_time(300, 300) is None
+
+    def test_plan_variables_set(self):
+        changes = plan_variables({"K": "V"}, {})
+        assert len(changes) == 1
+        assert changes[0].kind == ChangeKind.VARIABLE_SET
+        assert changes[0].key == "K"
+
+    def test_plan_variables_delete(self):
+        changes = plan_variables({}, {"K": "V"})
+        assert len(changes) == 1
+        assert changes[0].kind == ChangeKind.VARIABLE_DELETE
+        assert changes[0].destructive is True
+
+    def test_plan_variables_no_change(self):
+        assert plan_variables({"K": "V"}, {"K": "V"}) == []
+
+    def test_plan_secrets(self):
+        changes = plan_secrets(["KEY1", "KEY2"])
+        assert len(changes) == 2
+        for c in changes:
+            assert c.kind == ChangeKind.SECRET_SET
+            assert c.current is None  # unreadable by design
+
+    def test_plan_readme_no_change(self, tmp_path):
+        f = tmp_path / "README.md"
+        f.write_text("content", encoding="utf-8")
+        change = plan_readme(str(f), "content")
+        assert change is None
+
+    def test_plan_readme_change(self, tmp_path):
+        f = tmp_path / "README.md"
+        f.write_text("new content", encoding="utf-8")
+        change = plan_readme(str(f), "old content")
+        assert change is not None
+        assert change.kind == ChangeKind.README_SYNC
+
+    def test_build_plan_all(self, tmp_path):
+        readme_file = tmp_path / "README.md"
+        readme_file.write_text("new", encoding="utf-8")
+        spec = ManifestSpec(
+            space_id="owner/name",
+            hardware="t4-small",
+            sleep_time=300,
+            variables={"K": "V"},
+            secrets=["SECRET"],
+            readme_path=str(readme_file),
+        )
+        changes = build_plan(
+            spec=spec,
+            current_hardware="cpu-basic",
+            current_sleep_time=None,
+            current_variables={},
+            current_readme="old",
+        )
+        kinds = {c.kind for c in changes}
+        assert ChangeKind.HARDWARE in kinds
+        assert ChangeKind.SLEEP_TIME in kinds
+        assert ChangeKind.VARIABLE_SET in kinds
+        assert ChangeKind.SECRET_SET in kinds
+        assert ChangeKind.README_SYNC in kinds
+
+
+# ---------------------------------------------------------------------------
+# hf_backend.py — auth resolution (no live calls)
+# ---------------------------------------------------------------------------
+
+from cli_anything.hf_spaces.utils.hf_backend import (HfAuthError,
+                                                     HfBackendError,
+                                                     HfRateLimitError,
+                                                     HfSpaceNotFoundError,
+                                                     _translate_exc,
+                                                     require_token,
+                                                     resolve_token)
+
+
+class TestHfBackendAuth:
+    def test_resolve_token_explicit(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        token = resolve_token("explicit-token")
+        assert token == "explicit-token"
+
+    def test_resolve_token_env(self, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "env-token")
+        token = resolve_token()
+        assert token == "env-token"
+
+    def test_resolve_token_none(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        # Patch the cache path to a non-existent location
+        import cli_anything.hf_spaces.utils.hf_backend as backend_mod
+
+        monkeypatch.setattr(backend_mod, "_HF_TOKEN_CACHE", tmp_path / "no-token")
+        token = resolve_token()
+        assert token is None
+
+    def test_require_token_raises_when_none(self, monkeypatch, tmp_path):
+        import cli_anything.hf_spaces.utils.hf_backend as backend_mod
+
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr(backend_mod, "_HF_TOKEN_CACHE", tmp_path / "no-token")
+        with pytest.raises(HfAuthError):
+            require_token()
+
+    def test_require_token_returns_explicit(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        assert require_token("explicit") == "explicit"
+
+    def test_translate_exc_401(self):
+        with pytest.raises(HfAuthError):
+            _translate_exc(Exception("HTTP 401 Unauthorized"), "owner/name")
+
+    def test_translate_exc_404(self):
+        with pytest.raises(HfSpaceNotFoundError):
+            _translate_exc(Exception("404 not found"), "owner/name")
+
+    def test_translate_exc_429(self):
+        with pytest.raises(HfRateLimitError):
+            _translate_exc(Exception("429 rate limit exceeded"))
+
+    def test_translate_exc_generic(self):
+        with pytest.raises(HfBackendError):
+            _translate_exc(Exception("something went wrong"))
+
+    def test_translate_exc_forbidden(self):
+        with pytest.raises(HfAuthError):
+            _translate_exc(Exception("403 Forbidden"), "owner/name")
+
+    def test_translate_exc_repository_not_found(self):
+        with pytest.raises(HfSpaceNotFoundError):
+            _translate_exc(Exception("Repository not found"), "owner/name")
+
+
+# ---------------------------------------------------------------------------
+# CLI root — basic smoke tests via Click test runner
+# ---------------------------------------------------------------------------
+
+from cli_anything.hf_spaces.hf_spaces_cli import cli
+from click.testing import CliRunner
+
+
+class TestCLISmoke:
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "hf-spaces" in result.output.lower() or "huggingface" in result.output.lower()
+
+    def test_version(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert "1.0.0" in result.output
+
+    def test_hardware_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["hardware", "--help"])
+        assert result.exit_code == 0
+
+    def test_space_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["space", "--help"])
+        assert result.exit_code == 0
+
+    def test_secrets_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["secrets", "--help"])
+        assert result.exit_code == 0
+
+    def test_vars_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["vars", "--help"])
+        assert result.exit_code == 0
+
+    def test_manifest_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["manifest", "--help"])
+        assert result.exit_code == 0
+
+    def test_doctor_no_crash(self):
+        runner = CliRunner()
+        # doctor may exit 1 (no token in test env) but must not crash
+        result = runner.invoke(cli, ["doctor"])
+        assert result.exit_code in (0, 1)
+
+    def test_hardware_list_tiers(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["hardware", "list-tiers"])
+        assert result.exit_code == 0
+        assert "cpu-basic" in result.output
+
+    def test_hardware_list_tiers_json(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "hardware", "list-tiers"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert len(data["tiers"]) >= 18
+
+    def test_hardware_set_no_confirm_shows_stop(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["hardware", "set", "owner/name", "t4-small"])
+        assert result.exit_code == 0
+        assert "[STOP]" in result.output
+
+    def test_space_pause_no_confirm_shows_stop(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["space", "pause", "owner/name"])
+        assert result.exit_code == 0
+        assert "[STOP]" in result.output
+
+    def test_secrets_delete_no_confirm_shows_stop(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["secrets", "delete", "owner/name", "MY_KEY"])
+        assert result.exit_code == 0
+        assert "[STOP]" in result.output
+
+    def test_secrets_list_no_manifest(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["secrets", "list"])
+        assert result.exit_code == 0
+        assert "No secrets found" in result.output or "HuggingFace API" in result.output
+
+    def test_manifest_init_creates_file(self, tmp_path):
+        runner = CliRunner()
+        out_file = str(tmp_path / "manifest.json")
+        result = runner.invoke(
+            cli,
+            ["manifest", "init", "owner/name", "--out", out_file],
+        )
+        assert result.exit_code == 0
+        assert Path(out_file).exists()
+        data = json.loads(Path(out_file).read_text())
+        assert data["space_id"] == "owner/name"
+
+    def test_manifest_show(self, tmp_path):
+        spec = ManifestSpec(space_id="owner/name", hardware="cpu-basic")
+        path = tmp_path / "m.json"
+        spec.save(path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["manifest", "show", str(path)])
+        assert result.exit_code == 0
+        assert "owner/name" in result.output
+
+    def test_session_list_empty(self, tmp_path, monkeypatch):
+        import cli_anything.hf_spaces.core.session as sess_mod
+
+        monkeypatch.setattr(sess_mod, "_SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["session", "list"])
+        assert result.exit_code == 0
+
+    def test_json_flag_propagates(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "hardware", "list-tiers"])
+        assert result.exit_code == 0
+        # Must be valid JSON
+        data = json.loads(result.output)
+        assert "tiers" in data

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/tests/test_full_e2e.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/tests/test_full_e2e.py
@@ -1,0 +1,364 @@
+"""
+End-to-end subprocess tests for cli-anything-hf-spaces.
+
+Gated by HF_SPACES_E2E=1.  Requires a valid HF_TOKEN and a test Space
+specified via HF_TEST_SPACE (defaults to damBruh/cli-anything-e2e-test).
+
+Gate behaviour:
+    HF_SPACES_E2E=0 (default) : all tests in this file are SKIPPED.
+    HF_SPACES_E2E=1 + HfApi unreachable : tests FAIL (not skip).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import List
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Gate
+# ---------------------------------------------------------------------------
+
+_E2E = os.environ.get("HF_SPACES_E2E", "0").strip() == "1"
+pytestmark = pytest.mark.skipif(not _E2E, reason="HF_SPACES_E2E not set to 1")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_cli(name: str = "hf-spaces") -> List[str]:
+    """Return the command vector for the CLI.
+
+    Resolution order:
+      1. If CLI_ANYTHING_FORCE_INSTALLED=1, require the installed binary.
+      2. If the binary is on PATH, use it.
+      3. Fall back to `python -m cli_anything.hf_spaces`.
+    """
+    force = os.environ.get("CLI_ANYTHING_FORCE_INSTALLED", "").strip() == "1"
+    path = shutil.which(name)
+    if path:
+        return [path]
+    if force:
+        raise RuntimeError(f"{name!r} not found in PATH and CLI_ANYTHING_FORCE_INSTALLED=1.")
+    return [sys.executable, "-m", "cli_anything.hf_spaces"]
+
+
+def _run(
+    *args: str,
+    token: str | None = None,
+    expect_exit: int = 0,
+    json_output: bool = False,
+) -> subprocess.CompletedProcess:
+    """Run the CLI with the given args.  Asserts exit code matches ``expect_exit``."""
+    cmd = _resolve_cli()
+    if json_output:
+        cmd = cmd + ["--json"]
+    if token:
+        cmd = cmd + ["--token", token]
+    cmd = cmd + list(args)
+    env = os.environ.copy()
+    # Ensure token env var is set for the subprocess when not passed explicitly.
+    if not token and "HF_TOKEN" not in env:
+        tok = _get_token()
+        if tok:
+            env["HF_TOKEN"] = tok
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    assert result.returncode == expect_exit, (
+        f"Exit {result.returncode!r} != {expect_exit!r}\n"
+        f"stdout: {result.stdout!r}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    return result
+
+
+def _get_token() -> str:
+    """Resolve HF token from env or ~/.cache/huggingface/token."""
+    tok = os.environ.get("HF_TOKEN", "").strip()
+    if tok:
+        return tok
+    fallback = os.path.expanduser("~/.cache/huggingface/token")
+    if os.path.isfile(fallback):
+        with open(fallback) as fh:
+            return fh.read().strip()
+    return ""
+
+
+def _test_space() -> str:
+    return os.environ.get("HF_TEST_SPACE", "damBruh/cli-anything-e2e-test")
+
+
+def _require_reachable() -> None:
+    """Fail (not skip) if HfApi is unreachable when gate is ON."""
+    try:
+        from huggingface_hub import HfApi
+
+        HfApi(token=_get_token() or None).whoami()
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(f"HF_SPACES_E2E=1 but HfApi is unreachable: {exc}")
+
+
+# Run the reachability check once when the gate is active.
+if _E2E:
+    _require_reachable()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def space() -> str:
+    return _test_space()
+
+
+@pytest.fixture(scope="module")
+def token() -> str:
+    tok = _get_token()
+    if not tok:
+        pytest.fail("No HF_TOKEN set and ~/.cache/huggingface/token not found.")
+    return tok
+
+
+# ---------------------------------------------------------------------------
+# Doctor
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorE2E:
+    def test_doctor_exits_zero(self, token: str) -> None:
+        _run("doctor", token=token)
+
+    def test_doctor_json(self, token: str) -> None:
+        result = _run("doctor", token=token, json_output=True)
+        data = json.loads(result.stdout)
+        assert "checks" in data
+        assert isinstance(data["checks"], list)
+
+    def test_doctor_shows_token_masked(self, token: str) -> None:
+        result = _run("doctor", token=token)
+        # Token must NOT appear verbatim in stdout.
+        assert token not in result.stdout
+        assert token not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Space info
+# ---------------------------------------------------------------------------
+
+
+class TestSpaceInfoE2E:
+    def test_info_exits_zero(self, space: str, token: str) -> None:
+        _run("space", "info", space, token=token)
+
+    def test_info_json_has_repo_id(self, space: str, token: str) -> None:
+        result = _run("space", "info", space, token=token, json_output=True)
+        data = json.loads(result.stdout)
+        assert data.get("repo_id") == space or data.get("id") == space or space in str(data)
+
+    def test_info_unknown_space_fails(self, token: str) -> None:
+        _run(
+            "space",
+            "info",
+            "damBruh/cli-anything-does-not-exist-xyzzy",
+            token=token,
+            expect_exit=1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hardware
+# ---------------------------------------------------------------------------
+
+
+class TestHardwareE2E:
+    def test_hardware_get(self, space: str, token: str) -> None:
+        _run("hardware", "get", space, token=token)
+
+    def test_hardware_get_json(self, space: str, token: str) -> None:
+        result = _run("hardware", "get", space, token=token, json_output=True)
+        data = json.loads(result.stdout)
+        assert "hardware" in data or "current" in data or "requested" in data or data
+
+    def test_hardware_list_tiers(self, token: str) -> None:
+        _run("hardware", "list-tiers", token=token)
+
+    def test_hardware_set_without_confirm_rejected(self, space: str, token: str) -> None:
+        # Omitting --confirm must result in a non-zero exit (STOP-AND-SHOW gate).
+        _run("hardware", "set", space, "cpu-basic", token=token, expect_exit=1)
+
+    def test_hardware_set_invalid_slug_rejected(self, space: str, token: str) -> None:
+        _run("hardware", "set", space, "not-a-real-tier", "--confirm", token=token, expect_exit=2)
+
+
+# ---------------------------------------------------------------------------
+# Variables
+# ---------------------------------------------------------------------------
+
+
+class TestVariablesE2E:
+    _VAR_KEY = "CLI_ANYTHING_E2E_TEST_VAR"
+    _VAR_VAL = "hello-e2e-value"
+
+    def test_vars_set(self, space: str, token: str) -> None:
+        _run("vars", "set", space, self._VAR_KEY, self._VAR_VAL, token=token)
+
+    def test_vars_list_contains_key(self, space: str, token: str) -> None:
+        result = _run("vars", "list", space, token=token, json_output=True)
+        data = json.loads(result.stdout)
+        # data may be a dict keyed by var name or a list of objects.
+        text = json.dumps(data)
+        assert self._VAR_KEY in text
+
+    def test_vars_get(self, space: str, token: str) -> None:
+        result = _run("vars", "get", space, self._VAR_KEY, token=token)
+        assert self._VAR_VAL in result.stdout
+
+    def test_vars_delete_without_confirm_rejected(self, space: str, token: str) -> None:
+        _run("vars", "delete", space, self._VAR_KEY, token=token, expect_exit=1)
+
+    def test_vars_delete_with_confirm(self, space: str, token: str) -> None:
+        # Clean up the variable created by test_vars_set.
+        _run("vars", "delete", space, self._VAR_KEY, "--confirm", token=token)
+
+
+# ---------------------------------------------------------------------------
+# Secrets (write-only — only set/delete can be verified, not read)
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsE2E:
+    _SECRET_KEY = "CLI_ANYTHING_E2E_TEST_SECRET"
+
+    def test_secrets_set(self, space: str, token: str) -> None:
+        _run("secrets", "set", space, self._SECRET_KEY, "--value", "e2e-secret-val", token=token)
+
+    def test_secrets_list_shows_manifest_warning(self, space: str, token: str) -> None:
+        # secrets list reads local manifest only — should warn about API gap.
+        with tempfile.TemporaryDirectory() as td:
+            manifest_path = os.path.join(td, "manifest.json")
+            _run("manifest", "init", space, "--out", manifest_path, token=token)
+            result = _run("secrets", "list", space, "--manifest", manifest_path, token=token)
+        combined = result.stdout + result.stderr
+        # Should mention the limitation.
+        assert any(
+            phrase in combined.lower()
+            for phrase in ("write-only", "manifest", "api does not", "local")
+        )
+
+    def test_secrets_delete_without_confirm_rejected(self, space: str, token: str) -> None:
+        _run("secrets", "delete", space, self._SECRET_KEY, token=token, expect_exit=1)
+
+    def test_secrets_delete_with_confirm(self, space: str, token: str) -> None:
+        _run("secrets", "delete", space, self._SECRET_KEY, "--confirm", token=token)
+
+
+# ---------------------------------------------------------------------------
+# README
+# ---------------------------------------------------------------------------
+
+
+class TestReadmeE2E:
+    def test_readme_get(self, space: str, token: str) -> None:
+        result = _run("readme", "get", space, token=token)
+        assert result.stdout.strip()
+
+    def test_readme_get_to_file(self, space: str, token: str) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            out_path = os.path.join(td, "README.md")
+            _run("readme", "get", space, "--out", out_path, token=token)
+            assert os.path.isfile(out_path)
+            with open(out_path) as fh:
+                content = fh.read()
+            assert content.strip()
+
+    def test_readme_sync_noop_when_identical(self, space: str, token: str) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            readme_path = os.path.join(td, "README.md")
+            # Get the current README.
+            _run("readme", "get", space, "--out", readme_path, token=token)
+            # Syncing the same content should be a no-op (exit 0).
+            result = _run("readme", "sync", space, readme_path, token=token)
+            combined = result.stdout + result.stderr
+            assert any(
+                w in combined.lower() for w in ("no change", "identical", "up to date", "skipped")
+            )
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+class TestManifestE2E:
+    def test_manifest_init(self, space: str, token: str) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            out = os.path.join(td, "manifest.json")
+            _run("manifest", "init", space, "--out", out, token=token)
+            assert os.path.isfile(out)
+            with open(out) as fh:
+                data = json.load(fh)
+            assert data.get("schema") == "1"
+            assert data.get("repo_id") == space
+
+    def test_manifest_show(self, space: str, token: str) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            mpath = os.path.join(td, "manifest.json")
+            _run("manifest", "init", space, "--out", mpath, token=token)
+            _run("manifest", "show", mpath, token=token)
+
+    def test_manifest_plan(self, space: str, token: str) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            mpath = os.path.join(td, "manifest.json")
+            _run("manifest", "init", space, "--out", mpath, token=token)
+            # plan should exit 0 even when there are no changes.
+            _run("manifest", "plan", mpath, token=token)
+
+    def test_manifest_apply_without_confirm_rejected(self, space: str, token: str) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            mpath = os.path.join(td, "manifest.json")
+            _run("manifest", "init", space, "--out", mpath, token=token)
+            _run("manifest", "apply", mpath, token=token, expect_exit=1)
+
+
+# ---------------------------------------------------------------------------
+# Space list
+# ---------------------------------------------------------------------------
+
+
+class TestSpaceListE2E:
+    def test_list_returns_results(self, token: str) -> None:
+        result = _run("space", "list", "--author", "damBruh", token=token, json_output=True)
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+
+    def test_list_limit(self, token: str) -> None:
+        result = _run(
+            "space", "list", "--author", "damBruh", "--limit", "1", token=token, json_output=True
+        )
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        assert len(data) <= 1
+
+
+# ---------------------------------------------------------------------------
+# Session
+# ---------------------------------------------------------------------------
+
+
+class TestSessionE2E:
+    def test_session_list_exits_zero(self, token: str) -> None:
+        _run("session", "list", token=token)
+
+    def test_session_list_json(self, token: str) -> None:
+        result = _run("session", "list", token=token, json_output=True)
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/utils/hf_backend.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/utils/hf_backend.py
@@ -1,0 +1,532 @@
+"""
+HfApi wrapper for cli-anything-hf-spaces.
+
+Provides:
+- Auth resolution (--token > HF_TOKEN > ~/.cache/huggingface/token)
+- Typed exceptions for common HF API errors
+- Thin wrappers around HfApi methods with consistent error handling
+- Raw httpx SSE log streaming (logs run/build — bypasses HfApi public surface)
+
+Token is NEVER written to disk by this module.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Generator, Iterator, List, Optional
+
+# ---------------------------------------------------------------------------
+# Typed exceptions
+# ---------------------------------------------------------------------------
+
+
+class HfBackendError(Exception):
+    """Base class for all HF backend errors."""
+
+
+class HfAuthError(HfBackendError):
+    """Raised when authentication fails or no token is available."""
+
+
+class HfSpaceNotFoundError(HfBackendError):
+    """Raised when the requested Space does not exist or is not accessible."""
+
+
+class HfHardwareError(HfBackendError):
+    """Raised when a hardware tier change fails."""
+
+
+class HfRateLimitError(HfBackendError):
+    """Raised when the HF API rate limit is exceeded."""
+
+
+class HfLogsUnavailableError(HfBackendError):
+    """Raised when log streaming is not available (httpx missing or API error)."""
+
+
+# ---------------------------------------------------------------------------
+# Auth resolution
+# ---------------------------------------------------------------------------
+
+_HF_TOKEN_CACHE = Path.home() / ".cache" / "huggingface" / "token"
+
+
+def resolve_token(token: Optional[str] = None) -> Optional[str]:
+    """
+    Resolve a HuggingFace token in priority order:
+      1. Explicit *token* argument (in-memory, never written to disk)
+      2. ``HF_TOKEN`` environment variable
+      3. ``~/.cache/huggingface/token`` (written by ``huggingface-cli login``)
+      4. ``None`` (unauthenticated — public spaces only)
+
+    The returned token is never written to disk by this function.
+    """
+    if token:
+        return token
+    env_token = os.environ.get("HF_TOKEN", "").strip()
+    if env_token:
+        return env_token
+    if _HF_TOKEN_CACHE.exists():
+        cached = _HF_TOKEN_CACHE.read_text(encoding="utf-8").strip()
+        if cached:
+            return cached
+    return None
+
+
+def require_token(token: Optional[str] = None) -> str:
+    """
+    Like ``resolve_token`` but raises ``HfAuthError`` if no token is found.
+    """
+    resolved = resolve_token(token)
+    if not resolved:
+        raise HfAuthError(
+            "No HuggingFace token found. Provide via:\n"
+            "  --token <token>\n"
+            "  HF_TOKEN env var\n"
+            "  huggingface-cli login"
+        )
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# HfApi factory
+# ---------------------------------------------------------------------------
+
+
+def _get_api(token: Optional[str] = None):
+    """
+    Return an authenticated HfApi instance.
+
+    Raises:
+        ImportError: if huggingface_hub is not installed.
+    """
+    try:
+        from huggingface_hub import HfApi  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise ImportError(
+            "huggingface_hub is required. Install with:\n  pip install 'cli-anything-hf-spaces[hf]'"
+        ) from exc
+    return HfApi(token=token)
+
+
+# ---------------------------------------------------------------------------
+# Space info
+# ---------------------------------------------------------------------------
+
+
+def get_space_info(repo_id: str, token: Optional[str] = None) -> Any:
+    """
+    Return SpaceInfo for *repo_id*.
+
+    Raises:
+        HfSpaceNotFoundError: if the Space does not exist.
+        HfAuthError: on 401/403.
+    """
+    api = _get_api(token)
+    try:
+        return api.space_info(repo_id=repo_id, token=token)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+def get_space_runtime(repo_id: str, token: Optional[str] = None) -> Any:
+    """Return the SpaceRuntime for *repo_id*."""
+    api = _get_api(token)
+    try:
+        return api.get_space_runtime(repo_id=repo_id, token=token)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+def list_spaces(
+    author: Optional[str] = None,
+    search: Optional[str] = None,
+    token: Optional[str] = None,
+    limit: int = 50,
+) -> List[Any]:
+    """
+    List spaces, optionally filtered by *author* and/or *search* query.
+
+    Returns a list (materialised from the HfApi generator).
+    """
+    api = _get_api(token)
+    try:
+        gen = api.list_spaces(author=author, search=search, token=token, limit=limit)
+        return list(gen)
+    except Exception as exc:
+        _translate_exc(exc)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def pause_space(repo_id: str, token: Optional[str] = None) -> None:
+    """Pause a Space (sets stage → PAUSED)."""
+    tok = require_token(token)
+    api = _get_api(tok)
+    try:
+        api.pause_space(repo_id=repo_id, token=tok)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+def restart_space(repo_id: str, token: Optional[str] = None) -> None:
+    """Warm-restart a Space."""
+    tok = require_token(token)
+    api = _get_api(tok)
+    try:
+        api.restart_space(repo_id=repo_id, token=tok)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+# ---------------------------------------------------------------------------
+# Hardware
+# ---------------------------------------------------------------------------
+
+
+def get_hardware(repo_id: str, token: Optional[str] = None) -> Optional[str]:
+    """
+    Return the current hardware slug for *repo_id*, or None if unknown.
+    """
+    api = _get_api(token)
+    try:
+        runtime = api.get_space_runtime(repo_id=repo_id, token=token)
+        hw = getattr(runtime, "hardware", None)
+        if hw is None:
+            return None
+        # SpaceHardware enum — return .value (the slug string)
+        return str(hw.value) if hasattr(hw, "value") else str(hw)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+def set_hardware(
+    repo_id: str,
+    hardware_slug: str,
+    token: Optional[str] = None,
+) -> None:
+    """
+    Request a hardware tier change for *repo_id*.
+
+    *hardware_slug* must be a valid ``SpaceHardware`` value.
+    This is a destructive/billing operation — callers must STOP-AND-SHOW before invoking.
+    """
+    from cli_anything.hf_spaces.core.hardware import hardware_to_sdk_enum
+
+    tok = require_token(token)
+    api = _get_api(tok)
+    hw_enum = hardware_to_sdk_enum(hardware_slug)
+    try:
+        api.request_space_hardware(repo_id=repo_id, hardware=hw_enum, token=tok)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+def set_sleep_time(
+    repo_id: str,
+    sleep_time: int,
+    token: Optional[str] = None,
+) -> None:
+    """Set the sleep time for *repo_id* in seconds (-1 = never sleep)."""
+    tok = require_token(token)
+    api = _get_api(tok)
+    try:
+        api.set_space_sleep_time(repo_id=repo_id, sleep_time=sleep_time, token=tok)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+# ---------------------------------------------------------------------------
+# Secrets (write-only)
+# ---------------------------------------------------------------------------
+
+
+def set_secret(
+    repo_id: str,
+    key: str,
+    value: str,
+    token: Optional[str] = None,
+) -> None:
+    """
+    Write a secret to the Space.
+
+    The *value* is sent directly to HfApi and is never written to disk.
+    """
+    tok = require_token(token)
+    api = _get_api(tok)
+    try:
+        api.add_space_secret(repo_id=repo_id, key=key, value=value, token=tok)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+def delete_secret(
+    repo_id: str,
+    key: str,
+    token: Optional[str] = None,
+) -> None:
+    """
+    Delete a secret from the Space.
+
+    Destructive — callers must STOP-AND-SHOW before invoking.
+    """
+    tok = require_token(token)
+    api = _get_api(tok)
+    try:
+        api.delete_space_secret(repo_id=repo_id, key=key, token=tok)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+# ---------------------------------------------------------------------------
+# Variables (readable)
+# ---------------------------------------------------------------------------
+
+
+def get_variables(
+    repo_id: str,
+    token: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Return the variables dict for *repo_id*.
+
+    Shape: ``{"KEY": {"value": "...", "description": "..."}}``
+    """
+    api = _get_api(token)
+    try:
+        return api.get_space_variables(repo_id=repo_id, token=token)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+def set_variable(
+    repo_id: str,
+    key: str,
+    value: str,
+    token: Optional[str] = None,
+) -> None:
+    """Set or update a Space environment variable."""
+    tok = require_token(token)
+    api = _get_api(tok)
+    try:
+        api.add_space_variable(repo_id=repo_id, key=key, value=value, token=tok)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+def delete_variable(
+    repo_id: str,
+    key: str,
+    token: Optional[str] = None,
+) -> None:
+    """Delete a Space environment variable."""
+    tok = require_token(token)
+    api = _get_api(tok)
+    try:
+        api.delete_space_variable(repo_id=repo_id, key=key, token=tok)
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+# ---------------------------------------------------------------------------
+# README
+# ---------------------------------------------------------------------------
+
+
+def get_readme(repo_id: str, token: Optional[str] = None) -> Optional[str]:
+    """
+    Fetch the raw content of README.md from the Space repo.
+
+    Returns None if the file does not exist.
+    """
+    try:
+        import tempfile
+
+        from huggingface_hub import \
+            hf_hub_download  # type: ignore[import-untyped]
+
+        path = hf_hub_download(
+            repo_id=repo_id,
+            filename="README.md",
+            repo_type="space",
+            token=token,
+        )
+        return Path(path).read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+
+def upload_readme(
+    repo_id: str,
+    content: str,
+    token: Optional[str] = None,
+    commit_message: str = "Update README.md via cli-anything-hf-spaces",
+) -> None:
+    """
+    Upload README.md content to the Space repo.
+
+    Uses ``HfApi.upload_file`` — ``Repository`` class is deprecated and not used.
+    """
+    import io
+
+    tok = require_token(token)
+    api = _get_api(tok)
+    try:
+        api.upload_file(
+            path_or_fileobj=io.BytesIO(content.encode("utf-8")),
+            path_in_repo="README.md",
+            repo_id=repo_id,
+            repo_type="space",
+            token=tok,
+            commit_message=commit_message,
+        )
+    except Exception as exc:
+        _translate_exc(exc, repo_id)
+
+
+# ---------------------------------------------------------------------------
+# Space duplication
+# ---------------------------------------------------------------------------
+
+
+def duplicate_space(
+    from_id: str,
+    to_id: str,
+    private: bool = True,
+    exist_ok: bool = False,
+    token: Optional[str] = None,
+) -> Any:
+    """
+    Duplicate a Space from *from_id* to *to_id*.
+
+    Returns the new SpaceInfo.
+    """
+    tok = require_token(token)
+    api = _get_api(tok)
+    try:
+        return api.duplicate_space(
+            from_id=from_id,
+            to_id=to_id,
+            private=private,
+            exist_ok=exist_ok,
+            token=tok,
+        )
+    except Exception as exc:
+        _translate_exc(exc, from_id)
+
+
+# ---------------------------------------------------------------------------
+# Log streaming (bypasses HfApi — raw httpx SSE)
+# ---------------------------------------------------------------------------
+
+_HF_LOGS_RUN_URL = "https://huggingface.co/api/spaces/{owner}/{name}/logs/run"
+_HF_LOGS_BUILD_URL = "https://huggingface.co/api/spaces/{owner}/{name}/logs/build"
+
+
+def stream_logs(
+    owner: str,
+    name: str,
+    log_type: str = "run",
+    token: Optional[str] = None,
+    max_lines: int = 200,
+) -> Generator[str, None, None]:
+    """
+    Stream Space logs via the HuggingFace SSE log endpoint.
+
+    NOTE: This bypasses the public HfApi surface and calls the raw REST
+    endpoint directly, as HfApi does not expose a log-streaming method.
+
+    Args:
+        owner: Space owner (user or org).
+        name: Space name.
+        log_type: ``"run"`` or ``"build"``.
+        token: Auth token (required for private spaces).
+        max_lines: Stop after this many log lines.
+
+    Yields:
+        Log line strings (text/event-stream ``data:`` payloads, decoded).
+
+    Raises:
+        HfLogsUnavailableError: if httpx is not installed or the endpoint
+            returns a non-200 status.
+    """
+    try:
+        import httpx
+    except ImportError as exc:
+        raise HfLogsUnavailableError(
+            "httpx is required for log streaming. Install with:\n"
+            "  pip install 'cli-anything-hf-spaces[logs]'"
+        ) from exc
+
+    if log_type == "build":
+        url = _HF_LOGS_BUILD_URL.format(owner=owner, name=name)
+    else:
+        url = _HF_LOGS_RUN_URL.format(owner=owner, name=name)
+
+    headers: Dict[str, str] = {"Accept": "text/event-stream"}
+    resolved = resolve_token(token)
+    if resolved:
+        headers["Authorization"] = f"Bearer {resolved}"
+
+    count = 0
+    try:
+        with httpx.stream("GET", url, headers=headers, timeout=30.0) as resp:
+            if resp.status_code == 401:
+                raise HfLogsUnavailableError(
+                    "Authentication required for log streaming. Provide a token via "
+                    "--token or HF_TOKEN."
+                )
+            if resp.status_code == 404:
+                raise HfLogsUnavailableError(
+                    f"Space not found or logs endpoint unavailable: {owner}/{name}"
+                )
+            if resp.status_code != 200:
+                raise HfLogsUnavailableError(
+                    f"Log endpoint returned HTTP {resp.status_code} for {owner}/{name}"
+                )
+            for line in resp.iter_lines():
+                if line.startswith("data:"):
+                    payload = line[5:].strip()
+                    if payload and payload != "[DONE]":
+                        yield payload
+                        count += 1
+                        if count >= max_lines:
+                            return
+    except HfLogsUnavailableError:
+        raise
+    except Exception as exc:
+        raise HfLogsUnavailableError(f"Log streaming failed for {owner}/{name}: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Exception translation
+# ---------------------------------------------------------------------------
+
+
+def _translate_exc(exc: Exception, repo_id: Optional[str] = None) -> None:
+    """
+    Convert huggingface_hub exceptions to typed HfBackendError subclasses.
+
+    Always re-raises — never returns normally.
+    """
+    msg = str(exc)
+    lower = msg.lower()
+
+    # Try to classify by message content (hub exceptions vary by version)
+    if "401" in msg or "unauthorized" in lower or "invalid token" in lower:
+        raise HfAuthError(f"Authentication failed. Check your token. ({msg})") from exc
+    if "403" in msg or "forbidden" in lower:
+        raise HfAuthError(f"Access forbidden for {repo_id or 'resource'}. ({msg})") from exc
+    if "404" in msg or "not found" in lower or "repository not found" in lower:
+        label = f" '{repo_id}'" if repo_id else ""
+        raise HfSpaceNotFoundError(f"Space{label} not found or not accessible. ({msg})") from exc
+    if "429" in msg or "rate limit" in lower:
+        raise HfRateLimitError(
+            f"HuggingFace API rate limit exceeded. Retry after a moment. ({msg})"
+        ) from exc
+    # Default: re-wrap as HfBackendError
+    raise HfBackendError(f"HuggingFace API error: {msg}") from exc

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/utils/repl_skin.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/cli_anything/hf_spaces/utils/repl_skin.py
@@ -1,0 +1,491 @@
+"""cli-anything REPL Skin — Unified terminal interface for all CLI harnesses.
+
+Vendor copy for cli-anything-hf-spaces.
+Original: cli_anything/elementor/utils/repl_skin.py
+
+Usage:
+    from cli_anything.hf_spaces.utils.repl_skin import ReplSkin
+
+    skin = ReplSkin("hf_spaces", version="1.0.0")
+    skin.print_banner()
+    skin.success("Space restarted")
+    skin.error("Auth failed")
+    skin.table(headers, rows)
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# ── ANSI color codes (no external deps for core styling) ──────────────
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_ITALIC = "\033[3m"
+_UNDERLINE = "\033[4m"
+
+# Brand colors
+_CYAN = "\033[38;5;80m"  # cli-anything brand cyan
+_CYAN_BG = "\033[48;5;80m"
+_WHITE = "\033[97m"
+_GRAY = "\033[38;5;245m"
+_DARK_GRAY = "\033[38;5;240m"
+_LIGHT_GRAY = "\033[38;5;250m"
+
+# Software accent colors — each software gets a unique accent
+_ACCENT_COLORS = {
+    "gimp": "\033[38;5;214m",  # warm orange
+    "blender": "\033[38;5;208m",  # deep orange
+    "inkscape": "\033[38;5;39m",  # bright blue
+    "audacity": "\033[38;5;33m",  # navy blue
+    "libreoffice": "\033[38;5;40m",  # green
+    "obs_studio": "\033[38;5;55m",  # purple
+    "kdenlive": "\033[38;5;69m",  # slate blue
+    "shotcut": "\033[38;5;35m",  # teal green
+    "hf_spaces": "\033[38;5;166m",  # HuggingFace orange
+}
+_DEFAULT_ACCENT = "\033[38;5;75m"  # default sky blue
+
+# Status colors
+_GREEN = "\033[38;5;78m"
+_YELLOW = "\033[38;5;220m"
+_RED = "\033[38;5;196m"
+_BLUE = "\033[38;5;75m"
+_MAGENTA = "\033[38;5;176m"
+
+_SKILL_SOURCE_REPO = os.environ.get("CLI_ANYTHING_SKILL_REPO", "HKUDS/CLI-Anything")
+
+# ── Brand icon ────────────────────────────────────────────────────────
+
+_ICON = f"{_CYAN}{_BOLD}◆{_RESET}"
+_ICON_SMALL = f"{_CYAN}▸{_RESET}"
+
+# ── Box drawing characters ────────────────────────────────────────────
+
+_H_LINE = "─"
+_V_LINE = "│"
+_TL = "╭"
+_TR = "╮"
+_BL = "╰"
+_BR = "╯"
+_T_DOWN = "┬"
+_T_UP = "┴"
+_T_RIGHT = "├"
+_T_LEFT = "┤"
+_CROSS = "┼"
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes for length calculation."""
+    import re
+
+    return re.sub(r"\033\[[^m]*m", "", text)
+
+
+def _visible_len(text: str) -> int:
+    """Get visible length of text (excluding ANSI codes)."""
+    return len(_strip_ansi(text))
+
+
+def _display_home_path(path: str) -> str:
+    """Display a path relative to the home directory when possible."""
+    expanded = Path(path).expanduser().resolve()
+    home = Path.home().resolve()
+    try:
+        relative = expanded.relative_to(home)
+        return f"~/{relative.as_posix()}"
+    except ValueError:
+        return str(expanded)
+
+
+class ReplSkin:
+    """Unified REPL skin for cli-anything CLIs.
+
+    Provides consistent branding, prompts, and message formatting
+    across all CLI harnesses built with the cli-anything methodology.
+    """
+
+    def __init__(
+        self,
+        software: str,
+        version: str = "1.0.0",
+        history_file: str | None = None,
+        skill_path: str | None = None,
+    ):
+        """Initialize the REPL skin.
+
+        Args:
+            software: Software name (e.g., "hf_spaces").
+            version: CLI version string.
+            history_file: Path for persistent command history.
+                         Defaults to ~/.cli-anything-<software>/history
+            skill_path: Path to the SKILL.md file for agent discovery.
+        """
+        self.software = software.lower().replace("-", "_")
+        self.display_name = software.replace("_", " ").title()
+        self.version = version
+        self.skill_slug = self.software.replace("_", "-")
+        self.skill_id = f"cli-anything-{self.skill_slug}"
+        self.skill_install_cmd = (
+            f"npx skills add {_SKILL_SOURCE_REPO} --skill {self.skill_id} -g -y"
+        )
+        global_skill_root = Path(
+            os.environ.get(
+                "CLI_ANYTHING_GLOBAL_SKILLS_DIR",
+                str(Path.home() / ".agents" / "skills"),
+            )
+        ).expanduser()
+        self.global_skill_path = str(global_skill_root / self.skill_id / "SKILL.md")
+
+        if skill_path is None:
+            package_skill = Path(__file__).resolve().parent.parent / "skills" / "SKILL.md"
+            repo_skill = None
+            for parent in Path(__file__).resolve().parents:
+                candidate = parent / "skills" / self.skill_id / "SKILL.md"
+                if candidate.is_file():
+                    repo_skill = candidate
+                    break
+            if repo_skill and repo_skill.is_file():
+                skill_path = str(repo_skill)
+            elif package_skill.is_file():
+                skill_path = str(package_skill)
+        self.skill_path = skill_path
+        self.accent = _ACCENT_COLORS.get(self.software, _DEFAULT_ACCENT)
+
+        if history_file is None:
+            hist_dir = Path.home() / f".cli-anything-{self.software}"
+            hist_dir.mkdir(parents=True, exist_ok=True)
+            self.history_file = str(hist_dir / "history")
+        else:
+            self.history_file = history_file
+
+        self._color = self._detect_color_support()
+
+    def _detect_color_support(self) -> bool:
+        """Check if terminal supports color."""
+        if os.environ.get("NO_COLOR"):
+            return False
+        if os.environ.get("CLI_ANYTHING_NO_COLOR"):
+            return False
+        if not hasattr(sys.stdout, "isatty"):
+            return False
+        return sys.stdout.isatty()
+
+    def _c(self, code: str, text: str) -> str:
+        """Apply color code if colors are supported."""
+        if not self._color:
+            return text
+        return f"{code}{text}{_RESET}"
+
+    # ── Banner ────────────────────────────────────────────────────────
+
+    def print_banner(self) -> None:
+        """Print the startup banner with branding."""
+        import textwrap
+
+        inner = 72
+
+        def _box_line(content: str) -> str:
+            pad = inner - _visible_len(content)
+            vl = self._c(_DARK_GRAY, _V_LINE)
+            return f"{vl}{content}{' ' * max(0, pad)}{vl}"
+
+        def _meta_lines(label: str, value: str) -> list:
+            icon = self._c(_MAGENTA, "◇")
+            label_text = self._c(_DARK_GRAY, label)
+            prefix = f" {icon} {label_text} "
+            available = max(12, inner - _visible_len(prefix))
+            wrapped = textwrap.wrap(
+                value,
+                width=available,
+                break_long_words=True,
+                break_on_hyphens=False,
+            ) or [""]
+            lines = [f"{prefix}{self._c(_LIGHT_GRAY, wrapped[0])}"]
+            continuation_prefix = " " * _visible_len(prefix)
+            for chunk in wrapped[1:]:
+                lines.append(f"{continuation_prefix}{self._c(_LIGHT_GRAY, chunk)}")
+            return lines
+
+        top = self._c(_DARK_GRAY, f"{_TL}{_H_LINE * inner}{_TR}")
+        bot = self._c(_DARK_GRAY, f"{_BL}{_H_LINE * inner}{_BR}")
+
+        icon = self._c(_CYAN + _BOLD, "◆")
+        brand = self._c(_CYAN + _BOLD, "cli-anything")
+        dot = self._c(_DARK_GRAY, "·")
+        name = self._c(self.accent + _BOLD, self.display_name)
+        title = f" {icon}  {brand} {dot} {name}"
+
+        ver = f" {self._c(_DARK_GRAY, f'   v{self.version}')}"
+        tip = f" {self._c(_DARK_GRAY, '   Type help for commands, quit to exit')}"
+        empty = ""
+
+        meta_lines: list = []
+        meta_lines.extend(_meta_lines("Install:", self.skill_install_cmd))
+        meta_lines.extend(_meta_lines("Global skill:", _display_home_path(self.global_skill_path)))
+        print(top)
+        print(_box_line(title))
+        print(_box_line(ver))
+        for line in meta_lines:
+            print(_box_line(line))
+        print(_box_line(empty))
+        print(_box_line(tip))
+        print(bot)
+        print()
+
+    # ── Prompt ────────────────────────────────────────────────────────
+
+    def prompt(
+        self,
+        project_name: str = "",
+        modified: bool = False,
+        context: str = "",
+    ) -> str:
+        """Build a styled prompt string."""
+        parts = []
+        if self._color:
+            parts.append(f"{_CYAN}◆{_RESET} ")
+        else:
+            parts.append("> ")
+        parts.append(self._c(self.accent + _BOLD, self.software))
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            parts.append(f" {self._c(_DARK_GRAY, '[')}")
+            parts.append(self._c(_LIGHT_GRAY, f"{ctx}{mod}"))
+            parts.append(self._c(_DARK_GRAY, "]"))
+        parts.append(self._c(_GRAY, " ❯ "))
+        return "".join(parts)
+
+    def prompt_tokens(
+        self,
+        project_name: str = "",
+        modified: bool = False,
+        context: str = "",
+    ) -> list:
+        """Build prompt_toolkit formatted text tokens."""
+        tokens = []
+        tokens.append(("class:icon", "◆ "))
+        tokens.append(("class:software", self.software))
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            tokens.append(("class:bracket", " ["))
+            tokens.append(("class:context", f"{ctx}{mod}"))
+            tokens.append(("class:bracket", "]"))
+        tokens.append(("class:arrow", " ❯ "))
+        return tokens
+
+    def get_prompt_style(self):
+        """Get a prompt_toolkit Style object matching the skin."""
+        try:
+            from prompt_toolkit.styles import Style
+        except ImportError:
+            return None
+        accent_hex = _ANSI_256_TO_HEX.get(self.accent, "#5fafff")
+        return Style.from_dict(
+            {
+                "icon": "#5fdfdf bold",
+                "software": f"{accent_hex} bold",
+                "bracket": "#585858",
+                "context": "#bcbcbc",
+                "arrow": "#808080",
+                "completion-menu.completion": "bg:#303030 #bcbcbc",
+                "completion-menu.completion.current": f"bg:{accent_hex} #000000",
+                "completion-menu.meta.completion": "bg:#303030 #808080",
+                "completion-menu.meta.completion.current": f"bg:{accent_hex} #000000",
+                "auto-suggest": "#585858",
+                "bottom-toolbar": "bg:#1c1c1c #808080",
+                "bottom-toolbar.text": "#808080",
+            }
+        )
+
+    # ── Messages ──────────────────────────────────────────────────────
+
+    def success(self, message: str) -> None:
+        """Print a success message with green checkmark."""
+        icon = self._c(_GREEN + _BOLD, "✓")
+        print(f"  {icon} {self._c(_GREEN, message)}")
+
+    def error(self, message: str) -> None:
+        """Print an error message with red cross."""
+        icon = self._c(_RED + _BOLD, "✗")
+        print(f"  {icon} {self._c(_RED, message)}", file=sys.stderr)
+
+    def warning(self, message: str) -> None:
+        """Print a warning message with yellow triangle."""
+        icon = self._c(_YELLOW + _BOLD, "⚠")
+        print(f"  {icon} {self._c(_YELLOW, message)}")
+
+    def info(self, message: str) -> None:
+        """Print an info message with blue dot."""
+        icon = self._c(_BLUE, "●")
+        print(f"  {icon} {self._c(_LIGHT_GRAY, message)}")
+
+    def hint(self, message: str) -> None:
+        """Print a subtle hint message."""
+        print(f"  {self._c(_DARK_GRAY, message)}")
+
+    def section(self, title: str) -> None:
+        """Print a section header."""
+        print()
+        print(f"  {self._c(self.accent + _BOLD, title)}")
+        print(f"  {self._c(_DARK_GRAY, _H_LINE * len(title))}")
+
+    # ── Status display ────────────────────────────────────────────────
+
+    def status(self, label: str, value: str) -> None:
+        """Print a key-value status line."""
+        lbl = self._c(_GRAY, f"  {label}:")
+        val = self._c(_WHITE, f" {value}")
+        print(f"{lbl}{val}")
+
+    def status_block(self, items: dict, title: str = "") -> None:
+        """Print a block of status key-value pairs."""
+        if title:
+            self.section(title)
+        max_key = max(len(k) for k in items) if items else 0
+        for label, value in items.items():
+            lbl = self._c(_GRAY, f"  {label:<{max_key}}")
+            val = self._c(_WHITE, f"  {value}")
+            print(f"{lbl}{val}")
+
+    def progress(self, current: int, total: int, label: str = "") -> None:
+        """Print a simple progress indicator."""
+        pct = int(current / total * 100) if total > 0 else 0
+        bar_width = 20
+        filled = int(bar_width * current / total) if total > 0 else 0
+        bar = "█" * filled + "░" * (bar_width - filled)
+        text = f"  {self._c(_CYAN, bar)} {self._c(_GRAY, f'{pct:3d}%')}"
+        if label:
+            text += f" {self._c(_LIGHT_GRAY, label)}"
+        print(text)
+
+    # ── Table display ─────────────────────────────────────────────────
+
+    def table(
+        self,
+        headers: list,
+        rows: list,
+        max_col_width: int = 40,
+    ) -> None:
+        """Print a formatted table with box-drawing characters."""
+        if not headers:
+            return
+        col_widths = [min(len(h), max_col_width) for h in headers]
+        for row in rows:
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    col_widths[i] = min(max(col_widths[i], len(str(cell))), max_col_width)
+
+        def pad(text: str, width: int) -> str:
+            t = str(text)[:width]
+            return t + " " * (width - len(t))
+
+        header_cells = [
+            self._c(_CYAN + _BOLD, pad(h, col_widths[i])) for i, h in enumerate(headers)
+        ]
+        sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+        print(f"  {sep.join(header_cells)}")
+        print(
+            self._c(
+                _DARK_GRAY,
+                f"  {'───'.join([_H_LINE * w for w in col_widths])}",
+            )
+        )
+        for row in rows:
+            cells = []
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    cells.append(self._c(_LIGHT_GRAY, pad(str(cell), col_widths[i])))
+            row_sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+            print(f"  {row_sep.join(cells)}")
+
+    # ── Help display ──────────────────────────────────────────────────
+
+    def help(self, commands: dict) -> None:
+        """Print a formatted help listing."""
+        self.section("Commands")
+        max_cmd = max(len(c) for c in commands) if commands else 0
+        for cmd, desc in commands.items():
+            cmd_styled = self._c(self.accent, f"  {cmd:<{max_cmd}}")
+            desc_styled = self._c(_GRAY, f"  {desc}")
+            print(f"{cmd_styled}{desc_styled}")
+        print()
+
+    # ── Goodbye ───────────────────────────────────────────────────────
+
+    def print_goodbye(self) -> None:
+        """Print a styled goodbye message."""
+        print(f"\n  {_ICON_SMALL} {self._c(_GRAY, 'Goodbye!')}\n")
+
+    # ── Prompt toolkit session factory ────────────────────────────────
+
+    def create_prompt_session(self):
+        """Create a prompt_toolkit PromptSession with skin styling."""
+        try:
+            from prompt_toolkit import PromptSession
+            from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+            from prompt_toolkit.history import FileHistory
+
+            style = self.get_prompt_style()
+            return PromptSession(
+                history=FileHistory(self.history_file),
+                auto_suggest=AutoSuggestFromHistory(),
+                style=style,
+                enable_history_search=True,
+            )
+        except ImportError:
+            return None
+
+    def get_input(
+        self,
+        pt_session,
+        project_name: str = "",
+        modified: bool = False,
+        context: str = "",
+    ) -> str:
+        """Get input from user using prompt_toolkit or fallback."""
+        if pt_session is not None:
+            from prompt_toolkit.formatted_text import FormattedText
+
+            tokens = self.prompt_tokens(project_name, modified, context)
+            return pt_session.prompt(FormattedText(tokens)).strip()
+        raw_prompt = self.prompt(project_name, modified, context)
+        return input(raw_prompt).strip()
+
+    # ── Toolbar builder ───────────────────────────────────────────────
+
+    def bottom_toolbar(self, items: dict):
+        """Create a bottom toolbar callback for prompt_toolkit."""
+
+        def toolbar():
+            from prompt_toolkit.formatted_text import FormattedText
+
+            parts = []
+            for i, (k, v) in enumerate(items.items()):
+                if i > 0:
+                    parts.append(("class:bottom-toolbar.text", "  │  "))
+                parts.append(("class:bottom-toolbar.text", f" {k}: "))
+                parts.append(("class:bottom-toolbar", v))
+            return FormattedText(parts)
+
+        return toolbar
+
+
+# ── ANSI 256-color to hex mapping (for prompt_toolkit styles) ─────────
+
+_ANSI_256_TO_HEX = {
+    "\033[38;5;33m": "#0087ff",  # audacity navy blue
+    "\033[38;5;35m": "#00af5f",  # shotcut teal
+    "\033[38;5;39m": "#00afff",  # inkscape bright blue
+    "\033[38;5;40m": "#00d700",  # libreoffice green
+    "\033[38;5;55m": "#5f00af",  # obs purple
+    "\033[38;5;69m": "#5f87ff",  # kdenlive slate blue
+    "\033[38;5;75m": "#5fafff",  # default sky blue
+    "\033[38;5;80m": "#5fd7d7",  # brand cyan
+    "\033[38;5;166m": "#d75f00",  # hf_spaces orange
+    "\033[38;5;208m": "#ff8700",  # blender deep orange
+    "\033[38;5;214m": "#ffaf00",  # gimp warm orange
+}

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/setup.py
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/setup.py
@@ -1,0 +1,64 @@
+"""
+setup.py for cli-anything-hf-spaces.
+
+Install:
+    pip install -e .                          # core only
+    pip install -e ".[hf]"                    # + huggingface_hub
+    pip install -e ".[logs]"                  # + httpx for log streaming
+    pip install -e ".[repl]"                  # + prompt-toolkit for REPL
+    pip install -e ".[all]"                   # everything
+    pip install -e ".[dev]"                   # dev dependencies
+"""
+
+from setuptools import find_namespace_packages, setup
+
+setup(
+    name="cli-anything-hf-spaces",
+    version="1.0.0",
+    description="cli-anything harness for HuggingFace Spaces administration",
+    python_requires=">=3.10",
+    packages=find_namespace_packages(include=["cli_anything.*"]),
+    install_requires=[
+        "click>=8.1,<9.0",
+    ],
+    extras_require={
+        "hf": [
+            "huggingface_hub>=0.26.0,<1.0",
+        ],
+        "logs": [
+            "huggingface_hub>=0.26.0,<1.0",
+            "httpx>=0.24.0",
+        ],
+        "repl": [
+            "prompt-toolkit>=3.0,<4.0",
+        ],
+        "all": [
+            "huggingface_hub>=0.26.0,<1.0",
+            "httpx>=0.24.0",
+            "prompt-toolkit>=3.0,<4.0",
+        ],
+        "dev": [
+            "huggingface_hub>=0.26.0,<1.0",
+            "httpx>=0.24.0",
+            "prompt-toolkit>=3.0,<4.0",
+            "pytest>=7",
+            "pytest-cov>=4",
+            "build",
+            "twine",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "hf-spaces=cli_anything.hf_spaces.hf_spaces_cli:main",
+            "cli-anything-hf-spaces=cli_anything.hf_spaces.hf_spaces_cli:main",
+        ],
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "License :: OSI Approved :: MIT License",
+        "Environment :: Console",
+    ],
+)

--- a/skyyrose/cli_harnesses/hf-spaces/agent-harness/skills/cli-anything-hf-spaces/SKILL.md
+++ b/skyyrose/cli_harnesses/hf-spaces/agent-harness/skills/cli-anything-hf-spaces/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: cli-anything-hf-spaces
+description: >
+  CLI harness for HuggingFace Spaces administration. Manages hardware tiers,
+  env vars, secrets, sleep/restart, logs, README sync, and manifest-driven
+  desired-state apply.
+---
+
+# cli-anything-hf-spaces
+
+## When to use this skill
+
+Use this skill when you need to:
+- Administer HuggingFace Spaces from the command line
+- Change hardware tiers (with billing awareness)
+- Manage Space secrets and environment variables
+- Stream runtime or build logs
+- Sync README.md files
+- Apply manifest-driven desired state to a Space
+
+## Prerequisites
+
+```bash
+pip install 'cli-anything-hf-spaces[all]'
+# or for minimal install:
+pip install cli-anything-hf-spaces
+```
+
+Auth (in priority order):
+1. `--token <token>` (in-memory only, never written to disk)
+2. `HF_TOKEN` environment variable
+3. `~/.cache/huggingface/token` (from `huggingface-cli login`)
+
+## Command groups
+
+| Group      | Description                                      |
+|------------|--------------------------------------------------|
+| `space`    | info, list, pause, restart, duplicate            |
+| `hardware` | get, set (STOP-AND-SHOW), list-tiers             |
+| `secrets`  | set, delete (STOP-AND-SHOW), list (manifest only)|
+| `vars`     | list, get, set, delete                           |
+| `logs`     | run, build (httpx SSE streaming)                 |
+| `readme`   | get, set, sync                                   |
+| `manifest` | init, show, plan, apply (STOP-AND-SHOW)          |
+| `session`  | list, show, delete                               |
+| `doctor`   | auth + SDK health check                          |
+
+## Key constraints
+
+- **Secrets are write-only** via HfApi. `secrets list` reads local manifest only.
+- **Log streaming** requires `httpx`: `pip install 'cli-anything-hf-spaces[logs]'`
+- **Factory reset** is web-UI only — not available in this CLI.
+- **STOP-AND-SHOW gate** on: `hardware set`, `secrets delete`, `space pause`, `manifest apply`
+- Token is **never** written to disk by the CLI.
+
+## Quick reference
+
+```bash
+hf-spaces space info owner/my-space
+hf-spaces hardware set owner/my-space t4-small --confirm
+hf-spaces secrets set owner/my-space MY_API_KEY
+hf-spaces vars list owner/my-space
+hf-spaces logs run owner/my-space
+hf-spaces readme sync owner/my-space ./README.md
+hf-spaces manifest plan ./hf-space-manifest.json
+hf-spaces manifest apply ./hf-space-manifest.json --confirm
+hf-spaces doctor
+hf-spaces          # interactive REPL
+```

--- a/skyyrose/cli_harnesses/marvelous/CLAUDE.md
+++ b/skyyrose/cli_harnesses/marvelous/CLAUDE.md
@@ -1,0 +1,3 @@
+<claude-mem-context>
+
+</claude-mem-context>

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/MARVELOUS.md
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/MARVELOUS.md
@@ -1,0 +1,204 @@
+# MARVELOUS.md — cli-anything-marvelous Research + Architecture
+
+## Phase 1 — API Research
+
+### Marvelous Designer Scripting API
+
+Marvelous Designer (CLO Virtual Fashion, MD 12+) exposes a Python scripting interface
+through internal modules available only within the application process:
+
+| Module | Key Functions |
+|--------|--------------|
+| `import_api` | `ImportFile(path)`, `ImportZpac(path)`, `ImportZprj(path)` |
+| `export_api` | `ExportOBJ(path)`, `ExportFBX(path)`, `ExportAlembic(path)`, `ExportUSD(path)`, `ExportZpac(path)`, `ExportZprj(path)` |
+| `utility_api` | `NewProject()`, `Simulate(frames)`, `GetVersion()` |
+| `fabric_api` | `GetFabricCount()`, `AssignFabricToPattern(patternName, fabricName, texturePath)` |
+| `pattern_api` | `GetPatternPieceNames()`, `GetPatternPieceCount()` |
+| `ApiTypes` | Enum types for export format options |
+
+**Reference:** https://developer.marvelousdesigner.com/scenario.html
+
+### File Formats
+
+| Extension | Description |
+|-----------|-------------|
+| `.zpac` | Primary project bundle — ZIP archive containing `project.json`, `garment.json`, texture assets |
+| `.zprj` | Legacy project format — similar ZIP structure |
+
+Both are readable with Python's stdlib `zipfile` module without MD installed.
+
+### Headless / Batch Execution
+
+**Important caveat:** As of MD 12, Marvelous Designer does not officially expose a
+headless mode or documented `--script` CLI flag. The `--script` behavior assumed by
+this harness is based on user workflow reports and is NOT confirmed in official
+developer documentation. Official docs state: *"No command-line/batch session is
+available as of Marvelous Designer 12."*
+
+The `marvelous_backend.run_md_script()` function wraps the assumed invocation:
+```
+"Marvelous Designer" --script /tmp/script.py
+```
+
+If MD's actual invocation syntax differs, only `marvelous_backend.py` needs updating.
+All script templates are valid Python and will work once the invocation path is known.
+
+### macOS Binary Location
+
+```
+/Applications/CLO Virtual Fashion/Marvelous Designer*/Marvelous Designer.app/Contents/MacOS/Marvelous Designer
+```
+
+Override via `MARVELOUS_DESIGNER_BIN` env var.
+
+### Export Format Coverage
+
+| Format | API Function | Notes |
+|--------|-------------|-------|
+| obj | `ExportOBJ()` | Most compatible |
+| fbx | `ExportFBX()` | Maya/3ds Max/Blender |
+| alembic | `ExportAlembic()` | VFX pipelines |
+| usd | `ExportUSD()` | Pixar Universal Scene Description |
+| zpac | `ExportZpac()` | MD native round-trip |
+| zprj | `ExportZprj()` | MD legacy round-trip |
+
+Note: GLB/GLTF is **not** in the MD Python API. Use FBX + Blender CLI for GLB conversion.
+
+---
+
+## Phase 2 — Architecture
+
+### Package Layout
+
+```
+cli_anything/marvelous/
+├── __init__.py               # __version__ = "1.0.0"
+├── __main__.py               # python -m cli_anything.marvelous entry
+├── marvelous_cli.py          # Click root group + all command groups
+├── core/
+│   ├── garment.py            # FabricProperty, PatternPiece, Garment dataclasses
+│   ├── project.py            # .zpac/.zprj parser (zipfile, no MD needed)
+│   ├── session.py            # Atomic session CRUD (fcntl + tmpfile + os.replace)
+│   └── library.py            # Local garment template library
+├── utils/
+│   ├── marvelous_backend.py  # subprocess wrapper, find_marvelous_binary, script runner
+│   └── repl_skin.py          # prompt-toolkit REPL skin (marvelous accent: violet)
+├── resources/
+│   └── scripts/
+│       ├── export.py.tpl     # MD export script template (${var} substitution)
+│       ├── simulate.py.tpl   # MD simulation script template
+│       └── add_fabric.py.tpl # MD fabric-assignment script template
+└── tests/
+    ├── TEST.md               # Test plan and inventory
+    ├── test_core.py          # 57 unit tests (pure Python, no MD needed)
+    └── test_full_e2e.py      # Smoke + live tests (MARVELOUS_E2E=1 gate)
+```
+
+### Command Hierarchy
+
+```
+cli-anything-marvelous [--json] [--verbose]
+├── project
+│   ├── info <file>           # Parse .zpac/.zprj metadata
+│   └── new --name            # Create new session
+├── garment
+│   ├── list <file>           # List patterns + fabrics from project
+│   └── add-fabric <file>     # Assign fabric via MD script (requires MD)
+├── simulate
+│   └── run <file>            # Run MD simulation for N frames (requires MD)
+├── export
+│   └── run <file>            # Export to obj/fbx/alembic/usd/zpac/zprj (requires MD)
+├── library
+│   ├── list                  # List locally imported garment templates
+│   └── import <file>         # Import .zpac into local library
+├── config
+│   └── doctor                # Check MD binary + directory health
+├── session
+│   ├── status <id>           # Show session state
+│   ├── save                  # Save current session
+│   ├── list                  # List all sessions
+│   └── delete <id>           # Delete session
+└── repl                      # Interactive REPL (default when no subcommand)
+```
+
+### Data Flow
+
+```
+.zpac file
+    └── zipfile.ZipFile
+        ├── project.json  →  ProjectMeta (core/project.py)
+        └── garment.json  →  Garment     (core/garment.py)
+
+CLI command
+    └── marvelous_cli.py
+        ├── Pure operations  →  core/* (no MD needed)
+        └── MD operations    →  marvelous_backend.py
+                                    ├── load_script_template(name)   resources/scripts/*.tpl
+                                    ├── render_script_template(vars) string.Template
+                                    └── run_md_script(text)          subprocess ["MD", "--script", tmpfile]
+```
+
+### Session + Library Storage
+
+```
+~/.cli-anything-marvelous/
+└── sessions/
+    └── session-{uuid}.json   # Atomic writes via _locked_save_json
+
+~/.cli_anything/marvelous/
+└── library/
+    ├── {slug}/
+    │   ├── source.zpac        # Copied project file
+    │   └── meta.json          # LibraryEntry metadata
+    └── ...
+```
+
+### Atomic Write Pattern
+
+All JSON writes use `_locked_save_json(path, payload)`:
+
+1. `fcntl.flock(fd, LOCK_EX)` — acquire exclusive lock on lock file
+2. `tempfile.mkstemp(dir=path.parent)` — write to temp file in same directory
+3. `os.replace(tmp, path)` — atomic rename (POSIX guarantee: readers never see partial write)
+4. `finally: fcntl.flock(fd, LOCK_UN)` — release lock
+
+### Script Template Rendering
+
+```python
+from string import Template
+t = Template(open("export.py.tpl").read())
+script = t.substitute(project_path="/path/to.zpac", output_path="/out/dir", export_format="obj")
+```
+
+Missing variable → `KeyError` (surfaces to CLI as error, not silent failure).
+
+### REPL Architecture
+
+`repl` command uses `prompt_toolkit.PromptSession` with:
+- History: `FileHistory("~/.cli-anything-marvelous/repl_history")`
+- Accent: `"\033[38;5;171m"` (violet) via `ReplSkin("marvelous")`
+- Dispatch: `main.main(args=parts, standalone_mode=False)` on each input line
+- Exit: `exit`, `quit`, or `Ctrl-D`
+
+### Exception Hierarchy
+
+```
+MarvelousError (base)
+├── MarvelousNotFoundError    # MD binary not found
+├── MarvelousScriptError      # MD ran but script failed (returncode + stderr)
+└── MarvelousTimeoutError     # MD process exceeded timeout
+```
+
+All exceptions translate to `emit_error()` in `marvelous_cli.py`; `--json` mode
+outputs `{"error": "...", "code": "..."}`.
+
+### Test Strategy
+
+**Unit tests** (`test_core.py`) — 57 tests, zero MD dependency:
+- Synthetic `.zpac` via `zipfile.ZipFile(tmp_path / "x.zpac", "w")`
+- Session/library dirs monkeypatched to `tmp_path`
+- `glob.glob` monkeypatched to simulate missing MD binary
+
+**E2E tests** (`test_full_e2e.py`) — gated on `MARVELOUS_E2E=1`:
+- Smoke tests (8) run always — no MD needed
+- Live tests (2) need real MD + optionally `MARVELOUS_TEST_ZPAC=/path/to.zpac`

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/README.md
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/README.md
@@ -1,0 +1,183 @@
+# cli-anything-marvelous
+
+CLI harness for [Marvelous Designer](https://marvelousdesigner.com/) — the 3D garment
+tailoring application by CLO Virtual Fashion.
+
+Wraps the MD scripting API in a composable CLI with JSON output, session management,
+a local garment library, and an interactive REPL.
+
+---
+
+## Installation
+
+```bash
+pip install -e ".[dev]"
+```
+
+**Hard dependency:** Marvelous Designer must be installed for `simulate run`,
+`export run`, and `garment add-fabric` commands. All other commands work without MD.
+
+---
+
+## Quick Start
+
+```bash
+# Inspect a project file (no MD needed)
+cli-anything-marvelous project info shirt.zpac
+cli-anything-marvelous --json project info shirt.zpac
+
+# Export to OBJ (requires MD)
+cli-anything-marvelous export run shirt.zpac --format obj --output ./exports/shirt
+
+# Simulate 30 frames and save (requires MD)
+cli-anything-marvelous simulate run shirt.zpac --frames 30 --output ./renders/shirt_sim.zpac
+
+# Assign a fabric texture (requires MD)
+cli-anything-marvelous garment add-fabric shirt.zpac \
+  --pattern "Front Bodice" --fabric "Cotton Twill" --texture ./textures/cotton.jpg \
+  --output ./modified_shirt.zpac
+
+# Import into local library
+cli-anything-marvelous library import shirt.zpac --slug my-shirt --name "Sample Shirt"
+
+# Interactive REPL
+cli-anything-marvelous
+```
+
+---
+
+## Commands
+
+### `project info <file>`
+Parse `.zpac` or `.zprj` metadata without launching MD.
+
+```
+Options:
+  --json  Output as JSON
+```
+
+### `project new`
+Create a new session with optional project association.
+
+### `garment list <file>`
+List pattern pieces and fabric assignments from a project file.
+
+### `garment add-fabric <file>`
+Assign a fabric texture to a pattern piece via MD script injection.
+
+```
+Options:
+  --pattern TEXT   Pattern piece name (required)
+  --fabric TEXT    Fabric display name (required)
+  --texture PATH   Texture image path (required)
+  --output PATH    Output .zpac path (required)
+  --timeout INT    MD timeout in seconds (default: 300)
+```
+
+### `simulate run <file>`
+Run MD cloth simulation for N frames.
+
+```
+Options:
+  --frames INT   Frame count (default: 30)
+  --output PATH  Output .zpac path (required)
+  --timeout INT  MD timeout in seconds (default: 600)
+```
+
+### `export run <file>`
+Export garment to a standard format.
+
+```
+Options:
+  --format [obj|fbx|alembic|usd|zpac|zprj]  Export format (default: obj)
+  --output PATH                              Output path (required)
+  --timeout INT                              MD timeout in seconds (default: 300)
+```
+
+### `library list`
+List imported garment templates.
+
+### `library import <file>`
+Import a `.zpac` file into the local template library.
+
+```
+Options:
+  --slug TEXT    Library identifier (required)
+  --name TEXT    Display name (required)
+  --description TEXT
+  --tags TEXT    Comma-separated tags
+```
+
+### `config doctor`
+Check MD binary discovery and storage directory health.
+
+### `session status <id>`
+Show state of a saved session.
+
+### `session save`
+Save current session state.
+
+### `session list`
+List all saved sessions.
+
+### `session delete <id>`
+Delete a session by ID.
+
+### `repl`
+Interactive REPL (default command when invoked with no arguments).
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `MARVELOUS_DESIGNER_BIN` | Override path to MD binary |
+| `MARVELOUS_E2E` | Set to `1` to enable live E2E tests |
+| `MARVELOUS_TEST_ZPAC` | Path to real `.zpac` for E2E live tests |
+| `CLI_ANYTHING_FORCE_INSTALLED` | Set to `1` to require installed binary in tests |
+
+---
+
+## Storage Locations
+
+| Path | Contents |
+|------|----------|
+| `~/.cli-anything-marvelous/sessions/` | Saved sessions (JSON, atomic writes) |
+| `~/.cli_anything/marvelous/library/` | Imported garment templates |
+| `~/.cli-anything-marvelous/repl_history` | REPL command history |
+
+---
+
+## Testing
+
+```bash
+# Unit tests only (no MD required)
+pytest cli_anything/marvelous/tests/test_core.py -v
+
+# All tests including CLI smoke tests
+pytest cli_anything/marvelous/tests/ -v
+
+# With coverage
+pytest cli_anything/marvelous/tests/ --cov=cli_anything.marvelous --cov-report=term-missing
+
+# Full live run (requires MD installed + real .zpac)
+MARVELOUS_E2E=1 MARVELOUS_TEST_ZPAC=/path/to/shirt.zpac \
+  pytest cli_anything/marvelous/tests/ -v
+```
+
+---
+
+## Architecture Notes
+
+Script templates in `resources/scripts/` are injected into MD at runtime using
+Python's `string.Template` with `${var}` substitution. The templates use the real
+MD Python API (`import_api`, `export_api`, `utility_api`, `fabric_api`) and will
+execute correctly once the `--script` invocation path is confirmed.
+
+**Known limitation:** MD's `--script` flag is not officially documented as of MD 12.
+The invocation `"Marvelous Designer" --script /tmp/script.py` is based on user
+workflow reports. If the actual syntax differs, update `run_md_script()` in
+`cli_anything/marvelous/utils/marvelous_backend.py`.
+
+See `MARVELOUS.md` for full API research and architectural decision log.

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/README.md
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/README.md
@@ -1,0 +1,183 @@
+# cli-anything-marvelous
+
+CLI harness for [Marvelous Designer](https://marvelousdesigner.com/) — the 3D garment
+tailoring application by CLO Virtual Fashion.
+
+Wraps the MD scripting API in a composable CLI with JSON output, session management,
+a local garment library, and an interactive REPL.
+
+---
+
+## Installation
+
+```bash
+pip install -e ".[dev]"
+```
+
+**Hard dependency:** Marvelous Designer must be installed for `simulate run`,
+`export run`, and `garment add-fabric` commands. All other commands work without MD.
+
+---
+
+## Quick Start
+
+```bash
+# Inspect a project file (no MD needed)
+cli-anything-marvelous project info shirt.zpac
+cli-anything-marvelous --json project info shirt.zpac
+
+# Export to OBJ (requires MD)
+cli-anything-marvelous export run shirt.zpac --format obj --output ./exports/shirt
+
+# Simulate 30 frames and save (requires MD)
+cli-anything-marvelous simulate run shirt.zpac --frames 30 --output ./renders/shirt_sim.zpac
+
+# Assign a fabric texture (requires MD)
+cli-anything-marvelous garment add-fabric shirt.zpac \
+  --pattern "Front Bodice" --fabric "Cotton Twill" --texture ./textures/cotton.jpg \
+  --output ./modified_shirt.zpac
+
+# Import into local library
+cli-anything-marvelous library import shirt.zpac --slug my-shirt --name "Sample Shirt"
+
+# Interactive REPL
+cli-anything-marvelous
+```
+
+---
+
+## Commands
+
+### `project info <file>`
+Parse `.zpac` or `.zprj` metadata without launching MD.
+
+```
+Options:
+  --json  Output as JSON
+```
+
+### `project new`
+Create a new session with optional project association.
+
+### `garment list <file>`
+List pattern pieces and fabric assignments from a project file.
+
+### `garment add-fabric <file>`
+Assign a fabric texture to a pattern piece via MD script injection.
+
+```
+Options:
+  --pattern TEXT   Pattern piece name (required)
+  --fabric TEXT    Fabric display name (required)
+  --texture PATH   Texture image path (required)
+  --output PATH    Output .zpac path (required)
+  --timeout INT    MD timeout in seconds (default: 300)
+```
+
+### `simulate run <file>`
+Run MD cloth simulation for N frames.
+
+```
+Options:
+  --frames INT   Frame count (default: 30)
+  --output PATH  Output .zpac path (required)
+  --timeout INT  MD timeout in seconds (default: 600)
+```
+
+### `export run <file>`
+Export garment to a standard format.
+
+```
+Options:
+  --format [obj|fbx|alembic|usd|zpac|zprj]  Export format (default: obj)
+  --output PATH                              Output path (required)
+  --timeout INT                              MD timeout in seconds (default: 300)
+```
+
+### `library list`
+List imported garment templates.
+
+### `library import <file>`
+Import a `.zpac` file into the local template library.
+
+```
+Options:
+  --slug TEXT    Library identifier (required)
+  --name TEXT    Display name (required)
+  --description TEXT
+  --tags TEXT    Comma-separated tags
+```
+
+### `config doctor`
+Check MD binary discovery and storage directory health.
+
+### `session status <id>`
+Show state of a saved session.
+
+### `session save`
+Save current session state.
+
+### `session list`
+List all saved sessions.
+
+### `session delete <id>`
+Delete a session by ID.
+
+### `repl`
+Interactive REPL (default command when invoked with no arguments).
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `MARVELOUS_DESIGNER_BIN` | Override path to MD binary |
+| `MARVELOUS_E2E` | Set to `1` to enable live E2E tests |
+| `MARVELOUS_TEST_ZPAC` | Path to real `.zpac` for E2E live tests |
+| `CLI_ANYTHING_FORCE_INSTALLED` | Set to `1` to require installed binary in tests |
+
+---
+
+## Storage Locations
+
+| Path | Contents |
+|------|----------|
+| `~/.cli-anything-marvelous/sessions/` | Saved sessions (JSON, atomic writes) |
+| `~/.cli_anything/marvelous/library/` | Imported garment templates |
+| `~/.cli-anything-marvelous/repl_history` | REPL command history |
+
+---
+
+## Testing
+
+```bash
+# Unit tests only (no MD required)
+pytest cli_anything/marvelous/tests/test_core.py -v
+
+# All tests including CLI smoke tests
+pytest cli_anything/marvelous/tests/ -v
+
+# With coverage
+pytest cli_anything/marvelous/tests/ --cov=cli_anything.marvelous --cov-report=term-missing
+
+# Full live run (requires MD installed + real .zpac)
+MARVELOUS_E2E=1 MARVELOUS_TEST_ZPAC=/path/to/shirt.zpac \
+  pytest cli_anything/marvelous/tests/ -v
+```
+
+---
+
+## Architecture Notes
+
+Script templates in `resources/scripts/` are injected into MD at runtime using
+Python's `string.Template` with `${var}` substitution. The templates use the real
+MD Python API (`import_api`, `export_api`, `utility_api`, `fabric_api`) and will
+execute correctly once the `--script` invocation path is confirmed.
+
+**Known limitation:** MD's `--script` flag is not officially documented as of MD 12.
+The invocation `"Marvelous Designer" --script /tmp/script.py` is based on user
+workflow reports. If the actual syntax differs, update `run_md_script()` in
+`cli_anything/marvelous/utils/marvelous_backend.py`.
+
+See `MARVELOUS.md` for full API research and architectural decision log.

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/__init__.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/__init__.py
@@ -1,0 +1,4 @@
+"""cli-anything-marvelous — Marvelous Designer CLI harness."""
+
+__version__ = "1.0.0"
+__all__ = ["__version__"]

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/__main__.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for `python -m cli_anything.marvelous`."""
+
+from cli_anything.marvelous.marvelous_cli import main
+
+if __name__ == "__main__":
+    main()

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/core/__init__.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/core/__init__.py
@@ -1,0 +1,1 @@
+"""cli-anything-marvelous core data layer."""

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/core/garment.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/core/garment.py
@@ -1,0 +1,118 @@
+"""Garment domain model for Marvelous Designer projects.
+
+Dataclasses representing garments, fabrics, and patterns as read from
+.zpac/.zprj ZIP containers or populated at runtime.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class FabricProperty:
+    """Physical fabric properties used by MD simulation."""
+
+    name: str
+    texture_path: str = ""
+    color_hex: str = "#FFFFFF"
+    density: float = 0.3  # g/cm²
+    thickness: float = 0.5  # mm
+    stretch_weft: float = 50.0  # N/m
+    stretch_warp: float = 50.0  # N/m
+    shear_stiffness: float = 10.0
+    bending_weft: float = 0.5
+    bending_warp: float = 0.5
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "FabricProperty":
+        valid = {k for k in cls.__dataclass_fields__}
+        return cls(**{k: v for k, v in data.items() if k in valid})
+
+
+@dataclass
+class PatternPiece:
+    """A single 2D pattern piece within a garment."""
+
+    name: str
+    fabric_name: str = ""
+    vertex_count: int = 0
+    area_cm2: float = 0.0
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PatternPiece":
+        valid = {k for k in cls.__dataclass_fields__}
+        return cls(**{k: v for k, v in data.items() if k in valid})
+
+
+@dataclass
+class Garment:
+    """Full garment definition — patterns + fabrics.
+
+    This is the central domain object passed through commands and sessions.
+    Populated by parsing a .zpac/.zprj file or constructed from user input.
+    """
+
+    name: str
+    source_file: str = ""
+    patterns: list[PatternPiece] = field(default_factory=list)
+    fabrics: list[FabricProperty] = field(default_factory=list)
+    simulation_frames: int = 100
+    notes: str = ""
+
+    @property
+    def pattern_count(self) -> int:
+        return len(self.patterns)
+
+    @property
+    def fabric_count(self) -> int:
+        return len(self.fabrics)
+
+    def fabric_by_name(self, name: str) -> FabricProperty | None:
+        """Return fabric matching *name* (case-insensitive), or None."""
+        nl = name.lower()
+        return next((f for f in self.fabrics if f.name.lower() == nl), None)
+
+    def pattern_by_name(self, name: str) -> PatternPiece | None:
+        """Return pattern piece matching *name* (case-insensitive), or None."""
+        nl = name.lower()
+        return next((p for p in self.patterns if p.name.lower() == nl), None)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "source_file": self.source_file,
+            "patterns": [p.to_dict() for p in self.patterns],
+            "fabrics": [f.to_dict() for f in self.fabrics],
+            "simulation_frames": self.simulation_frames,
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Garment":
+        patterns = [PatternPiece.from_dict(p) for p in data.get("patterns", [])]
+        fabrics = [FabricProperty.from_dict(f) for f in data.get("fabrics", [])]
+        return cls(
+            name=data.get("name", "Untitled"),
+            source_file=data.get("source_file", ""),
+            patterns=patterns,
+            fabrics=fabrics,
+            simulation_frames=int(data.get("simulation_frames", 100)),
+            notes=data.get("notes", ""),
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_json(cls, text: str) -> "Garment":
+        return cls.from_dict(json.loads(text))

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/core/library.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/core/library.py
@@ -1,0 +1,166 @@
+"""Local garment template library for cli-anything-marvelous.
+
+The library lives at ~/.cli_anything/marvelous/library/ by default.
+Each entry is a subdirectory containing:
+    meta.json    — LibraryEntry metadata
+    garment.json — serialised Garment (optional, for pure-data templates)
+    *.zpac       — source project file (optional)
+
+Tests monkeypatch LIBRARY_DIR to a tmp_path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from cli_anything.marvelous.core.garment import Garment
+from cli_anything.marvelous.core.session import _locked_save_json
+
+# Default location; tests monkeypatch this or set MARVELOUS_LIBRARY_DIR
+LIBRARY_DIR = Path(
+    os.environ.get("MARVELOUS_LIBRARY_DIR", "")
+    or str(Path.home() / ".cli_anything" / "marvelous" / "library")
+)
+
+
+# ── Model ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class LibraryEntry:
+    """A garment template stored in the local library."""
+
+    slug: str
+    name: str
+    description: str = ""
+    tags: list[str] = field(default_factory=list)
+    source_file: str = ""  # relative path inside library entry dir
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "LibraryEntry":
+        valid = {k for k in cls.__dataclass_fields__}
+        d = {k: v for k, v in data.items() if k in valid}
+        if "tags" in d and not isinstance(d["tags"], list):
+            d["tags"] = []
+        return cls(**d)
+
+
+# ── CRUD ──────────────────────────────────────────────────────────────────
+
+
+def _entry_dir(slug: str) -> Path:
+    return LIBRARY_DIR / slug
+
+
+def list_library() -> list[LibraryEntry]:
+    """Return all library entries, sorted by slug."""
+    if not LIBRARY_DIR.exists():
+        return []
+    entries: list[LibraryEntry] = []
+    for meta_path in sorted(LIBRARY_DIR.glob("*/meta.json")):
+        try:
+            with meta_path.open(encoding="utf-8") as fh:
+                entries.append(LibraryEntry.from_dict(json.load(fh)))
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return entries
+
+
+def get_entry(slug: str) -> LibraryEntry:
+    """Load a single library entry by slug.
+
+    Raises:
+        KeyError: Entry not found.
+        ValueError: meta.json is malformed.
+    """
+    meta_path = _entry_dir(slug) / "meta.json"
+    if not meta_path.exists():
+        raise KeyError(f"Library entry '{slug}' not found")
+    try:
+        with meta_path.open(encoding="utf-8") as fh:
+            return LibraryEntry.from_dict(json.load(fh))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Malformed meta.json for '{slug}': {exc}") from exc
+
+
+def import_project(
+    source: str | Path,
+    slug: str,
+    name: str,
+    description: str = "",
+    tags: list[str] | None = None,
+) -> LibraryEntry:
+    """Import a .zpac/.zprj file into the library.
+
+    Copies the file into the library directory under *slug* and writes
+    a meta.json.
+
+    Args:
+        source:      Path to .zpac or .zprj file to import.
+        slug:        Unique library identifier (e.g. "tshirt-basic").
+        name:        Human-readable name.
+        description: Optional description.
+        tags:        Optional list of tags.
+
+    Returns:
+        The created LibraryEntry.
+
+    Raises:
+        FileNotFoundError: Source file does not exist.
+        FileExistsError:   Library entry with that slug already exists.
+        ValueError:        Source is not a .zpac or .zprj file.
+    """
+    src = Path(source)
+    if not src.exists():
+        raise FileNotFoundError(f"Source file not found: {src}")
+    if src.suffix.lower() not in (".zpac", ".zprj"):
+        raise ValueError(f"Expected .zpac or .zprj, got: {src.suffix}")
+
+    entry_dir = _entry_dir(slug)
+    if entry_dir.exists():
+        raise FileExistsError(
+            f"Library entry '{slug}' already exists at {entry_dir}. "
+            "Delete it first or choose a different slug."
+        )
+
+    entry_dir.mkdir(parents=True, exist_ok=True)
+    dest = entry_dir / src.name
+    shutil.copy2(str(src), str(dest))
+
+    entry = LibraryEntry(
+        slug=slug,
+        name=name,
+        description=description,
+        tags=tags or [],
+        source_file=src.name,
+    )
+    _locked_save_json(entry_dir / "meta.json", entry.to_dict())
+    return entry
+
+
+def delete_entry(slug: str) -> bool:
+    """Remove a library entry and its files.
+
+    Returns True if deleted, False if it did not exist.
+    """
+    entry_dir = _entry_dir(slug)
+    if not entry_dir.exists():
+        return False
+    shutil.rmtree(str(entry_dir))
+    return True
+
+
+def entry_source_path(entry: LibraryEntry) -> Path | None:
+    """Return the absolute path to the entry's source file, or None."""
+    if not entry.source_file:
+        return None
+    p = _entry_dir(entry.slug) / entry.source_file
+    return p if p.exists() else None

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/core/project.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/core/project.py
@@ -1,0 +1,200 @@
+"""Marvelous Designer project file (.zpac / .zprj) parser.
+
+.zpac and .zprj files are standard ZIP containers.  This module
+extracts garment metadata from the archive without requiring
+Marvelous Designer to be installed.
+
+Archive layout (typical):
+    project.json   — top-level metadata (name, version, creation date)
+    garment.json   — pattern / fabric inventory
+    fabric/        — per-fabric JSON or binary data
+    pattern/       — per-pattern SVG or binary data
+    thumbnail.png  — cover image
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from cli_anything.marvelous.core.garment import (FabricProperty, Garment,
+                                                 PatternPiece)
+
+# ── Exceptions ────────────────────────────────────────────────────────────
+
+
+class ProjectFileError(Exception):
+    """Raised when a .zpac/.zprj file cannot be read or parsed."""
+
+
+# ── Metadata model ────────────────────────────────────────────────────────
+
+
+@dataclass
+class ProjectMeta:
+    """Lightweight metadata extracted from a .zpac/.zprj archive."""
+
+    path: str
+    name: str
+    file_format: str  # "zpac" | "zprj"
+    md_version: str = ""
+    created_at: str = ""
+    pattern_count: int = 0
+    fabric_count: int = 0
+    has_thumbnail: bool = False
+    raw_manifest: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "name": self.name,
+            "file_format": self.file_format,
+            "md_version": self.md_version,
+            "created_at": self.created_at,
+            "pattern_count": self.pattern_count,
+            "fabric_count": self.fabric_count,
+            "has_thumbnail": self.has_thumbnail,
+        }
+
+
+# ── Parser ────────────────────────────────────────────────────────────────
+
+
+def _read_zip_json(zf: zipfile.ZipFile, *candidates: str) -> dict[str, Any] | None:
+    """Try each candidate filename and return parsed JSON, or None."""
+    names_lower = {n.lower(): n for n in zf.namelist()}
+    for cand in candidates:
+        real = names_lower.get(cand.lower())
+        if real:
+            try:
+                return json.loads(zf.read(real).decode("utf-8", errors="replace"))
+            except (json.JSONDecodeError, KeyError):
+                return None
+    return None
+
+
+def read_project_meta(path: str | Path) -> ProjectMeta:
+    """Parse a .zpac or .zprj file and return its ProjectMeta.
+
+    Only reads ZIP index + small JSON blobs — does not load textures or
+    binary geometry data.
+
+    Args:
+        path: Filesystem path to the .zpac or .zprj file.
+
+    Returns:
+        ProjectMeta populated from the archive.
+
+    Raises:
+        FileNotFoundError: File does not exist.
+        ProjectFileError: Not a valid ZIP/MD archive.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Project file not found: {p}")
+
+    suffix = p.suffix.lower().lstrip(".")
+    if suffix not in ("zpac", "zprj"):
+        raise ProjectFileError(f"Unsupported format '{p.suffix}'. Expected .zpac or .zprj")
+
+    if not zipfile.is_zipfile(p):
+        raise ProjectFileError(f"File is not a valid ZIP archive: {p}")
+
+    try:
+        with zipfile.ZipFile(p, "r") as zf:
+            names = zf.namelist()
+
+            # Read top-level manifest
+            manifest = _read_zip_json(zf, "project.json", "manifest.json") or {}
+
+            # Garment inventory
+            garment_data = _read_zip_json(zf, "garment.json", "data/garment.json") or {}
+
+            pattern_count = len(garment_data.get("patterns", []))
+            fabric_count = len(garment_data.get("fabrics", []))
+
+            # Fallback: count from directory listing
+            if pattern_count == 0:
+                pattern_count = sum(
+                    1 for n in names if "/pattern/" in n.lower() and not n.endswith("/")
+                )
+            if fabric_count == 0:
+                fabric_count = sum(
+                    1 for n in names if "/fabric/" in n.lower() and not n.endswith("/")
+                )
+
+            has_thumbnail = any(
+                n.lower().endswith((".png", ".jpg", ".jpeg")) and "thumbnail" in n.lower()
+                for n in names
+            )
+
+            name = manifest.get("name") or p.stem
+
+            return ProjectMeta(
+                path=str(p),
+                name=name,
+                file_format=suffix,
+                md_version=str(manifest.get("md_version", manifest.get("version", ""))),
+                created_at=str(manifest.get("created_at", manifest.get("date", ""))),
+                pattern_count=pattern_count,
+                fabric_count=fabric_count,
+                has_thumbnail=has_thumbnail,
+                raw_manifest=manifest,
+            )
+
+    except zipfile.BadZipFile as exc:
+        raise ProjectFileError(f"Corrupt ZIP archive: {p}") from exc
+
+
+def load_garment_from_project(path: str | Path) -> Garment:
+    """Parse garment data from a .zpac/.zprj and return a Garment object.
+
+    Best-effort: if the archive lacks structured JSON we return a Garment
+    populated only from what the ZIP index reveals.
+
+    Args:
+        path: Filesystem path to the .zpac or .zprj file.
+
+    Returns:
+        Garment populated from archive contents.
+
+    Raises:
+        FileNotFoundError: File does not exist.
+        ProjectFileError: Not a valid ZIP/MD archive.
+    """
+    meta = read_project_meta(path)
+    p = Path(path)
+
+    try:
+        with zipfile.ZipFile(p, "r") as zf:
+            garment_data = _read_zip_json(zf, "garment.json", "data/garment.json") or {}
+    except zipfile.BadZipFile as exc:
+        raise ProjectFileError(f"Corrupt ZIP archive: {p}") from exc
+
+    # Build pattern pieces
+    patterns: list[PatternPiece] = []
+    for raw in garment_data.get("patterns", []):
+        if isinstance(raw, dict):
+            patterns.append(PatternPiece.from_dict(raw))
+        elif isinstance(raw, str):
+            patterns.append(PatternPiece(name=raw))
+
+    # Build fabrics
+    fabrics: list[FabricProperty] = []
+    for raw in garment_data.get("fabrics", []):
+        if isinstance(raw, dict):
+            fabrics.append(FabricProperty.from_dict(raw))
+        elif isinstance(raw, str):
+            fabrics.append(FabricProperty(name=raw))
+
+    return Garment(
+        name=meta.name,
+        source_file=str(p),
+        patterns=patterns,
+        fabrics=fabrics,
+        simulation_frames=int(garment_data.get("simulation_frames", 100)),
+        notes=garment_data.get("notes", ""),
+    )

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/core/session.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/core/session.py
@@ -1,0 +1,156 @@
+"""Session management for cli-anything-marvelous.
+
+Sessions persist CLI state across invocations: open project path,
+active garment, simulation settings. Written atomically via
+_locked_save_json so concurrent CLI processes don't corrupt state.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import os
+import tempfile
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Thread-safe monotonic counter to ensure unique session IDs even when
+# multiple threads call new_session() within the same millisecond.
+_session_counter = itertools.count()
+_session_counter_lock = threading.Lock()
+
+# Default location; tests monkeypatch this to tmp_path or set MARVELOUS_SESSIONS_DIR
+SESSIONS_DIR = Path(
+    os.environ.get("MARVELOUS_SESSIONS_DIR", "")
+    or str(Path.home() / ".cli-anything-marvelous" / "sessions")
+)
+
+
+# ── Atomic write ─────────────────────────────────────────────────────────
+
+
+def _locked_save_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write *payload* to *path* atomically with an exclusive lock.
+
+    Uses tempfile + os.replace so a crashed write never leaves a
+    half-written JSON.  The fcntl lock is best-effort (skipped on
+    Windows or if the OS refuses it).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=".session-", suffix=".json")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            try:
+                import fcntl
+
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            except (ImportError, OSError):
+                pass
+            json.dump(payload, fh, indent=2, ensure_ascii=False)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ── Session model ────────────────────────────────────────────────────────
+
+
+@dataclass
+class Session:
+    """Represents a single CLI work session for Marvelous Designer."""
+
+    session_id: str
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    project_path: str = ""
+    garment_name: str = ""
+    simulation_frames: int = 100
+    last_export_path: str = ""
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Session":
+        valid = {k for k in cls.__dataclass_fields__}
+        return cls(**{k: v for k, v in data.items() if k in valid})
+
+
+# ── CRUD ─────────────────────────────────────────────────────────────────
+
+
+def _session_path(session_id: str) -> Path:
+    return SESSIONS_DIR / f"{session_id}.json"
+
+
+def save_session(session: Session) -> Path:
+    """Persist *session* to disk.  Returns the path written."""
+    session.updated_at = time.time()
+    path = _session_path(session.session_id)
+    _locked_save_json(path, session.to_dict())
+    return path
+
+
+def load_session(session_id: str) -> Session:
+    """Load session by ID.
+
+    Raises:
+        FileNotFoundError: Session does not exist.
+        ValueError: JSON is malformed.
+    """
+    path = _session_path(session_id)
+    if not path.exists():
+        raise FileNotFoundError(f"Session '{session_id}' not found at {path}")
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Malformed session JSON at {path}: {exc}") from exc
+    return Session.from_dict(data)
+
+
+def list_sessions() -> list[Session]:
+    """Return all sessions, sorted newest-first."""
+    if not SESSIONS_DIR.exists():
+        return []
+    sessions: list[Session] = []
+    for p in SESSIONS_DIR.glob("*.json"):
+        try:
+            with p.open(encoding="utf-8") as fh:
+                sessions.append(Session.from_dict(json.load(fh)))
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return sorted(sessions, key=lambda s: s.updated_at, reverse=True)
+
+
+def delete_session(session_id: str) -> bool:
+    """Delete session by ID.  Returns True if deleted, False if not found."""
+    path = _session_path(session_id)
+    if not path.exists():
+        return False
+    path.unlink()
+    return True
+
+
+def new_session(project_path: str = "", garment_name: str = "") -> Session:
+    """Create and save a new session with a unique timestamp+counter ID."""
+    with _session_counter_lock:
+        seq = next(_session_counter)
+    session_id = f"md-{int(time.time() * 1000)}-{seq}"
+    s = Session(
+        session_id=session_id,
+        project_path=project_path,
+        garment_name=garment_name,
+    )
+    save_session(s)
+    return s

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/marvelous_cli.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/marvelous_cli.py
@@ -1,0 +1,733 @@
+"""cli-anything-marvelous — Click CLI entry point for Marvelous Designer.
+
+Defaults to REPL mode when invoked without a subcommand.
+
+Command groups:
+    project   — info, new
+    garment   — list, add-fabric
+    simulate  — run
+    export    — (top-level command group)
+    library   — list, import
+    config    — doctor
+    session   — status, save, list, delete
+    repl      — interactive shell
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+from cli_anything.marvelous import __version__
+from cli_anything.marvelous.core import garment as garment_mod
+from cli_anything.marvelous.core import library as library_mod
+from cli_anything.marvelous.core import project as project_mod
+from cli_anything.marvelous.core import session as session_mod
+from cli_anything.marvelous.utils.marvelous_backend import (
+    MarvelousError, MarvelousNotFoundError, MarvelousScriptError,
+    MarvelousTimeoutError, find_marvelous_binary, load_script_template,
+    render_script_template, run_md_script)
+from cli_anything.marvelous.utils.repl_skin import ReplSkin
+
+# ── CLI state ─────────────────────────────────────────────────────────────
+
+
+class CliState:
+    """Shared state threaded through Click context."""
+
+    def __init__(self, json_mode: bool = False, verbose: bool = False):
+        self.json_mode = json_mode
+        self.verbose = verbose
+        self.skin = ReplSkin("marvelous", version=__version__)
+        self.session: session_mod.Session | None = None
+
+    def emit(self, data: Any, *, text: str | None = None) -> None:
+        """Output data as JSON or human-readable text."""
+        if self.json_mode:
+            click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+        else:
+            click.echo(text if text is not None else str(data))
+
+    def emit_error(self, message: str, code: int = 1) -> None:
+        """Print error via skin and exit."""
+        self.skin.error(message)
+        sys.exit(code)
+
+
+def handle_backend_error(state: CliState, exc: Exception) -> None:
+    """Translate backend exceptions to user-friendly messages."""
+    if isinstance(exc, MarvelousNotFoundError):
+        state.emit_error(
+            "Marvelous Designer not found. Install from https://www.marvelousdesigner.com/ "
+            "or set MARVELOUS_DESIGNER_BIN=/path/to/binary."
+        )
+    elif isinstance(exc, MarvelousTimeoutError):
+        state.emit_error(f"Timed out: {exc}")
+    elif isinstance(exc, MarvelousScriptError):
+        state.emit_error(f"Script error (exit {exc.returncode}): {exc}")
+    elif isinstance(exc, MarvelousError):
+        state.emit_error(f"Marvelous Designer error: {exc}")
+    else:
+        state.emit_error(f"Unexpected error: {exc}")
+
+
+# ── Root group ────────────────────────────────────────────────────────────
+
+
+@click.group(invoke_without_command=True)
+@click.option("--json", "json_mode", is_flag=True, help="Output results as JSON.")
+@click.option("--verbose", "-v", is_flag=True, help="Enable verbose output.")
+@click.version_option(__version__, prog_name="cli-anything-marvelous")
+@click.pass_context
+def main(ctx: click.Context, json_mode: bool, verbose: bool) -> None:
+    """cli-anything harness for Marvelous Designer.
+
+    Invoke without a subcommand to enter the interactive REPL.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj = CliState(json_mode=json_mode, verbose=verbose)
+
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(repl)
+
+
+# ── project group ─────────────────────────────────────────────────────────
+
+
+@main.group()
+@click.pass_context
+def project(ctx: click.Context) -> None:
+    """Manage Marvelous Designer project files (.zpac / .zprj)."""
+
+
+@project.command("info")
+@click.argument("path", type=click.Path(exists=True))
+@click.pass_obj
+def project_info(state: CliState, path: str) -> None:
+    """Show metadata for a .zpac or .zprj project file."""
+    try:
+        meta = project_mod.read_project_meta(path)
+    except (FileNotFoundError, project_mod.ProjectFileError) as exc:
+        state.emit_error(str(exc))
+        return
+
+    if state.json_mode:
+        state.emit(meta.to_dict())
+    else:
+        state.skin.status_block(
+            {
+                "Name": meta.name,
+                "Format": meta.file_format.upper(),
+                "MD Version": meta.md_version or "(unknown)",
+                "Created": meta.created_at or "(unknown)",
+                "Patterns": str(meta.pattern_count),
+                "Fabrics": str(meta.fabric_count),
+                "Thumbnail": "yes" if meta.has_thumbnail else "no",
+                "Path": meta.path,
+            },
+            title="Project Info",
+        )
+
+
+@project.command("new")
+@click.argument("output", type=click.Path())
+@click.option("--name", default="", help="Project name (defaults to filename stem).")
+@click.pass_obj
+def project_new(state: CliState, output: str, name: str) -> None:
+    """Create a new empty session pointing at OUTPUT path.
+
+    Does not create a .zpac file — use Marvelous Designer for that.
+    Creates a CLI session pre-configured with the given output path.
+    """
+    out_path = Path(output)
+    project_name = name or out_path.stem
+    s = session_mod.new_session(
+        project_path=str(out_path),
+        garment_name=project_name,
+    )
+    if state.json_mode:
+        state.emit(s.to_dict())
+    else:
+        state.skin.success(f"Session created: {s.session_id}")
+        state.skin.status("Project path", s.project_path)
+        state.skin.status("Session ID", s.session_id)
+
+
+# ── garment group ─────────────────────────────────────────────────────────
+
+
+@main.group()
+@click.pass_context
+def garment(ctx: click.Context) -> None:
+    """Inspect and modify garments in a project file."""
+
+
+@garment.command("list")
+@click.argument("path", type=click.Path(exists=True))
+@click.pass_obj
+def garment_list(state: CliState, path: str) -> None:
+    """List pattern pieces and fabrics in a .zpac or .zprj file."""
+    try:
+        g = project_mod.load_garment_from_project(path)
+    except (FileNotFoundError, project_mod.ProjectFileError) as exc:
+        state.emit_error(str(exc))
+        return
+
+    if state.json_mode:
+        state.emit(g.to_dict())
+        return
+
+    state.skin.section(f"Garment: {g.name}")
+    state.skin.info(f"Source: {g.source_file}")
+    state.skin.info(f"Simulation frames: {g.simulation_frames}")
+
+    if g.patterns:
+        state.skin.section("Pattern Pieces")
+        state.skin.table(
+            ["Name", "Fabric", "Vertices", "Area (cm²)"],
+            [[p.name, p.fabric_name, str(p.vertex_count), f"{p.area_cm2:.1f}"] for p in g.patterns],
+        )
+    else:
+        state.skin.hint("No pattern pieces found in archive.")
+
+    if g.fabrics:
+        state.skin.section("Fabrics")
+        state.skin.table(
+            ["Name", "Color", "Density", "Thickness"],
+            [[f.name, f.color_hex, f"{f.density:.2f}", f"{f.thickness:.1f}mm"] for f in g.fabrics],
+        )
+    else:
+        state.skin.hint("No fabrics found in archive.")
+
+
+@garment.command("add-fabric")
+@click.argument("project_path", type=click.Path(exists=True))
+@click.option("--pattern", required=True, help="Pattern piece name to assign fabric to.")
+@click.option("--fabric-name", required=True, help="Name for the new fabric.")
+@click.option(
+    "--texture",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to fabric texture image.",
+)
+@click.option(
+    "--output",
+    required=True,
+    type=click.Path(),
+    help="Path to save modified .zpac.",
+)
+@click.option("--timeout", default=300, show_default=True, help="Script timeout in seconds.")
+@click.pass_obj
+def garment_add_fabric(
+    state: CliState,
+    project_path: str,
+    pattern: str,
+    fabric_name: str,
+    texture: str,
+    output: str,
+    timeout: int,
+) -> None:
+    """Assign a fabric to a pattern piece inside Marvelous Designer."""
+    try:
+        template_text = load_script_template("add_fabric.py.tpl")
+        script = render_script_template(
+            template_text,
+            {
+                "project_path": project_path,
+                "pattern_name": pattern,
+                "fabric_name": fabric_name,
+                "texture_path": texture,
+                "output_path": output,
+            },
+        )
+        if state.verbose:
+            state.skin.info("Running add_fabric script inside MD...")
+        proc = run_md_script(script, timeout=timeout)
+        if state.json_mode:
+            state.emit(
+                {
+                    "ok": True,
+                    "output_path": output,
+                    "stdout": proc.stdout,
+                }
+            )
+        else:
+            state.skin.success(f"Fabric '{fabric_name}' assigned. Saved: {output}")
+            if state.verbose:
+                click.echo(proc.stdout)
+    except Exception as exc:
+        handle_backend_error(state, exc)
+
+
+# ── simulate group ────────────────────────────────────────────────────────
+
+
+@main.group()
+@click.pass_context
+def simulate(ctx: click.Context) -> None:
+    """Run garment physics simulation in Marvelous Designer."""
+
+
+@simulate.command("run")
+@click.argument("project_path", type=click.Path(exists=True))
+@click.option("--frames", default=100, show_default=True, help="Number of sim frames.")
+@click.option(
+    "--output",
+    required=True,
+    type=click.Path(),
+    help="Path to save the simulated .zpac.",
+)
+@click.option("--timeout", default=600, show_default=True, help="Script timeout in seconds.")
+@click.pass_obj
+def simulate_run(
+    state: CliState,
+    project_path: str,
+    frames: int,
+    output: str,
+    timeout: int,
+) -> None:
+    """Simulate garment physics and save the result."""
+    try:
+        template_text = load_script_template("simulate.py.tpl")
+        script = render_script_template(
+            template_text,
+            {
+                "project_path": project_path,
+                "frames": str(frames),
+                "output_path": output,
+            },
+        )
+        if state.verbose:
+            state.skin.info(f"Simulating {frames} frames...")
+        proc = run_md_script(script, timeout=timeout)
+        if state.json_mode:
+            state.emit(
+                {
+                    "ok": True,
+                    "frames": frames,
+                    "output_path": output,
+                    "stdout": proc.stdout,
+                }
+            )
+        else:
+            state.skin.success(f"Simulation complete ({frames} frames). Saved: {output}")
+            if state.verbose:
+                click.echo(proc.stdout)
+    except Exception as exc:
+        handle_backend_error(state, exc)
+
+
+# ── export group ──────────────────────────────────────────────────────────
+
+
+@main.group("export")
+@click.pass_context
+def export_group(ctx: click.Context) -> None:
+    """Export garments from Marvelous Designer projects."""
+
+
+@export_group.command("run")
+@click.argument("project_path", type=click.Path(exists=True))
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["obj", "fbx", "alembic", "usd", "zpac", "zprj"], case_sensitive=False),
+    default="obj",
+    show_default=True,
+    help="Export format. Note: GLB is not supported by MD's API; use usd instead.",
+)
+@click.option(
+    "--output",
+    required=True,
+    type=click.Path(),
+    help="Output path (without extension; extension is added per format).",
+)
+@click.option("--timeout", default=300, show_default=True, help="Script timeout in seconds.")
+@click.pass_obj
+def export_run(
+    state: CliState,
+    project_path: str,
+    fmt: str,
+    output: str,
+    timeout: int,
+) -> None:
+    """Export a .zpac/.zprj to OBJ, FBX, Alembic, USD, ZPac, or ZPrj."""
+    try:
+        template_text = load_script_template("export.py.tpl")
+        script = render_script_template(
+            template_text,
+            {
+                "project_path": project_path,
+                "output_path": output,
+                "export_format": fmt,
+            },
+        )
+        if state.verbose:
+            state.skin.info(f"Exporting as {fmt.upper()}...")
+        proc = run_md_script(script, timeout=timeout)
+        if state.json_mode:
+            state.emit(
+                {
+                    "ok": True,
+                    "format": fmt,
+                    "output_path": output,
+                    "stdout": proc.stdout,
+                }
+            )
+        else:
+            state.skin.success(f"Export complete ({fmt.upper()}): {output}")
+            if state.verbose:
+                click.echo(proc.stdout)
+    except Exception as exc:
+        handle_backend_error(state, exc)
+
+
+# ── library group ─────────────────────────────────────────────────────────
+
+
+@main.group()
+@click.pass_context
+def library(ctx: click.Context) -> None:
+    """Manage local garment template library."""
+
+
+@library.command("list")
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
+@click.pass_obj
+def library_list(state: CliState, json_mode: bool = False) -> None:
+    if json_mode:
+        state.json_mode = True
+    """List all entries in the local garment library."""
+    entries = library_mod.list_library()
+    if state.json_mode:
+        state.emit([e.to_dict() for e in entries])
+        return
+    if not entries:
+        state.skin.hint("Library is empty. Use 'library import' to add templates.")
+        return
+    state.skin.table(
+        ["Slug", "Name", "Tags", "Description"],
+        [[e.slug, e.name, ", ".join(e.tags), e.description] for e in entries],
+    )
+
+
+@library.command("import")
+@click.argument("source", type=click.Path(exists=True))
+@click.option("--slug", required=True, help="Unique identifier (e.g. tshirt-basic).")
+@click.option("--name", required=True, help="Human-readable name.")
+@click.option("--description", default="", help="Optional description.")
+@click.option("--tags", default="", help="Comma-separated tags.")
+@click.pass_obj
+def library_import(
+    state: CliState,
+    source: str,
+    slug: str,
+    name: str,
+    description: str,
+    tags: str,
+) -> None:
+    """Import a .zpac or .zprj file into the local library."""
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()]
+    try:
+        entry = library_mod.import_project(source, slug, name, description, tag_list)
+    except (FileNotFoundError, FileExistsError, ValueError) as exc:
+        state.emit_error(str(exc))
+        return
+    if state.json_mode:
+        state.emit(entry.to_dict())
+    else:
+        state.skin.success(f"Imported '{entry.name}' as '{entry.slug}'")
+
+
+# ── config group ──────────────────────────────────────────────────────────
+
+
+@main.group()
+@click.pass_context
+def config(ctx: click.Context) -> None:
+    """Configuration and environment diagnostics."""
+
+
+@config.command("doctor")
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
+@click.pass_obj
+def config_doctor(state: CliState, json_mode: bool = False) -> None:
+    if json_mode:
+        state.json_mode = True
+    """Check that Marvelous Designer is installed and discoverable."""
+    issues: list[str] = []
+    md_bin: str | None = None
+
+    try:
+        md_bin = find_marvelous_binary()
+        bin_ok = True
+    except MarvelousNotFoundError as exc:
+        bin_ok = False
+        issues.append(str(exc))
+
+    session_dir_ok = True
+    try:
+        session_mod.SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        session_dir_ok = False
+        issues.append(f"Cannot create sessions dir: {exc}")
+
+    library_dir_ok = True
+    try:
+        library_mod.LIBRARY_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        library_dir_ok = False
+        issues.append(f"Cannot create library dir: {exc}")
+
+    if state.json_mode:
+        state.emit(
+            {
+                "md_binary": md_bin,
+                "md_binary_found": bin_ok,
+                "sessions_dir": str(session_mod.SESSIONS_DIR),
+                "sessions_dir_ok": session_dir_ok,
+                "library_dir": str(library_mod.LIBRARY_DIR),
+                "library_dir_ok": library_dir_ok,
+                "issues": issues,
+                "ok": len(issues) == 0,
+            }
+        )
+        return
+
+    state.skin.section("Marvelous Designer Doctor")
+    _ok = state.skin.success
+    _fail = state.skin.error
+
+    if bin_ok:
+        _ok(f"MD binary: {md_bin}")
+    else:
+        _fail("MD binary: not found")
+
+    if session_dir_ok:
+        _ok(f"Sessions dir: {session_mod.SESSIONS_DIR}")
+    else:
+        _fail(f"Sessions dir: {session_mod.SESSIONS_DIR} (not writable)")
+
+    if library_dir_ok:
+        _ok(f"Library dir: {library_mod.LIBRARY_DIR}")
+    else:
+        _fail(f"Library dir: {library_mod.LIBRARY_DIR} (not writable)")
+
+    if issues:
+        state.skin.section("Issues")
+        for issue in issues:
+            state.skin.warning(issue)
+    else:
+        state.skin.info("All checks passed.")
+
+
+# ── session group ─────────────────────────────────────────────────────────
+
+
+@main.group()
+@click.pass_context
+def session(ctx: click.Context) -> None:
+    """Manage CLI sessions (persistent work context)."""
+
+
+@session.command("status")
+@click.argument("session_id", required=False)
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
+@click.pass_obj
+def session_status(state: CliState, session_id: str | None, json_mode: bool = False) -> None:
+    if json_mode:
+        state.json_mode = True
+    """Show status of SESSION_ID or the most recent session."""
+    try:
+        if session_id:
+            s = session_mod.load_session(session_id)
+        else:
+            sessions = session_mod.list_sessions()
+            if not sessions:
+                state.emit_error("No sessions found.")
+                return
+            s = sessions[0]
+    except (FileNotFoundError, ValueError) as exc:
+        state.emit_error(str(exc))
+        return
+
+    if state.json_mode:
+        state.emit(s.to_dict())
+    else:
+        import time
+
+        state.skin.status_block(
+            {
+                "ID": s.session_id,
+                "Project": s.project_path or "(none)",
+                "Garment": s.garment_name or "(none)",
+                "Sim frames": str(s.simulation_frames),
+                "Last export": s.last_export_path or "(none)",
+                "Updated": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(s.updated_at)),
+                "Notes": s.notes or "(none)",
+            },
+            title="Session Status",
+        )
+
+
+@session.command("save")
+@click.argument("session_id", required=False)
+@click.option("--project", default=None, help="Project file path.")
+@click.option("--garment", default=None, help="Garment name.")
+@click.option("--frames", default=None, type=int, help="Simulation frames.")
+@click.option("--notes", default=None, help="Session notes.")
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
+@click.pass_obj
+def session_save(
+    state: CliState,
+    session_id: str | None,
+    project: str | None,
+    garment: str | None,
+    frames: int | None,
+    notes: str | None,
+    json_mode: bool = False,
+) -> None:
+    if json_mode:
+        state.json_mode = True
+    """Create or update a session. Creates new if SESSION_ID is omitted."""
+    if session_id:
+        try:
+            s = session_mod.load_session(session_id)
+        except (FileNotFoundError, ValueError):
+            s = session_mod.Session(session_id=session_id)
+    else:
+        s = session_mod.Session(session_id=f"md-{int(__import__('time').time() * 1000)}")
+
+    if project is not None:
+        s.project_path = project
+    if garment is not None:
+        s.garment_name = garment
+    if frames is not None:
+        s.simulation_frames = frames
+    if notes is not None:
+        s.notes = notes
+
+    path = session_mod.save_session(s)
+    if state.json_mode:
+        state.emit(s.to_dict())
+    else:
+        state.skin.success(f"Session saved: {s.session_id}")
+        state.skin.hint(f"Path: {path}")
+
+
+@session.command("list")
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
+@click.pass_obj
+def session_list(state: CliState, json_mode: bool = False) -> None:
+    if json_mode:
+        state.json_mode = True
+    """List all saved sessions, newest first."""
+    sessions = session_mod.list_sessions()
+    if state.json_mode:
+        state.emit([s.to_dict() for s in sessions])
+        return
+    if not sessions:
+        state.skin.hint("No sessions found.")
+        return
+    import time
+
+    state.skin.table(
+        ["ID", "Project", "Garment", "Updated"],
+        [
+            [
+                s.session_id,
+                Path(s.project_path).name if s.project_path else "(none)",
+                s.garment_name or "(none)",
+                time.strftime("%Y-%m-%d %H:%M", time.localtime(s.updated_at)),
+            ]
+            for s in sessions
+        ],
+    )
+
+
+@session.command("delete")
+@click.argument("session_id")
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
+@click.pass_obj
+def session_delete(state: CliState, session_id: str, json_mode: bool = False) -> None:
+    if json_mode:
+        state.json_mode = True
+    """Delete a session by ID."""
+    deleted = session_mod.delete_session(session_id)
+    if state.json_mode:
+        state.emit({"deleted": deleted, "session_id": session_id})
+    elif deleted:
+        state.skin.success(f"Deleted session: {session_id}")
+    else:
+        state.emit_error(f"Session not found: {session_id}")
+
+
+# ── repl ──────────────────────────────────────────────────────────────────
+
+
+@main.command("repl")
+@click.pass_obj
+def repl(state: CliState) -> None:
+    """Launch interactive REPL shell for Marvelous Designer."""
+    skin = state.skin
+    skin.print_banner()
+
+    pt_session = skin.create_prompt_session()
+
+    project_name = ""
+    modified = False
+
+    while True:
+        try:
+            line = skin.get_input(pt_session, project_name=project_name, modified=modified)
+        except (EOFError, KeyboardInterrupt):
+            skin.print_goodbye()
+            break
+
+        if not line:
+            continue
+
+        parts = line.split()
+        cmd = parts[0].lower()
+
+        if cmd in ("quit", "exit", "q"):
+            skin.print_goodbye()
+            break
+
+        if cmd == "help":
+            skin.help(
+                {
+                    "project info <path>": "Show project metadata",
+                    "project new <output>": "Create a new session",
+                    "garment list <path>": "List garment patterns and fabrics",
+                    "garment add-fabric": "Assign fabric inside MD",
+                    "simulate run": "Run physics simulation",
+                    "export run": "Export to OBJ/FBX/Alembic/USD",
+                    "library list": "Show garment template library",
+                    "library import": "Import .zpac into library",
+                    "config doctor": "Check MD installation",
+                    "session status": "Show current session",
+                    "session list": "List all sessions",
+                    "session save": "Save session state",
+                    "session delete <id>": "Delete a session",
+                    "quit": "Exit the REPL",
+                }
+            )
+            continue
+
+        # Dispatch to Click commands via main
+        try:
+            main.main(
+                args=parts,
+                obj=state,
+                standalone_mode=False,
+            )
+        except SystemExit:
+            pass
+        except click.exceptions.UsageError as exc:
+            skin.error(str(exc))
+        except Exception as exc:
+            skin.error(f"Error: {exc}")

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/resources/scripts/add_fabric.py.tpl
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/resources/scripts/add_fabric.py.tpl
@@ -1,0 +1,75 @@
+# cli-anything-marvelous — add_fabric script template
+# Rendered via string.Template; placeholders use $${var} syntax.
+#
+# Variables:
+#   project_path   — absolute path to .zpac or .zprj file to open
+#   pattern_name   — name of the pattern piece to assign fabric to
+#   fabric_name    — display name for the new fabric
+#   texture_path   — absolute path to fabric texture image (png/jpg)
+#   output_path    — absolute path to save modified .zpac
+#
+# Run inside Marvelous Designer via:
+#   "Marvelous Designer" --script add_fabric.py
+#
+# API reference: https://developer.marvelousdesigner.com/scenario.html
+
+import sys
+
+try:
+    import import_api
+    import fabric_api
+    import export_api
+except ImportError as e:
+    print(f"[cli-anything] Failed to import MD API: {e}", file=sys.stderr)
+    sys.exit(1)
+
+PROJECT_PATH = r"${project_path}"
+PATTERN_NAME = "${pattern_name}"
+FABRIC_NAME  = "${fabric_name}"
+TEXTURE_PATH = r"${texture_path}"
+OUTPUT_PATH  = r"${output_path}"
+
+# ── Open project ──────────────────────────────────────────────────────────
+
+print(f"[cli-anything] Opening project: {PROJECT_PATH}")
+result = import_api.ImportZpac(PROJECT_PATH)
+if not result:
+    print(f"[cli-anything] ERROR: Could not open project '{PROJECT_PATH}'", file=sys.stderr)
+    sys.exit(2)
+
+# ── Check current fabric count ────────────────────────────────────────────
+
+before_count = fabric_api.GetFabricCount()
+print(f"[cli-anything] Current fabric count: {before_count}")
+
+# ── Assign fabric to pattern ──────────────────────────────────────────────
+
+print(f"[cli-anything] Assigning fabric '{FABRIC_NAME}' to pattern '{PATTERN_NAME}'")
+print(f"[cli-anything] Texture: {TEXTURE_PATH}")
+
+ok = fabric_api.AssignFabricToPattern(
+    patternName=PATTERN_NAME,
+    fabricName=FABRIC_NAME,
+    texturePath=TEXTURE_PATH,
+)
+
+if not ok:
+    print(
+        f"[cli-anything] ERROR: AssignFabricToPattern failed for "
+        f"pattern='{PATTERN_NAME}' fabric='{FABRIC_NAME}'",
+        file=sys.stderr,
+    )
+    sys.exit(3)
+
+after_count = fabric_api.GetFabricCount()
+print(f"[cli-anything] Fabric count after assignment: {after_count}")
+
+# ── Save result ───────────────────────────────────────────────────────────
+
+print(f"[cli-anything] Saving to: {OUTPUT_PATH}")
+saved = export_api.ExportZpac(OUTPUT_PATH)
+if not saved:
+    print(f"[cli-anything] ERROR: Could not save to '{OUTPUT_PATH}'", file=sys.stderr)
+    sys.exit(4)
+
+print(f"[cli-anything] Saved: {OUTPUT_PATH}")

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/resources/scripts/export.py.tpl
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/resources/scripts/export.py.tpl
@@ -1,0 +1,62 @@
+# cli-anything-marvelous — export script template
+# Rendered via string.Template; placeholders use $${var} syntax.
+#
+# Variables:
+#   project_path  — absolute path to .zpac or .zprj file to open
+#   output_path   — absolute path for the exported file (without extension)
+#   export_format — one of: obj, fbx, alembic, usd, zpac, zprj
+#
+# Run inside Marvelous Designer via:
+#   "Marvelous Designer" --script export.py
+#
+# API reference: https://developer.marvelousdesigner.com/scenario.html
+
+import sys
+
+try:
+    import import_api
+    import utility_api
+    import export_api
+    from ApiTypes import ExportType
+except ImportError as e:
+    print(f"[cli-anything] Failed to import MD API: {e}", file=sys.stderr)
+    sys.exit(1)
+
+PROJECT_PATH = r"${project_path}"
+OUTPUT_PATH  = r"${output_path}"
+EXPORT_FMT   = "${export_format}".lower().strip()
+
+# ── Open project ──────────────────────────────────────────────────────────
+
+print(f"[cli-anything] Opening project: {PROJECT_PATH}")
+result = import_api.ImportZpac(PROJECT_PATH)
+if not result:
+    print(f"[cli-anything] ERROR: Could not open project '{PROJECT_PATH}'", file=sys.stderr)
+    sys.exit(2)
+
+# ── Export ────────────────────────────────────────────────────────────────
+
+print(f"[cli-anything] Exporting as {EXPORT_FMT} to {OUTPUT_PATH}")
+
+if EXPORT_FMT == "obj":
+    ok = export_api.ExportOBJ(OUTPUT_PATH + ".obj")
+elif EXPORT_FMT == "fbx":
+    ok = export_api.ExportFBX(OUTPUT_PATH + ".fbx")
+elif EXPORT_FMT == "alembic":
+    ok = export_api.ExportAlembic(OUTPUT_PATH + ".abc")
+elif EXPORT_FMT == "usd":
+    ok = export_api.ExportUSD(OUTPUT_PATH + ".usd")
+elif EXPORT_FMT == "zpac":
+    ok = export_api.ExportZpac(OUTPUT_PATH + ".zpac")
+elif EXPORT_FMT == "zprj":
+    ok = export_api.ExportZprj(OUTPUT_PATH + ".zprj")
+else:
+    print(f"[cli-anything] ERROR: Unknown export format '{EXPORT_FMT}'", file=sys.stderr)
+    print("[cli-anything] Supported formats: obj, fbx, alembic, usd, zpac, zprj", file=sys.stderr)
+    sys.exit(3)
+
+if not ok:
+    print(f"[cli-anything] ERROR: Export failed for format '{EXPORT_FMT}'", file=sys.stderr)
+    sys.exit(4)
+
+print(f"[cli-anything] Export complete: {OUTPUT_PATH}")

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/resources/scripts/simulate.py.tpl
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/resources/scripts/simulate.py.tpl
@@ -1,0 +1,50 @@
+# cli-anything-marvelous — simulate script template
+# Rendered via string.Template; placeholders use $${var} syntax.
+#
+# Variables:
+#   project_path  — absolute path to .zpac or .zprj file to open
+#   frames        — number of simulation frames (integer)
+#   output_path   — absolute path to write resulting .zpac (after sim)
+#
+# Run inside Marvelous Designer via:
+#   "Marvelous Designer" --script simulate.py
+#
+# API reference: https://developer.marvelousdesigner.com/scenario.html
+
+import sys
+
+try:
+    import import_api
+    import utility_api
+    import export_api
+except ImportError as e:
+    print(f"[cli-anything] Failed to import MD API: {e}", file=sys.stderr)
+    sys.exit(1)
+
+PROJECT_PATH = r"${project_path}"
+FRAMES       = int("${frames}")
+OUTPUT_PATH  = r"${output_path}"
+
+# ── Open project ──────────────────────────────────────────────────────────
+
+print(f"[cli-anything] Opening project: {PROJECT_PATH}")
+result = import_api.ImportZpac(PROJECT_PATH)
+if not result:
+    print(f"[cli-anything] ERROR: Could not open project '{PROJECT_PATH}'", file=sys.stderr)
+    sys.exit(2)
+
+# ── Simulate ──────────────────────────────────────────────────────────────
+
+print(f"[cli-anything] Running simulation for {FRAMES} frames...")
+utility_api.Simulate(FRAMES)
+print(f"[cli-anything] Simulation complete.")
+
+# ── Save result ───────────────────────────────────────────────────────────
+
+print(f"[cli-anything] Saving result to: {OUTPUT_PATH}")
+ok = export_api.ExportZpac(OUTPUT_PATH)
+if not ok:
+    print(f"[cli-anything] ERROR: Could not save simulated project to '{OUTPUT_PATH}'", file=sys.stderr)
+    sys.exit(3)
+
+print(f"[cli-anything] Saved: {OUTPUT_PATH}")

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/skills/SKILL.md
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/skills/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: cli-anything-marvelous
+description: >
+  Operate the cli-anything-marvelous harness for Marvelous Designer.
+  Use when the user wants to parse .zpac/.zprj files, run simulations,
+  export garments, manage sessions, or interact with the local garment library.
+---
+
+# cli-anything-marvelous Skill
+
+## When to Use
+
+- User wants to inspect a `.zpac` or `.zprj` project file
+- User wants to simulate, export, or add fabrics via Marvelous Designer
+- User wants to manage garment sessions or the local template library
+- User wants to run the interactive REPL
+
+## Package Location
+
+```
+/Users/theceo/DevSkyy/vendor/cli-anything/marvelous/agent-harness/
+```
+
+Key files:
+- `cli_anything/marvelous/marvelous_cli.py` — all Click commands
+- `cli_anything/marvelous/core/` — project, garment, session, library modules
+- `cli_anything/marvelous/utils/marvelous_backend.py` — subprocess + script runner
+- `cli_anything/marvelous/resources/scripts/` — MD script templates
+
+## Command Reference
+
+```bash
+cli-anything-marvelous project info <file.zpac>          # Parse metadata
+cli-anything-marvelous --json project info <file.zpac>   # JSON output
+cli-anything-marvelous export run <file.zpac> --format obj --output ./out
+cli-anything-marvelous simulate run <file.zpac> --frames 30 --output ./sim.zpac
+cli-anything-marvelous garment add-fabric <file.zpac> \
+  --pattern "Front Bodice" --fabric "Cotton" --texture ./t.jpg --output ./out.zpac
+cli-anything-marvelous library import <file.zpac> --slug my-shirt --name "My Shirt"
+cli-anything-marvelous library list
+cli-anything-marvelous session save --project /path/to.zpac --garment "Shirt"
+cli-anything-marvelous session list
+cli-anything-marvelous session status <session-id>
+cli-anything-marvelous session delete <session-id>
+cli-anything-marvelous config doctor
+cli-anything-marvelous              # launches REPL
+```
+
+## Commands That Need MD Installed
+
+`export run`, `simulate run`, `garment add-fabric` — all require Marvelous Designer.
+
+All other commands work without MD.
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `MARVELOUS_DESIGNER_BIN` | Override MD binary path |
+| `MARVELOUS_E2E=1` | Enable live E2E tests |
+| `MARVELOUS_TEST_ZPAC` | Real .zpac path for live tests |
+
+## Running Tests
+
+```bash
+cd /Users/theceo/DevSkyy/vendor/cli-anything/marvelous/agent-harness
+pytest cli_anything/marvelous/tests/test_core.py -v           # unit only
+pytest cli_anything/marvelous/tests/ -v                       # + smoke E2E
+pytest cli_anything/marvelous/tests/ --cov=cli_anything.marvelous
+```
+
+## Python API (for programmatic use)
+
+```python
+from cli_anything.marvelous.core.project import read_project_meta
+from cli_anything.marvelous.core.garment import Garment
+from cli_anything.marvelous.core.session import new_session, save_session, load_session
+from cli_anything.marvelous.core.library import import_project, list_library
+from cli_anything.marvelous.utils.marvelous_backend import (
+    find_marvelous_binary,
+    load_script_template,
+    render_script_template,
+    run_md_script,
+)
+
+# Parse a .zpac without MD
+meta = read_project_meta(Path("shirt.zpac"))
+print(meta.name, meta.pattern_count, meta.fabric_count)
+
+# Run a script (requires MD)
+binary = find_marvelous_binary()
+tpl = load_script_template("export")
+script = render_script_template(tpl, {
+    "project_path": "/path/to/shirt.zpac",
+    "output_path": "/out/shirt",
+    "export_format": "obj",
+})
+run_md_script(script, binary=binary)
+```
+
+## Exceptions
+
+```python
+from cli_anything.marvelous.utils.marvelous_backend import (
+    MarvelousNotFoundError,   # MD binary not on PATH / not installed
+    MarvelousScriptError,     # MD ran but script exited non-zero
+    MarvelousTimeoutError,    # MD exceeded timeout
+)
+```
+
+## Key Design Decisions
+
+- `.zpac`/`.zprj` parsing uses stdlib `zipfile` — no MD required
+- Session writes are atomic (`fcntl.flock` + `tempfile` + `os.replace`)
+- Script templates use `string.Template` with `${var}` — no Jinja2 dependency
+- REPL dispatches back into Click via `main.main(args=parts, standalone_mode=False)`
+- Export formats: obj, fbx, alembic, usd, zpac, zprj (GLB is NOT in MD API)
+- `--script` invocation is unconfirmed in MD 12 official docs; update `run_md_script()` if syntax differs

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/TEST.md
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/TEST.md
@@ -1,0 +1,169 @@
+# cli-anything-marvelous — Test Plan
+
+## Overview
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| Unit test count | 40+ | Pure-Python, no MD required |
+| E2E test count | 8 | Skipped without `MARVELOUS_E2E=1` |
+| Coverage target | 85%+ | `pytest --cov=cli_anything.marvelous` |
+| Live MD gate | `MARVELOUS_E2E=1` | Only fires with real MD installed |
+
+## Test Inventory
+
+### test_core.py — Unit Tests
+
+| Class | Tests | Description |
+|-------|-------|-------------|
+| `TestFabricProperty` | 3 | Default values, dict round-trip, unknown key tolerance |
+| `TestPatternPiece` | 3 | Defaults, dict round-trip, extra key tolerance |
+| `TestGarment` | 7 | Empty, counts, fabric/pattern lookup, JSON round-trip, from_dict empty |
+| `TestReadProjectMeta` | 9 | Missing file, wrong ext, not-a-zip, empty zip, manifest name, pattern/fabric counts, thumbnail detection, zprj format, to_dict keys |
+| `TestLoadGarmentFromProject` | 3 | Basic load, string pattern/fabric handling, source_file recorded |
+| `TestSession` | 2 | Dict round-trip, from_dict extra keys |
+| `TestSessionCrud` | 9 | save/load, missing raises, empty list, sorted list, delete exists, delete not found, new_session persists, atomic write, malformed JSON |
+| `TestLibraryEntry` | 2 | Round-trip, bad tags coercion |
+| `TestLibraryCrud` | 9 | Empty list, import+list, dup slug raises, missing source, wrong ext, get_entry, not_found, delete, entry_source_path |
+| `TestFindMarvelousBinary` | 3 | Env override missing, env override valid, no MD raises |
+| `TestRenderScriptTemplate` | 3 | Basic substitution, missing var raises, multiple vars |
+| `TestLoadScriptTemplate` | 4 | export/simulate/add_fabric templates load, missing raises |
+
+**Total unit tests: 57**
+
+### test_templates.py — Script Template Rendering (Phase 6)
+
+| Class | Tests | Description |
+|-------|-------|-------------|
+| `TestExportTemplate` | 9 | Renders project/output/format vars, export_api call, ImportZpac call, missing-var raises, Windows path, Unicode path |
+| `TestSimulateTemplate` | 5 | Renders frames, utility_api.Simulate, ExportZpac, missing frames raises, zero frames |
+| `TestAddFabricTemplate` | 5 | Renders pattern/fabric name, AssignFabricToPattern call, missing var raises, special chars |
+
+**Subtotal: 19**
+
+### test_garment_edge_cases.py — Garment Dataclass Edges (Phase 6)
+
+| Class | Tests | Description |
+|-------|-------|-------------|
+| `TestFabricPropertyEdgeCases` | 5 | All-fields round-trip, float type, default color, from_dict only-name, to_dict key completeness |
+| `TestPatternPieceEdgeCases` | 3 | All-fields round-trip, default vertex_count, from_dict only-name |
+| `TestGarmentEdgeCases` | 11 | frames default/override, notes/source_file round-trip, multi-fabric, case-insensitive lookups, to_json valid JSON, Unicode round-trip, frames coercion |
+
+**Subtotal: 19**
+
+### test_backend_pure.py — Backend Without MD (Phase 6)
+
+| Class | Tests | Description |
+|-------|-------|-------------|
+| `TestFindMarvelousBinaryExtra` | 4 | Directory path raises, empty env falls through, whitespace env falls through, multiple installs picks last |
+| `TestRunMdScriptCleanup` | 4 | Tempfile cleaned on success, on script error, on timeout; error captures returncode+stderr |
+| `TestRenderScriptTemplateEdgeCases` | 4 | Empty template, extra vars ignored, bare-$ raises ValueError, numeric value coercion |
+
+**Subtotal: 12**
+
+### test_session_concurrent.py — Session Edge Cases + Concurrency (Phase 6)
+
+| Class | Tests | Description |
+|-------|-------|-------------|
+| `TestSessionSchemaEdgeCases` | 5 | Malformed JSON raises, unknown fields ignored, missing optional fields use defaults, list_sessions skips corrupt, empty dict raises TypeError, updated_at bumped on save |
+| `TestSessionConcurrentWrites` | 3 | Concurrent same-session writes leave valid JSON, concurrent distinct sessions all written, concurrent new_session IDs are unique |
+
+**Subtotal: 8**
+
+**Phase 6 total: 58 new tests**
+
+### test_full_e2e.py — CLI + Live Tests
+
+| Class | Tests | Gate |
+|-------|-------|------|
+| `TestCliSmoke` | 8 | Always (no MD needed) |
+| `TestLiveExport` | 2 | `MARVELOUS_E2E=1` only |
+
+**Total E2E tests: 10**
+
+## Unit Test Plan
+
+### Fixtures
+
+```python
+def _make_zpac(path, manifest=None, garment=None) -> Path:
+    """Create minimal synthetic .zpac ZIP for pure-Python testing."""
+    with zipfile.ZipFile(path, "w") as zf:
+        if manifest: zf.writestr("project.json", json.dumps(manifest))
+        if garment:  zf.writestr("garment.json", json.dumps(garment))
+    return path
+```
+
+Session tests use `monkeypatch.setattr(session_mod, "SESSIONS_DIR", tmp_path / "sessions")`.
+Library tests use `monkeypatch.setattr(library_mod, "LIBRARY_DIR", tmp_path / "library")`.
+Backend tests monkeypatch `glob.glob` to simulate no MD installed.
+
+### Key assertions
+
+- `_locked_save_json`: no `.session-*.json` tempfiles left after write
+- `load_session("nonexistent")` → `FileNotFoundError`
+- `load_session` with corrupt JSON → `ValueError` with "Malformed" message
+- `import_project` with duplicate slug → `FileExistsError`
+- `render_script_template` missing var → `KeyError`
+- All three `.tpl` files loadable and contain expected API calls
+
+## E2E Test Plan
+
+`_resolve_cli()` resolution:
+1. `shutil.which("cli-anything-marvelous")` — installed binary
+2. `[sys.executable, "-m", "cli_anything.marvelous"]` — editable install
+3. If `CLI_ANYTHING_FORCE_INSTALLED=1`: raises `RuntimeError` when binary missing
+
+Smoke tests (`TestCliSmoke`) run without MD:
+- `--version` → stdout contains "1.0.0"
+- `--help` → stdout contains "marvelous"
+- `config doctor --json` → valid JSON with `md_binary_found` and `issues` keys
+- `project info --json <synthetic.zpac>` → parses name and format correctly
+- `session save/status/delete` round-trip via `--json`
+
+Live tests (`TestLiveExport`) skip unless `MARVELOUS_E2E=1`:
+- Use `MARVELOUS_TEST_ZPAC=/path/to/file.zpac` env var for real fixture
+- Falls back to synthetic .zpac (MD may reject — expected)
+- `export run --format obj` → `{"ok": true}`
+- `simulate run --frames 10` → `{"frames": 10}`
+
+## Coverage Targets
+
+```bash
+# Install dev deps
+pip install -e ".[dev]"
+
+# Unit tests only (no MD)
+pytest cli_anything/marvelous/tests/test_core.py -v --tb=short
+
+# All tests (smoke E2E always runs)
+pytest cli_anything/marvelous/tests/ -v --tb=short
+
+# With coverage
+pytest cli_anything/marvelous/tests/ --cov=cli_anything.marvelous \
+  --cov-report=term-missing -q
+
+# Force installed binary path (CI)
+CLI_ANYTHING_FORCE_INSTALLED=1 pytest cli_anything/marvelous/tests/ -v
+
+# Full live run (requires MD + real .zpac)
+MARVELOUS_E2E=1 MARVELOUS_TEST_ZPAC=/path/to/shirt.zpac \
+  pytest cli_anything/marvelous/tests/ -v
+```
+
+## Results
+
+_Updated after each test run._
+
+| Date | Unit | E2E (smoke) | E2E (live) | Coverage |
+|------|------|-------------|------------|----------|
+| TBD  | —    | —           | skipped    | —        |
+
+### Phase 6 — 2026-05-25
+
+| Date | Pass | Skipped | Fail | Notes |
+|------|------|---------|------|-------|
+| 2026-05-25 | 126 | 2 | 0 | Phase 6 adds 58 new tests across 4 files; 2 skipped are live-MD E2E |
+
+**Production bugs fixed during Phase 6:**
+1. **`resources/scripts/*.tpl` comment contained literal `${var}`** — `string.Template.substitute` tried to substitute a variable named `var`, raising `KeyError` every time any of the three templates was rendered. Fixed by escaping to `$${var}` in the comment line of all three `.tpl` files.
+2. **`new_session()` timestamp-only IDs collide under concurrent load** — millisecond resolution is insufficient when multiple threads call `new_session()` in the same millisecond. Fixed by appending a process-global monotonic counter (`itertools.count`) to the ID: `md-{ms}-{seq}`.

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/__init__.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/__init__.py
@@ -1,0 +1,1 @@
+"""cli-anything-marvelous test suite."""

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_backend_pure.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_backend_pure.py
@@ -1,0 +1,185 @@
+"""Backend wrapper pure-Python tests — no live MD required.
+
+Tests find_marvelous_binary, run_md_script cleanup behaviour,
+and render_script_template edge cases.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import cli_anything.marvelous.utils.marvelous_backend as backend_mod
+import pytest
+from cli_anything.marvelous.utils.marvelous_backend import (
+    MarvelousNotFoundError, MarvelousScriptError, MarvelousTimeoutError,
+    find_marvelous_binary, render_script_template, run_md_script)
+
+# ── find_marvelous_binary ─────────────────────────────────────────────────
+
+
+class TestFindMarvelousBinaryExtra:
+    def test_env_var_pointing_to_directory_raises(self, monkeypatch, tmp_path):
+        """A path that exists but is a directory (not a file) must raise."""
+        monkeypatch.setenv("MARVELOUS_DESIGNER_BIN", str(tmp_path))
+        with pytest.raises(MarvelousNotFoundError, match="set but file not found"):
+            find_marvelous_binary()
+
+    def test_env_var_empty_string_falls_through(self, monkeypatch):
+        """Empty string env var should not trigger the override branch."""
+        monkeypatch.setenv("MARVELOUS_DESIGNER_BIN", "")
+        import glob as glob_mod
+
+        monkeypatch.setattr(glob_mod, "glob", lambda *a, **kw: [])
+        with pytest.raises(MarvelousNotFoundError):
+            find_marvelous_binary()
+
+    def test_env_var_whitespace_only_falls_through(self, monkeypatch):
+        """Whitespace-only env var is stripped and treated as absent."""
+        monkeypatch.setenv("MARVELOUS_DESIGNER_BIN", "   ")
+        import glob as glob_mod
+
+        monkeypatch.setattr(glob_mod, "glob", lambda *a, **kw: [])
+        with pytest.raises(MarvelousNotFoundError):
+            find_marvelous_binary()
+
+    def test_glob_returns_multiple_picks_last(self, monkeypatch, tmp_path):
+        """When multiple MD installs are found, the last sorted entry is used."""
+        bin_a = tmp_path / "Marvelous Designer 11" / "Marvelous Designer"
+        bin_b = tmp_path / "Marvelous Designer 12" / "Marvelous Designer"
+        bin_a.parent.mkdir(parents=True)
+        bin_b.parent.mkdir(parents=True)
+        bin_a.write_bytes(b"v11")
+        bin_b.write_bytes(b"v12")
+
+        monkeypatch.delenv("MARVELOUS_DESIGNER_BIN", raising=False)
+        import glob as glob_mod
+
+        monkeypatch.setattr(glob_mod, "glob", lambda *a, **kw: sorted([str(bin_a), str(bin_b)]))
+        result = find_marvelous_binary()
+        assert result == str(bin_b)
+
+
+# ── run_md_script tempfile cleanup ────────────────────────────────────────
+
+
+class TestRunMdScriptCleanup:
+    def test_tempfile_cleaned_up_on_success(self, monkeypatch, tmp_path):
+        """Temp script file must be deleted even when subprocess succeeds."""
+        created_paths: list[str] = []
+        original_mkstemp = __import__("tempfile").mkstemp
+
+        def capturing_mkstemp(**kwargs):
+            fd, name = original_mkstemp(**kwargs)
+            created_paths.append(name)
+            return fd, name
+
+        import tempfile as tempfile_mod
+
+        monkeypatch.setattr(tempfile_mod, "mkstemp", capturing_mkstemp)
+
+        fake_proc = subprocess.CompletedProcess(args=["fake"], returncode=0, stdout="", stderr="")
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake_proc)
+
+        fake_bin = tmp_path / "FakeMD"
+        fake_bin.write_bytes(b"#!/bin/sh")
+
+        run_md_script("print('hello')", binary=str(fake_bin))
+
+        for path in created_paths:
+            assert not os.path.exists(path), f"Temp file not cleaned up: {path}"
+
+    def test_tempfile_cleaned_up_on_script_error(self, monkeypatch, tmp_path):
+        """Temp script file must be deleted even when subprocess returns non-zero."""
+        created_paths: list[str] = []
+        original_mkstemp = __import__("tempfile").mkstemp
+
+        def capturing_mkstemp(**kwargs):
+            fd, name = original_mkstemp(**kwargs)
+            created_paths.append(name)
+            return fd, name
+
+        import tempfile as tempfile_mod
+
+        monkeypatch.setattr(tempfile_mod, "mkstemp", capturing_mkstemp)
+
+        fail_proc = subprocess.CompletedProcess(
+            args=["fake"], returncode=1, stdout="", stderr="script error"
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fail_proc)
+
+        fake_bin = tmp_path / "FakeMD"
+        fake_bin.write_bytes(b"#!/bin/sh")
+
+        with pytest.raises(MarvelousScriptError):
+            run_md_script("raise RuntimeError()", binary=str(fake_bin))
+
+        for path in created_paths:
+            assert not os.path.exists(path), f"Temp file not cleaned up: {path}"
+
+    def test_tempfile_cleaned_up_on_timeout(self, monkeypatch, tmp_path):
+        """Temp script file must be deleted even when subprocess times out."""
+        created_paths: list[str] = []
+        original_mkstemp = __import__("tempfile").mkstemp
+
+        def capturing_mkstemp(**kwargs):
+            fd, name = original_mkstemp(**kwargs)
+            created_paths.append(name)
+            return fd, name
+
+        import tempfile as tempfile_mod
+
+        monkeypatch.setattr(tempfile_mod, "mkstemp", capturing_mkstemp)
+
+        def timeout_run(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd="fake", timeout=1)
+
+        monkeypatch.setattr(subprocess, "run", timeout_run)
+
+        fake_bin = tmp_path / "FakeMD"
+        fake_bin.write_bytes(b"#!/bin/sh")
+
+        with pytest.raises(MarvelousTimeoutError):
+            run_md_script("import time; time.sleep(9999)", binary=str(fake_bin), timeout=1)
+
+        for path in created_paths:
+            assert not os.path.exists(path), f"Temp file not cleaned up: {path}"
+
+    def test_script_error_captures_returncode_and_stderr(self, monkeypatch, tmp_path):
+        fail_proc = subprocess.CompletedProcess(
+            args=["fake"], returncode=42, stdout="", stderr="MD internal error"
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fail_proc)
+
+        fake_bin = tmp_path / "FakeMD"
+        fake_bin.write_bytes(b"#!/bin/sh")
+
+        with pytest.raises(MarvelousScriptError) as exc_info:
+            run_md_script("bad script", binary=str(fake_bin))
+
+        err = exc_info.value
+        assert err.returncode == 42
+        assert "MD internal error" in err.stderr
+
+
+# ── render_script_template edge cases ────────────────────────────────────
+
+
+class TestRenderScriptTemplateEdgeCases:
+    def test_empty_template_empty_vars(self):
+        assert render_script_template("", {}) == ""
+
+    def test_extra_vars_in_dict_ignored(self):
+        """Extra variables not referenced in the template are silently ignored."""
+        result = render_script_template("hello = '${name}'", {"name": "world", "extra": "ignored"})
+        assert result == "hello = 'world'"
+
+    def test_dollar_sign_bare_invalid_raises(self):
+        """Bare $ followed by a digit is an invalid placeholder and raises ValueError."""
+        with pytest.raises(ValueError):
+            render_script_template("price = $100", {})
+
+    def test_numeric_value_converted_to_string(self):
+        """Template.substitute converts int values to str automatically."""
+        result = render_script_template("frames = ${n}", {"n": 42})
+        assert "42" in result

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_core.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_core.py
@@ -1,0 +1,480 @@
+"""Unit tests for cli-anything-marvelous core modules.
+
+All tests are pure-Python — no Marvelous Designer installation required.
+Synthetic .zpac fixtures are created with stdlib zipfile.
+
+Run:
+    pytest cli_anything/marvelous/tests/test_core.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import zipfile
+from pathlib import Path
+
+import cli_anything.marvelous.core.library as library_mod
+import cli_anything.marvelous.core.session as session_mod
+import pytest
+from cli_anything.marvelous.core.garment import (FabricProperty, Garment,
+                                                 PatternPiece)
+from cli_anything.marvelous.core.library import (LibraryEntry, delete_entry,
+                                                 get_entry, import_project,
+                                                 list_library)
+from cli_anything.marvelous.core.project import (ProjectFileError, ProjectMeta,
+                                                 load_garment_from_project,
+                                                 read_project_meta)
+from cli_anything.marvelous.core.session import (Session, delete_session,
+                                                 list_sessions, load_session,
+                                                 new_session, save_session)
+from cli_anything.marvelous.utils.marvelous_backend import (
+    MarvelousNotFoundError, MarvelousScriptError, find_marvelous_binary,
+    load_script_template, render_script_template)
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _make_zpac(path: Path, manifest: dict | None = None, garment: dict | None = None) -> Path:
+    """Create a minimal synthetic .zpac ZIP fixture."""
+    with zipfile.ZipFile(path, "w") as zf:
+        if manifest is not None:
+            zf.writestr("project.json", json.dumps(manifest))
+        if garment is not None:
+            zf.writestr("garment.json", json.dumps(garment))
+    return path
+
+
+# ── FabricProperty ────────────────────────────────────────────────────────
+
+
+class TestFabricProperty:
+    def test_default_values(self):
+        f = FabricProperty(name="Cotton")
+        assert f.name == "Cotton"
+        assert f.color_hex == "#FFFFFF"
+        assert f.density == 0.3
+
+    def test_round_trip_dict(self):
+        f = FabricProperty(name="Silk", color_hex="#FF0000", thickness=1.2)
+        f2 = FabricProperty.from_dict(f.to_dict())
+        assert f2.name == "Silk"
+        assert f2.color_hex == "#FF0000"
+        assert f2.thickness == 1.2
+
+    def test_from_dict_ignores_unknown_keys(self):
+        data = {"name": "Wool", "unknown_field": "ignored", "density": 0.5}
+        f = FabricProperty.from_dict(data)
+        assert f.name == "Wool"
+        assert f.density == 0.5
+
+
+# ── PatternPiece ──────────────────────────────────────────────────────────
+
+
+class TestPatternPiece:
+    def test_defaults(self):
+        p = PatternPiece(name="Front Body")
+        assert p.fabric_name == ""
+        assert p.vertex_count == 0
+
+    def test_round_trip_dict(self):
+        p = PatternPiece(name="Sleeve", fabric_name="Cotton", area_cm2=320.5)
+        p2 = PatternPiece.from_dict(p.to_dict())
+        assert p2.name == "Sleeve"
+        assert p2.fabric_name == "Cotton"
+        assert p2.area_cm2 == 320.5
+
+    def test_from_dict_ignores_extra(self):
+        p = PatternPiece.from_dict({"name": "Collar", "extra": "ignored"})
+        assert p.name == "Collar"
+
+
+# ── Garment ───────────────────────────────────────────────────────────────
+
+
+class TestGarment:
+    def test_empty_garment(self):
+        g = Garment(name="T-Shirt")
+        assert g.pattern_count == 0
+        assert g.fabric_count == 0
+
+    def test_pattern_count_and_fabric_count(self):
+        g = Garment(
+            name="Dress",
+            patterns=[PatternPiece("Front"), PatternPiece("Back")],
+            fabrics=[FabricProperty("Satin")],
+        )
+        assert g.pattern_count == 2
+        assert g.fabric_count == 1
+
+    def test_fabric_by_name_found(self):
+        f = FabricProperty("Cotton")
+        g = Garment(name="Shirt", fabrics=[f])
+        assert g.fabric_by_name("cotton") is f
+
+    def test_fabric_by_name_not_found(self):
+        g = Garment(name="Shirt", fabrics=[FabricProperty("Cotton")])
+        assert g.fabric_by_name("Polyester") is None
+
+    def test_pattern_by_name(self):
+        p = PatternPiece("Front Body")
+        g = Garment(name="Jacket", patterns=[p])
+        assert g.pattern_by_name("front body") is p
+        assert g.pattern_by_name("Back") is None
+
+    def test_to_json_round_trip(self):
+        g = Garment(
+            name="Blazer",
+            patterns=[PatternPiece("Front", fabric_name="Wool")],
+            fabrics=[FabricProperty("Wool", color_hex="#222222")],
+            simulation_frames=200,
+        )
+        g2 = Garment.from_json(g.to_json())
+        assert g2.name == "Blazer"
+        assert g2.simulation_frames == 200
+        assert g2.patterns[0].name == "Front"
+        assert g2.fabrics[0].color_hex == "#222222"
+
+    def test_from_dict_empty(self):
+        g = Garment.from_dict({})
+        assert g.name == "Untitled"
+        assert g.pattern_count == 0
+
+
+# ── Project parser ────────────────────────────────────────────────────────
+
+
+class TestReadProjectMeta:
+    def test_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_project_meta(tmp_path / "missing.zpac")
+
+    def test_wrong_extension(self, tmp_path):
+        p = tmp_path / "file.obj"
+        p.write_bytes(b"")
+        with pytest.raises(ProjectFileError, match="Unsupported format"):
+            read_project_meta(p)
+
+    def test_not_a_zip(self, tmp_path):
+        p = tmp_path / "fake.zpac"
+        p.write_bytes(b"not a zip file")
+        with pytest.raises(ProjectFileError, match="valid ZIP"):
+            read_project_meta(p)
+
+    def test_empty_zip(self, tmp_path):
+        p = _make_zpac(tmp_path / "empty.zpac")
+        meta = read_project_meta(p)
+        assert meta.name == "empty"
+        assert meta.file_format == "zpac"
+        assert meta.pattern_count == 0
+        assert meta.fabric_count == 0
+
+    def test_reads_manifest_name(self, tmp_path):
+        p = _make_zpac(
+            tmp_path / "shirt.zpac",
+            manifest={"name": "Classic Shirt", "md_version": "12.0", "created_at": "2024-01-01"},
+        )
+        meta = read_project_meta(p)
+        assert meta.name == "Classic Shirt"
+        assert meta.md_version == "12.0"
+        assert meta.created_at == "2024-01-01"
+
+    def test_counts_patterns_and_fabrics_from_garment_json(self, tmp_path):
+        garment = {
+            "patterns": [{"name": "Front"}, {"name": "Back"}],
+            "fabrics": [{"name": "Cotton"}],
+        }
+        p = _make_zpac(tmp_path / "dress.zpac", garment=garment)
+        meta = read_project_meta(p)
+        assert meta.pattern_count == 2
+        assert meta.fabric_count == 1
+
+    def test_detects_thumbnail(self, tmp_path):
+        p = tmp_path / "with_thumb.zpac"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("thumbnail.png", b"\x89PNG")
+        meta = read_project_meta(p)
+        assert meta.has_thumbnail is True
+
+    def test_no_thumbnail(self, tmp_path):
+        p = _make_zpac(tmp_path / "no_thumb.zpac")
+        meta = read_project_meta(p)
+        assert meta.has_thumbnail is False
+
+    def test_zprj_format(self, tmp_path):
+        p = _make_zpac(tmp_path / "project.zprj")
+        meta = read_project_meta(p)
+        assert meta.file_format == "zprj"
+
+    def test_to_dict_keys(self, tmp_path):
+        p = _make_zpac(tmp_path / "t.zpac", manifest={"name": "T"})
+        meta = read_project_meta(p)
+        d = meta.to_dict()
+        assert "name" in d
+        assert "file_format" in d
+        assert "pattern_count" in d
+
+
+class TestLoadGarmentFromProject:
+    def test_basic_garment_load(self, tmp_path):
+        garment = {
+            "patterns": [{"name": "Front", "fabric_name": "Cotton", "area_cm2": 200.0}],
+            "fabrics": [{"name": "Cotton", "color_hex": "#FFFFFF"}],
+            "simulation_frames": 150,
+        }
+        p = _make_zpac(tmp_path / "shirt.zpac", manifest={"name": "Shirt"}, garment=garment)
+        g = load_garment_from_project(p)
+        assert g.name == "Shirt"
+        assert g.pattern_count == 1
+        assert g.fabric_count == 1
+        assert g.patterns[0].name == "Front"
+        assert g.fabrics[0].color_hex == "#FFFFFF"
+        assert g.simulation_frames == 150
+
+    def test_garment_with_string_patterns(self, tmp_path):
+        garment = {"patterns": ["Sleeve", "Collar"], "fabrics": ["Linen"]}
+        p = _make_zpac(tmp_path / "g.zpac", garment=garment)
+        g = load_garment_from_project(p)
+        assert g.pattern_count == 2
+        assert g.patterns[0].name == "Sleeve"
+        assert g.fabrics[0].name == "Linen"
+
+    def test_source_file_recorded(self, tmp_path):
+        p = _make_zpac(tmp_path / "recorded.zpac")
+        g = load_garment_from_project(p)
+        assert str(p) == g.source_file
+
+
+# ── Session ───────────────────────────────────────────────────────────────
+
+
+class TestSession:
+    def test_to_dict_round_trip(self):
+        s = Session(session_id="test-001", project_path="/tmp/a.zpac", garment_name="Dress")
+        s2 = Session.from_dict(s.to_dict())
+        assert s2.session_id == "test-001"
+        assert s2.project_path == "/tmp/a.zpac"
+        assert s2.garment_name == "Dress"
+
+    def test_from_dict_ignores_extra(self):
+        s = Session.from_dict({"session_id": "x", "unknown": "y"})
+        assert s.session_id == "x"
+
+
+class TestSessionCrud:
+    @pytest.fixture(autouse=True)
+    def patch_sessions_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(session_mod, "SESSIONS_DIR", tmp_path / "sessions")
+
+    def test_save_and_load(self):
+        s = Session(session_id="s-001", project_path="/tmp/p.zpac")
+        save_session(s)
+        loaded = load_session("s-001")
+        assert loaded.project_path == "/tmp/p.zpac"
+
+    def test_load_missing_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_session("nonexistent")
+
+    def test_list_sessions_empty(self):
+        assert list_sessions() == []
+
+    def test_list_sessions_sorted(self):
+        s1 = Session(session_id="old", updated_at=1000.0)
+        s2 = Session(session_id="new", updated_at=2000.0)
+        save_session(s1)
+        save_session(s2)
+        result = list_sessions()
+        assert result[0].session_id == "new"
+        assert result[1].session_id == "old"
+
+    def test_delete_session_exists(self):
+        s = Session(session_id="del-me")
+        save_session(s)
+        assert delete_session("del-me") is True
+        with pytest.raises(FileNotFoundError):
+            load_session("del-me")
+
+    def test_delete_session_not_found(self):
+        assert delete_session("ghost") is False
+
+    def test_new_session_creates_and_persists(self):
+        s = new_session(project_path="/tmp/x.zpac", garment_name="Jacket")
+        loaded = load_session(s.session_id)
+        assert loaded.project_path == "/tmp/x.zpac"
+        assert loaded.garment_name == "Jacket"
+
+    def test_locked_save_json_atomic(self, tmp_path):
+        """_locked_save_json writes without leaving temp files behind."""
+        from cli_anything.marvelous.core.session import _locked_save_json
+
+        target = tmp_path / "out.json"
+        _locked_save_json(target, {"key": "value"})
+        assert target.exists()
+        with target.open() as f:
+            data = json.load(f)
+        assert data["key"] == "value"
+        # No leftover temp files
+        temps = list(tmp_path.glob(".session-*.json"))
+        assert len(temps) == 0
+
+    def test_load_malformed_json_raises_value_error(self, tmp_path):
+        session_dir = tmp_path / "sessions"
+        session_dir.mkdir()
+        bad = session_dir / "bad.json"
+        bad.write_text("{not valid json", encoding="utf-8")
+        import cli_anything.marvelous.core.session as sm
+
+        sm.SESSIONS_DIR = session_dir
+        with pytest.raises(ValueError, match="Malformed"):
+            load_session("bad")
+
+
+# ── Library ───────────────────────────────────────────────────────────────
+
+
+class TestLibraryEntry:
+    def test_round_trip(self):
+        e = LibraryEntry(slug="tshirt", name="T-Shirt", tags=["basics", "tops"])
+        e2 = LibraryEntry.from_dict(e.to_dict())
+        assert e2.slug == "tshirt"
+        assert e2.tags == ["basics", "tops"]
+
+    def test_from_dict_bad_tags(self):
+        e = LibraryEntry.from_dict({"slug": "x", "name": "X", "tags": None})
+        assert e.tags == []
+
+
+class TestLibraryCrud:
+    @pytest.fixture(autouse=True)
+    def patch_library_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(library_mod, "LIBRARY_DIR", tmp_path / "library")
+
+    def _make_zpac_file(self, tmp_path: Path, name: str = "test.zpac") -> Path:
+        p = tmp_path / name
+        _make_zpac(p, manifest={"name": "Test"})
+        return p
+
+    def test_list_empty(self):
+        assert list_library() == []
+
+    def test_import_and_list(self, tmp_path):
+        src = self._make_zpac_file(tmp_path)
+        e = import_project(src, "tshirt", "T-Shirt", tags=["basics"])
+        entries = list_library()
+        assert len(entries) == 1
+        assert entries[0].slug == "tshirt"
+        assert entries[0].tags == ["basics"]
+
+    def test_import_duplicate_slug_raises(self, tmp_path):
+        src = self._make_zpac_file(tmp_path)
+        import_project(src, "dup", "Dup")
+        src2 = self._make_zpac_file(tmp_path, "test2.zpac")
+        with pytest.raises(FileExistsError):
+            import_project(src2, "dup", "Dup 2")
+
+    def test_import_missing_source_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            import_project(tmp_path / "missing.zpac", "x", "X")
+
+    def test_import_wrong_extension_raises(self, tmp_path):
+        obj_file = tmp_path / "model.obj"
+        obj_file.write_bytes(b"v 0 0 0")
+        with pytest.raises(ValueError, match="Expected .zpac"):
+            import_project(obj_file, "x", "X")
+
+    def test_get_entry(self, tmp_path):
+        src = self._make_zpac_file(tmp_path)
+        import_project(src, "get-test", "Get Test", description="Desc")
+        e = get_entry("get-test")
+        assert e.description == "Desc"
+
+    def test_get_entry_not_found(self):
+        with pytest.raises(KeyError):
+            get_entry("nonexistent")
+
+    def test_delete_entry(self, tmp_path):
+        src = self._make_zpac_file(tmp_path)
+        import_project(src, "to-delete", "To Delete")
+        assert delete_entry("to-delete") is True
+        assert list_library() == []
+
+    def test_delete_entry_not_found(self):
+        assert delete_entry("ghost") is False
+
+    def test_entry_source_path(self, tmp_path):
+        src = self._make_zpac_file(tmp_path)
+        e = import_project(src, "src-test", "Source Test")
+        from cli_anything.marvelous.core.library import entry_source_path
+
+        p = entry_source_path(e)
+        assert p is not None
+        assert p.exists()
+
+
+# ── Backend ───────────────────────────────────────────────────────────────
+
+
+class TestFindMarvelousBinary:
+    def test_env_override_not_found_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MARVELOUS_DESIGNER_BIN", str(tmp_path / "missing_binary"))
+        with pytest.raises(MarvelousNotFoundError, match="set but file not found"):
+            find_marvelous_binary()
+
+    def test_env_override_valid_file(self, monkeypatch, tmp_path):
+        fake_bin = tmp_path / "MarvelousDesigner"
+        fake_bin.write_bytes(b"#!/bin/sh")
+        monkeypatch.setenv("MARVELOUS_DESIGNER_BIN", str(fake_bin))
+        result = find_marvelous_binary()
+        assert result == str(fake_bin)
+
+    def test_no_md_installed_raises(self, monkeypatch):
+        monkeypatch.delenv("MARVELOUS_DESIGNER_BIN", raising=False)
+        # Only raises if no real MD installed; mock the glob
+        import glob as glob_mod
+
+        monkeypatch.setattr(glob_mod, "glob", lambda *a, **kw: [])
+        with pytest.raises(MarvelousNotFoundError):
+            find_marvelous_binary()
+
+
+class TestRenderScriptTemplate:
+    def test_basic_substitution(self):
+        result = render_script_template(
+            "project = r'${project_path}'\nframes = ${frames}",
+            {"project_path": "/tmp/shirt.zpac", "frames": "100"},
+        )
+        assert "project = r'/tmp/shirt.zpac'" in result
+        assert "frames = 100" in result
+
+    def test_missing_variable_raises(self):
+        with pytest.raises(KeyError):
+            render_script_template("x = ${missing}", {})
+
+    def test_multiple_vars(self):
+        tmpl = "${a} and ${b} and ${a}"
+        result = render_script_template(tmpl, {"a": "foo", "b": "bar"})
+        assert result == "foo and bar and foo"
+
+
+class TestLoadScriptTemplate:
+    def test_loads_export_template(self):
+        text = load_script_template("export.py.tpl")
+        assert "export_api" in text
+        assert "${project_path}" in text
+        assert "${export_format}" in text
+
+    def test_loads_simulate_template(self):
+        text = load_script_template("simulate.py.tpl")
+        assert "utility_api.Simulate" in text
+        assert "${frames}" in text
+
+    def test_loads_add_fabric_template(self):
+        text = load_script_template("add_fabric.py.tpl")
+        assert "fabric_api.AssignFabricToPattern" in text
+        assert "${pattern_name}" in text
+
+    def test_missing_template_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_script_template("nonexistent.py.tpl")

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_full_e2e.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_full_e2e.py
@@ -1,0 +1,223 @@
+"""Full E2E tests for cli-anything-marvelous.
+
+These tests require Marvelous Designer to be installed AND
+the MARVELOUS_E2E=1 environment variable to be set.
+
+Without MARVELOUS_E2E=1 all tests in this file are skipped cleanly.
+
+Run live tests:
+    MARVELOUS_E2E=1 pytest cli_anything/marvelous/tests/test_full_e2e.py -v
+
+The _resolve_cli() helper prefers the installed binary, falls back to
+  `python -m cli_anything.marvelous`, and respects
+  CLI_ANYTHING_FORCE_INSTALLED=1 to hard-require the installed path.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ── Gate ─────────────────────────────────────────────────────────────────
+
+_E2E = os.environ.get("MARVELOUS_E2E", "").strip() == "1"
+_SKIP = pytest.mark.skipif(not _E2E, reason="Set MARVELOUS_E2E=1 to run live MD tests")
+
+
+# ── CLI resolver ──────────────────────────────────────────────────────────
+
+
+def _resolve_cli() -> list[str]:
+    """Return argv prefix for invoking cli-anything-marvelous.
+
+    Resolution order:
+    1. Installed binary ``cli-anything-marvelous`` (always preferred).
+    2. ``python -m cli_anything.marvelous`` (editable / source run).
+
+    If CLI_ANYTHING_FORCE_INSTALLED=1 is set, raises RuntimeError when
+    the installed binary is not found (used in CI to catch packaging bugs).
+    """
+    force_installed = os.environ.get("CLI_ANYTHING_FORCE_INSTALLED", "").strip() == "1"
+
+    installed = shutil.which("cli-anything-marvelous")
+    if installed:
+        return [installed]
+
+    if force_installed:
+        raise RuntimeError(
+            "CLI_ANYTHING_FORCE_INSTALLED=1 but 'cli-anything-marvelous' "
+            "binary not found on PATH. Run: pip install -e ."
+        )
+
+    return [sys.executable, "-m", "cli_anything.marvelous"]
+
+
+def _run(*args: str, check: bool = True, **kwargs) -> subprocess.CompletedProcess[str]:
+    """Run cli-anything-marvelous with *args*."""
+    cmd = _resolve_cli() + list(args)
+    return subprocess.run(cmd, capture_output=True, text=True, check=check, **kwargs)
+
+
+# ── Smoke tests (no MD required) ─────────────────────────────────────────
+
+
+class TestCliSmoke:
+    """Basic CLI invocation tests that don't require a running MD instance."""
+
+    def test_version_flag(self):
+        result = _run("--version")
+        assert result.returncode == 0
+        assert "1.0.0" in result.stdout
+
+    def test_help_flag(self):
+        result = _run("--help")
+        assert result.returncode == 0
+        assert "marvelous" in result.stdout.lower()
+
+    def test_config_doctor_json(self):
+        """config doctor --json always returns valid JSON."""
+        result = _run("config", "doctor", "--json", check=False)
+        import json
+
+        data = json.loads(result.stdout)
+        assert "md_binary_found" in data
+        assert "issues" in data
+        assert isinstance(data["issues"], list)
+
+    def test_session_list_json_empty(self, tmp_path):
+        """session list --json returns empty list when no sessions exist."""
+        import json
+
+        env = {**os.environ, "MARVELOUS_SESSIONS_DIR": str(tmp_path / "sessions")}
+        result = _run("session", "list", "--json", env=env)
+        data = json.loads(result.stdout)
+        assert data == []
+
+    def test_library_list_json_empty(self, tmp_path):
+        """library list --json returns empty list when library is empty."""
+        import json
+
+        env = {**os.environ, "MARVELOUS_LIBRARY_DIR": str(tmp_path / "library")}
+        result = _run("library", "list", "--json", env=env)
+        data = json.loads(result.stdout)
+        assert data == []
+
+    def test_project_info_missing_file(self):
+        result = _run("project", "info", "/nonexistent/path.zpac", check=False)
+        assert result.returncode != 0
+
+    def test_project_info_json_valid_zpac(self, tmp_path):
+        """project info --json parses a synthetic .zpac."""
+        import json
+        import zipfile
+
+        zpac = tmp_path / "shirt.zpac"
+        with zipfile.ZipFile(zpac, "w") as zf:
+            zf.writestr("project.json", json.dumps({"name": "Shirt", "md_version": "12"}))
+        result = _run("--json", "project", "info", str(zpac))
+        data = json.loads(result.stdout)
+        assert data["name"] == "Shirt"
+        assert data["file_format"] == "zpac"
+
+    def test_session_save_and_status(self, tmp_path):
+        """session save + status round-trip via CLI."""
+        import json
+
+        env = {**os.environ, "MARVELOUS_SESSIONS_DIR": str(tmp_path / "sessions")}
+        save_result = _run(
+            "--json",
+            "session",
+            "save",
+            "--project",
+            "/tmp/test.zpac",
+            "--garment",
+            "TestGarment",
+            env=env,
+        )
+        saved = json.loads(save_result.stdout)
+        sid = saved["session_id"]
+
+        status_result = _run("--json", "session", "status", sid, env=env)
+        status = json.loads(status_result.stdout)
+        assert status["project_path"] == "/tmp/test.zpac"
+        assert status["garment_name"] == "TestGarment"
+
+    def test_session_delete(self, tmp_path):
+        import json
+
+        env = {**os.environ, "MARVELOUS_SESSIONS_DIR": str(tmp_path / "sessions")}
+        save_result = _run("--json", "session", "save", "--garment", "Del", env=env)
+        sid = json.loads(save_result.stdout)["session_id"]
+
+        del_result = _run("--json", "session", "delete", sid, env=env)
+        data = json.loads(del_result.stdout)
+        assert data["deleted"] is True
+
+
+# ── Live MD tests (require MARVELOUS_E2E=1 + installed MD) ───────────────
+
+
+@_SKIP
+class TestLiveExport:
+    """Tests that actually invoke Marvelous Designer via --script."""
+
+    @pytest.fixture
+    def sample_zpac(self, tmp_path) -> Path:
+        """Return path to a real .zpac fixture.
+
+        Set MARVELOUS_TEST_ZPAC=/path/to/file.zpac to use a real project.
+        Falls back to a minimal synthetic .zpac (MD may reject it).
+        """
+        env_zpac = os.environ.get("MARVELOUS_TEST_ZPAC", "")
+        if env_zpac and Path(env_zpac).exists():
+            return Path(env_zpac)
+        import json
+        import zipfile
+
+        p = tmp_path / "sample.zpac"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("project.json", json.dumps({"name": "SampleGarment"}))
+        return p
+
+    def test_export_obj(self, sample_zpac, tmp_path):
+        output = str(tmp_path / "exported_garment")
+        result = _run(
+            "--json",
+            "export",
+            "run",
+            str(sample_zpac),
+            "--format",
+            "obj",
+            "--output",
+            output,
+            check=False,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        import json
+
+        data = json.loads(result.stdout)
+        assert data["ok"] is True
+
+    def test_simulate_run(self, sample_zpac, tmp_path):
+        output = str(tmp_path / "simulated.zpac")
+        result = _run(
+            "--json",
+            "simulate",
+            "run",
+            str(sample_zpac),
+            "--frames",
+            "10",
+            "--output",
+            output,
+            check=False,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        import json
+
+        data = json.loads(result.stdout)
+        assert data["frames"] == 10

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_garment_edge_cases.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_garment_edge_cases.py
@@ -1,0 +1,164 @@
+"""Garment dataclass edge-case tests — pure-Python, no MD required.
+
+Covers default/override field combinations, serialisation round-trips,
+and boundary conditions not exercised in test_core.py.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from cli_anything.marvelous.core.garment import (FabricProperty, Garment,
+                                                 PatternPiece)
+
+# ── FabricProperty edge cases ─────────────────────────────────────────────
+
+
+class TestFabricPropertyEdgeCases:
+    def test_all_fields_round_trip(self):
+        f = FabricProperty(
+            name="Heavy Denim",
+            texture_path="/textures/denim.png",
+            color_hex="#1A2B3C",
+            density=0.8,
+            thickness=2.1,
+            stretch_weft=120.0,
+            stretch_warp=110.0,
+            shear_stiffness=25.0,
+            bending_weft=1.2,
+            bending_warp=1.1,
+        )
+        f2 = FabricProperty.from_dict(f.to_dict())
+        assert f2.texture_path == "/textures/denim.png"
+        assert f2.density == pytest.approx(0.8)
+        assert f2.stretch_weft == pytest.approx(120.0)
+        assert f2.shear_stiffness == pytest.approx(25.0)
+
+    def test_default_density_is_float(self):
+        f = FabricProperty(name="Linen")
+        assert isinstance(f.density, float)
+
+    def test_default_color_hex_is_white(self):
+        f = FabricProperty(name="Canvas")
+        assert f.color_hex == "#FFFFFF"
+
+    def test_from_dict_with_only_name(self):
+        f = FabricProperty.from_dict({"name": "MinimalFabric"})
+        assert f.name == "MinimalFabric"
+        assert f.thickness == 0.5  # default
+
+    def test_to_dict_contains_all_fields(self):
+        f = FabricProperty(name="Test")
+        d = f.to_dict()
+        expected_keys = {
+            "name",
+            "texture_path",
+            "color_hex",
+            "density",
+            "thickness",
+            "stretch_weft",
+            "stretch_warp",
+            "shear_stiffness",
+            "bending_weft",
+            "bending_warp",
+        }
+        assert expected_keys == set(d.keys())
+
+
+# ── PatternPiece edge cases ───────────────────────────────────────────────
+
+
+class TestPatternPieceEdgeCases:
+    def test_all_fields_round_trip(self):
+        p = PatternPiece(
+            name="Back Bodice",
+            fabric_name="Silk",
+            vertex_count=512,
+            area_cm2=480.75,
+            notes="Bias cut",
+        )
+        p2 = PatternPiece.from_dict(p.to_dict())
+        assert p2.vertex_count == 512
+        assert p2.area_cm2 == pytest.approx(480.75)
+        assert p2.notes == "Bias cut"
+
+    def test_default_vertex_count_is_zero(self):
+        p = PatternPiece(name="Collar")
+        assert p.vertex_count == 0
+
+    def test_from_dict_only_name(self):
+        p = PatternPiece.from_dict({"name": "Cuff"})
+        assert p.name == "Cuff"
+        assert p.area_cm2 == 0.0
+
+
+# ── Garment edge cases ────────────────────────────────────────────────────
+
+
+class TestGarmentEdgeCases:
+    def test_simulation_frames_default(self):
+        g = Garment(name="Default Frames")
+        assert g.simulation_frames == 100
+
+    def test_simulation_frames_override(self):
+        g = Garment(name="Long Sim", simulation_frames=500)
+        assert g.simulation_frames == 500
+
+    def test_notes_preserved_through_round_trip(self):
+        g = Garment(name="Noted", notes="Sample garment for testing")
+        g2 = Garment.from_dict(g.to_dict())
+        assert g2.notes == "Sample garment for testing"
+
+    def test_source_file_preserved_through_round_trip(self):
+        g = Garment(name="Sourced", source_file="/projects/shirt.zpac")
+        g2 = Garment.from_dict(g.to_dict())
+        assert g2.source_file == "/projects/shirt.zpac"
+
+    def test_multiple_fabrics_all_preserved(self):
+        fabrics = [
+            FabricProperty("Cotton"),
+            FabricProperty("Polyester"),
+            FabricProperty("Lycra"),
+        ]
+        g = Garment(name="Blend", fabrics=fabrics)
+        g2 = Garment.from_dict(g.to_dict())
+        assert g2.fabric_count == 3
+        names = {f.name for f in g2.fabrics}
+        assert names == {"Cotton", "Polyester", "Lycra"}
+
+    def test_fabric_by_name_case_insensitive_variants(self):
+        f = FabricProperty("Cashmere")
+        g = Garment(name="Luxury", fabrics=[f])
+        assert g.fabric_by_name("CASHMERE") is f
+        assert g.fabric_by_name("cashmere") is f
+        assert g.fabric_by_name("Cashmere") is f
+
+    def test_pattern_by_name_case_insensitive_variants(self):
+        p = PatternPiece("LEFT SLEEVE")
+        g = Garment(name="Coat", patterns=[p])
+        assert g.pattern_by_name("left sleeve") is p
+        assert g.pattern_by_name("LEFT SLEEVE") is p
+        assert g.pattern_by_name("Left Sleeve") is p
+
+    def test_to_json_produces_valid_json(self):
+        g = Garment(
+            name="JSON Test",
+            patterns=[PatternPiece("Front")],
+            fabrics=[FabricProperty("Silk")],
+        )
+        raw = g.to_json()
+        parsed = json.loads(raw)
+        assert parsed["name"] == "JSON Test"
+        assert len(parsed["patterns"]) == 1
+
+    def test_from_json_round_trip_with_unicode(self):
+        g = Garment(name="ткань", notes="Unicode fabric")
+        g2 = Garment.from_json(g.to_json())
+        assert g2.name == "ткань"
+
+    def test_from_dict_simulation_frames_coercion(self):
+        """simulation_frames provided as string should be coerced to int."""
+        g = Garment.from_dict({"name": "Coerce", "simulation_frames": "200"})
+        assert g.simulation_frames == 200
+        assert isinstance(g.simulation_frames, int)

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_session_concurrent.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_session_concurrent.py
@@ -1,0 +1,171 @@
+"""Session edge-case and concurrency tests — pure-Python, no MD required.
+
+Covers malformed-JSON behaviour, schema mismatch on load, and concurrent
+writes from multiple threads.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import cli_anything.marvelous.core.session as session_mod
+import pytest
+from cli_anything.marvelous.core.session import (Session, delete_session,
+                                                 list_sessions, load_session,
+                                                 new_session, save_session)
+
+# ── Shared fixture ────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def patch_sessions_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_mod, "SESSIONS_DIR", tmp_path / "sessions")
+
+
+# ── Malformed / schema-mismatch behaviour ─────────────────────────────────
+
+
+class TestSessionSchemaEdgeCases:
+    def test_malformed_json_raises_value_error(self, tmp_path):
+        """load_session with corrupt JSON must raise ValueError with 'Malformed'."""
+        session_dir = tmp_path / "sessions"
+        session_dir.mkdir(parents=True)
+        (session_dir / "corrupt.json").write_text("{bad json{{", encoding="utf-8")
+        session_mod.SESSIONS_DIR = session_dir
+        with pytest.raises(ValueError, match="Malformed"):
+            load_session("corrupt")
+
+    def test_schema_mismatch_unknown_fields_ignored(self):
+        """Session.from_dict silently drops unknown keys — no KeyError."""
+        data = {
+            "session_id": "schema-test",
+            "project_path": "/tmp/x.zpac",
+            "unknown_future_field": "some_value",
+            "another_unknown": 999,
+        }
+        s = Session.from_dict(data)
+        assert s.session_id == "schema-test"
+        assert s.project_path == "/tmp/x.zpac"
+
+    def test_schema_mismatch_missing_optional_fields_uses_defaults(self):
+        """A JSON with only session_id fills other fields with defaults."""
+        s = Session.from_dict({"session_id": "minimal"})
+        assert s.garment_name == ""
+        assert s.simulation_frames == 100
+        assert s.last_export_path == ""
+        assert s.notes == ""
+
+    def test_list_sessions_skips_corrupt_entries(self, tmp_path):
+        """list_sessions must skip unreadable JSON rather than crashing."""
+        session_dir = tmp_path / "sessions"
+        session_dir.mkdir(parents=True)
+        session_mod.SESSIONS_DIR = session_dir
+
+        # Write one valid and one corrupt session
+        good = Session(session_id="good-one", project_path="/tmp/ok.zpac")
+        save_session(good)
+        (session_dir / "bad.json").write_text("{{corrupt", encoding="utf-8")
+
+        result = list_sessions()
+        assert len(result) == 1
+        assert result[0].session_id == "good-one"
+
+    def test_empty_json_object_missing_required_field_raises(self):
+        """Session.from_dict({}) must raise TypeError because session_id is required."""
+        with pytest.raises(TypeError):
+            Session.from_dict({})
+
+    def test_session_updated_at_changes_on_save(self):
+        """save_session must bump updated_at each time it is called."""
+        import time
+
+        s = Session(session_id="time-test", updated_at=0.0)
+        save_session(s)
+        loaded = load_session("time-test")
+        assert loaded.updated_at > 0.0
+        assert loaded.updated_at == pytest.approx(time.time(), abs=5.0)
+
+
+# ── Concurrent writes ─────────────────────────────────────────────────────
+
+
+class TestSessionConcurrentWrites:
+    def test_concurrent_saves_produce_valid_json(self, tmp_path):
+        """8 threads each saving the same session must leave valid JSON on disk."""
+        session_dir = tmp_path / "sessions"
+        session_mod.SESSIONS_DIR = session_dir
+
+        errors: list[Exception] = []
+
+        def worker(i: int) -> None:
+            try:
+                s = Session(
+                    session_id="shared-session",
+                    project_path=f"/tmp/project_{i}.zpac",
+                    notes=f"worker-{i}",
+                )
+                save_session(s)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Threads raised errors: {errors}"
+
+        # The file must be valid JSON after all concurrent writes
+        session_file = session_dir / "shared-session.json"
+        assert session_file.exists()
+        with session_file.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+        assert data["session_id"] == "shared-session"
+
+    def test_concurrent_different_sessions_all_written(self, tmp_path):
+        """8 threads writing 8 distinct session IDs must all succeed."""
+        session_dir = tmp_path / "sessions"
+        session_mod.SESSIONS_DIR = session_dir
+
+        errors: list[Exception] = []
+
+        def worker(i: int) -> None:
+            try:
+                s = Session(session_id=f"session-{i}", project_path=f"/tmp/{i}.zpac")
+                save_session(s)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        sessions = list_sessions()
+        assert len(sessions) == 8
+
+    def test_concurrent_new_sessions_all_distinct_ids(self, tmp_path):
+        """new_session() from concurrent threads must produce distinct IDs."""
+        session_dir = tmp_path / "sessions"
+        session_mod.SESSIONS_DIR = session_dir
+
+        created_ids: list[str] = []
+        lock = threading.Lock()
+
+        def worker() -> None:
+            s = new_session(project_path="/tmp/x.zpac")
+            with lock:
+                created_ids.append(s.session_id)
+
+        threads = [threading.Thread(target=worker) for _ in range(6)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(created_ids) == len(set(created_ids)), "Duplicate session IDs generated"

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_templates.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/tests/test_templates.py
@@ -1,0 +1,152 @@
+"""Script template rendering tests — pure-Python, no MD required.
+
+Tests load the bundled .tpl files and verify that string.Template
+substitution produces scripts containing the expected MD API calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cli_anything.marvelous.utils.marvelous_backend import (
+    load_script_template, render_script_template)
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _render(name: str, variables: dict) -> str:
+    """Load a bundled template and substitute the given variables."""
+    return render_script_template(load_script_template(name), variables)
+
+
+# ── export.py.tpl ─────────────────────────────────────────────────────────
+
+
+class TestExportTemplate:
+    _base_vars = {
+        "project_path": "/tmp/shirt.zpac",
+        "output_path": "/tmp/shirt_out",
+        "export_format": "obj",
+    }
+
+    def test_renders_project_path(self):
+        result = _render("export.py.tpl", self._base_vars)
+        assert "/tmp/shirt.zpac" in result
+
+    def test_renders_output_path(self):
+        result = _render("export.py.tpl", self._base_vars)
+        assert "/tmp/shirt_out" in result
+
+    def test_renders_export_format(self):
+        result = _render("export.py.tpl", self._base_vars)
+        assert "obj" in result
+
+    def test_contains_export_api_call(self):
+        result = _render("export.py.tpl", self._base_vars)
+        assert "export_api" in result
+
+    def test_contains_import_zpac_call(self):
+        result = _render("export.py.tpl", self._base_vars)
+        assert "import_api.ImportZpac" in result
+
+    def test_missing_project_path_raises(self):
+        tpl = load_script_template("export.py.tpl")
+        with pytest.raises(KeyError):
+            render_script_template(tpl, {"output_path": "/tmp/x", "export_format": "obj"})
+
+    def test_missing_output_path_raises(self):
+        tpl = load_script_template("export.py.tpl")
+        with pytest.raises(KeyError):
+            render_script_template(tpl, {"project_path": "/tmp/x.zpac", "export_format": "obj"})
+
+    def test_windows_path_preserved(self):
+        """Backslashes in paths survive substitution unchanged."""
+        vars_ = {
+            "project_path": r"C:\Users\test\shirt.zpac",
+            "output_path": r"C:\Users\test\out",
+            "export_format": "fbx",
+        }
+        result = _render("export.py.tpl", vars_)
+        assert r"C:\Users\test\shirt.zpac" in result
+
+    def test_unicode_path_preserved(self):
+        vars_ = {
+            "project_path": "/tmp/рубашка.zpac",
+            "output_path": "/tmp/рубашка_out",
+            "export_format": "usd",
+        }
+        result = _render("export.py.tpl", vars_)
+        assert "рубашка.zpac" in result
+
+
+# ── simulate.py.tpl ───────────────────────────────────────────────────────
+
+
+class TestSimulateTemplate:
+    _base_vars = {
+        "project_path": "/tmp/dress.zpac",
+        "frames": "250",
+        "output_path": "/tmp/dress_sim.zpac",
+    }
+
+    def test_renders_frames(self):
+        result = _render("simulate.py.tpl", self._base_vars)
+        assert "250" in result
+
+    def test_contains_utility_api_simulate(self):
+        result = _render("simulate.py.tpl", self._base_vars)
+        assert "utility_api.Simulate" in result
+
+    def test_contains_export_zpac(self):
+        result = _render("simulate.py.tpl", self._base_vars)
+        assert "export_api.ExportZpac" in result
+
+    def test_missing_frames_raises(self):
+        tpl = load_script_template("simulate.py.tpl")
+        with pytest.raises(KeyError):
+            render_script_template(
+                tpl, {"project_path": "/tmp/x.zpac", "output_path": "/tmp/x_out.zpac"}
+            )
+
+    def test_zero_frames_renders(self):
+        """Zero is a valid integer; template should still render."""
+        vars_ = {**self._base_vars, "frames": "0"}
+        result = _render("simulate.py.tpl", vars_)
+        assert "FRAMES" in result
+
+
+# ── add_fabric.py.tpl ─────────────────────────────────────────────────────
+
+
+class TestAddFabricTemplate:
+    _base_vars = {
+        "project_path": "/tmp/jacket.zpac",
+        "pattern_name": "Front Panel",
+        "fabric_name": "Wool Blend",
+        "texture_path": "/tmp/wool.png",
+        "output_path": "/tmp/jacket_v2.zpac",
+    }
+
+    def test_renders_pattern_name(self):
+        result = _render("add_fabric.py.tpl", self._base_vars)
+        assert "Front Panel" in result
+
+    def test_renders_fabric_name(self):
+        result = _render("add_fabric.py.tpl", self._base_vars)
+        assert "Wool Blend" in result
+
+    def test_contains_assign_fabric_call(self):
+        result = _render("add_fabric.py.tpl", self._base_vars)
+        assert "fabric_api.AssignFabricToPattern" in result
+
+    def test_missing_pattern_name_raises(self):
+        tpl = load_script_template("add_fabric.py.tpl")
+        vars_incomplete = {k: v for k, v in self._base_vars.items() if k != "pattern_name"}
+        with pytest.raises(KeyError):
+            render_script_template(tpl, vars_incomplete)
+
+    def test_special_chars_in_fabric_name(self):
+        """Fabric names with spaces and quotes pass through without error."""
+        vars_ = {**self._base_vars, "fabric_name": "Silk & Satin (100%)"}
+        result = _render("add_fabric.py.tpl", self._base_vars)
+        # Substitution should not raise
+        assert result is not None

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/utils/__init__.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/utils/__init__.py
@@ -1,0 +1,1 @@
+"""cli-anything-marvelous utilities."""

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/utils/marvelous_backend.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/utils/marvelous_backend.py
@@ -1,0 +1,213 @@
+"""Marvelous Designer subprocess backend for cli-anything-marvelous.
+
+Locates the Marvelous Designer binary on macOS and runs Python scripts
+inside MD via the undocumented --script flag.
+
+⚠ HEADLESS CAVEAT: CLO Virtual Fashion's official docs state
+"no headless session available" and "command-line/batch options not
+currently available" as of MD 12 (https://developer.marvelousdesigner.com/).
+The --script flag is asserted by user workflow reports but is NOT
+documented in the official scripting API reference.  Build and test
+with caution; verify against your installed MD version.
+
+macOS binary glob:
+    /Applications/CLO Virtual Fashion/Marvelous Designer*/
+        Marvelous Designer.app/Contents/MacOS/Marvelous Designer
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from string import Template
+from typing import Any
+
+# ── Exceptions ────────────────────────────────────────────────────────────
+
+
+class MarvelousError(Exception):
+    """Base exception for all cli-anything-marvelous backend errors."""
+
+
+class MarvelousNotFoundError(MarvelousError):
+    """Marvelous Designer binary not found on this system.
+
+    Install Marvelous Designer from https://www.marvelousdesigner.com/
+    and ensure it is in the standard Applications location:
+        /Applications/CLO Virtual Fashion/Marvelous Designer*/
+    """
+
+
+class MarvelousScriptError(MarvelousError):
+    """A script executed inside Marvelous Designer reported an error."""
+
+    def __init__(self, message: str, returncode: int = 1, stderr: str = ""):
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+class MarvelousTimeoutError(MarvelousError):
+    """Marvelous Designer did not complete within the allowed timeout."""
+
+
+# ── Binary discovery ──────────────────────────────────────────────────────
+
+_MD_GLOB = (
+    "/Applications/CLO Virtual Fashion/"
+    "Marvelous Designer*/"
+    "Marvelous Designer.app/Contents/MacOS/Marvelous Designer"
+)
+
+_MD_BIN_ENV = "MARVELOUS_DESIGNER_BIN"
+
+
+def find_marvelous_binary() -> str:
+    """Return the path to the Marvelous Designer executable.
+
+    Resolution order:
+    1. ``MARVELOUS_DESIGNER_BIN`` environment variable (override).
+    2. Glob scan of the standard Applications path.
+
+    Returns:
+        Absolute path string to the binary.
+
+    Raises:
+        MarvelousNotFoundError: Binary not found by any method.
+    """
+    env_override = os.environ.get(_MD_BIN_ENV, "").strip()
+    if env_override:
+        if Path(env_override).is_file():
+            return env_override
+        raise MarvelousNotFoundError(
+            f"MARVELOUS_DESIGNER_BIN='{env_override}' set but file not found."
+        )
+
+    matches = sorted(glob.glob(_MD_GLOB))
+    if matches:
+        # Take newest version (sorted descending puts higher version numbers last
+        # for typical "Marvelous Designer 12" naming)
+        return matches[-1]
+
+    raise MarvelousNotFoundError(
+        "Marvelous Designer binary not found.\n"
+        f"Expected location: {_MD_GLOB}\n"
+        "Install from https://www.marvelousdesigner.com/ or set "
+        f"{_MD_BIN_ENV}=/path/to/binary."
+    )
+
+
+# ── Script runner ─────────────────────────────────────────────────────────
+
+
+def render_script_template(template_text: str, variables: dict[str, Any]) -> str:
+    """Substitute ${var} placeholders in a script template.
+
+    Uses stdlib ``string.Template`` — no Jinja2 dependency.
+
+    Args:
+        template_text: Script template with ``${var}`` placeholders.
+        variables:     Dict of variable names -> values.
+
+    Returns:
+        Rendered script string.
+
+    Raises:
+        KeyError: A required placeholder is missing from *variables*.
+    """
+    return Template(template_text).substitute(variables)
+
+
+def run_md_script(
+    script_text: str,
+    binary: str | None = None,
+    timeout: int = 300,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Write *script_text* to a temp file and run it inside MD.
+
+    Passes the temp file path via ``--script <path>`` to the MD binary.
+
+    ⚠ See module docstring for --script caveat.
+
+    Args:
+        script_text: Python source code to execute inside MD.
+        binary:      Path to MD binary (auto-detected if None).
+        timeout:     Seconds before raising MarvelousTimeoutError.
+        extra_env:   Additional environment variables for the subprocess.
+
+    Returns:
+        CompletedProcess with stdout/stderr captured.
+
+    Raises:
+        MarvelousNotFoundError: Binary not found.
+        MarvelousTimeoutError:  Process exceeded *timeout*.
+        MarvelousScriptError:   Process exited non-zero.
+    """
+    resolved_binary = binary or find_marvelous_binary()
+
+    env = {**os.environ}
+    if extra_env:
+        env.update(extra_env)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".py",
+        prefix="cli_anything_md_",
+        delete=False,
+        encoding="utf-8",
+    ) as tmp:
+        tmp.write(script_text)
+        script_path = tmp.name
+
+    try:
+        proc = subprocess.run(
+            [resolved_binary, "--script", script_path],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise MarvelousTimeoutError(f"Marvelous Designer timed out after {timeout}s") from exc
+    finally:
+        try:
+            os.unlink(script_path)
+        except OSError:
+            pass
+
+    if proc.returncode != 0:
+        raise MarvelousScriptError(
+            f"MD script exited with code {proc.returncode}",
+            returncode=proc.returncode,
+            stderr=proc.stderr,
+        )
+
+    return proc
+
+
+# ── Script template loader ────────────────────────────────────────────────
+
+
+def load_script_template(template_name: str) -> str:
+    """Load a bundled script template by filename.
+
+    Looks in cli_anything/marvelous/resources/scripts/<template_name>.
+
+    Args:
+        template_name: Filename, e.g. ``"export.py.tpl"``.
+
+    Returns:
+        Raw template text.
+
+    Raises:
+        FileNotFoundError: Template not found in package resources.
+    """
+    resources_dir = Path(__file__).resolve().parent.parent / "resources" / "scripts"
+    path = resources_dir / template_name
+    if not path.exists():
+        raise FileNotFoundError(f"Script template '{template_name}' not found at {path}")
+    return path.read_text(encoding="utf-8")

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/utils/repl_skin.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/cli_anything/marvelous/utils/repl_skin.py
@@ -1,0 +1,595 @@
+"""cli-anything REPL Skin — Unified terminal interface for all CLI harnesses.
+
+Copy this file into your CLI package at:
+    cli_anything/<software>/utils/repl_skin.py
+
+Usage:
+    from cli_anything.<software>.utils.repl_skin import ReplSkin
+
+    skin = ReplSkin("shotcut", version="1.0.0")
+    skin.print_banner()  # auto-detects repo-root or packaged SKILL.md
+    prompt_text = skin.prompt(project_name="my_video.mlt", modified=True)
+    skin.success("Project saved")
+    skin.error("File not found")
+    skin.warning("Unsaved changes")
+    skin.info("Processing 24 clips...")
+    skin.status("Track 1", "3 clips, 00:02:30")
+    skin.table(headers, rows)
+    skin.print_goodbye()
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# ── ANSI color codes (no external deps for core styling) ──────────────
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_ITALIC = "\033[3m"
+_UNDERLINE = "\033[4m"
+
+# Brand colors
+_CYAN = "\033[38;5;80m"  # cli-anything brand cyan
+_CYAN_BG = "\033[48;5;80m"
+_WHITE = "\033[97m"
+_GRAY = "\033[38;5;245m"
+_DARK_GRAY = "\033[38;5;240m"
+_LIGHT_GRAY = "\033[38;5;250m"
+
+# Software accent colors — each software gets a unique accent
+_ACCENT_COLORS = {
+    "gimp": "\033[38;5;214m",  # warm orange
+    "blender": "\033[38;5;208m",  # deep orange
+    "inkscape": "\033[38;5;39m",  # bright blue
+    "audacity": "\033[38;5;33m",  # navy blue
+    "libreoffice": "\033[38;5;40m",  # green
+    "obs_studio": "\033[38;5;55m",  # purple
+    "kdenlive": "\033[38;5;69m",  # slate blue
+    "shotcut": "\033[38;5;35m",  # teal green
+    "marvelous": "\033[38;5;171m",  # violet/magenta — garment design accent
+}
+_DEFAULT_ACCENT = "\033[38;5;75m"  # default sky blue
+
+# Status colors
+_GREEN = "\033[38;5;78m"
+_YELLOW = "\033[38;5;220m"
+_RED = "\033[38;5;196m"
+_BLUE = "\033[38;5;75m"
+_MAGENTA = "\033[38;5;176m"
+
+_SKILL_SOURCE_REPO = os.environ.get("CLI_ANYTHING_SKILL_REPO", "HKUDS/CLI-Anything")
+
+# ── Brand icon ────────────────────────────────────────────────────────
+
+# The cli-anything icon: a small colored diamond/chevron mark
+_ICON = f"{_CYAN}{_BOLD}◆{_RESET}"
+_ICON_SMALL = f"{_CYAN}▸{_RESET}"
+
+# ── Box drawing characters ────────────────────────────────────────────
+
+_H_LINE = "─"
+_V_LINE = "│"
+_TL = "╭"
+_TR = "╮"
+_BL = "╰"
+_BR = "╯"
+_T_DOWN = "┬"
+_T_UP = "┴"
+_T_RIGHT = "├"
+_T_LEFT = "┤"
+_CROSS = "┼"
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes for length calculation."""
+    import re
+
+    return re.sub(r"\033\[[^m]*m", "", text)
+
+
+def _visible_len(text: str) -> int:
+    """Get visible length of text (excluding ANSI codes)."""
+    return len(_strip_ansi(text))
+
+
+def _display_home_path(path: str) -> str:
+    """Display a path relative to the home directory when possible."""
+    expanded = Path(path).expanduser().resolve()
+    home = Path.home().resolve()
+    try:
+        relative = expanded.relative_to(home)
+        return f"~/{relative.as_posix()}"
+    except ValueError:
+        return str(expanded)
+
+
+class ReplSkin:
+    """Unified REPL skin for cli-anything CLIs.
+
+    Provides consistent branding, prompts, and message formatting
+    across all CLI harnesses built with the cli-anything methodology.
+    """
+
+    def __init__(
+        self,
+        software: str,
+        version: str = "1.0.0",
+        history_file: str | None = None,
+        skill_path: str | None = None,
+    ):
+        """Initialize the REPL skin.
+
+        Args:
+            software: Software name (e.g., "gimp", "shotcut", "blender").
+            version: CLI version string.
+            history_file: Path for persistent command history.
+                         Defaults to ~/.cli-anything-<software>/history
+            skill_path: Path to the SKILL.md file for agent discovery.
+                        Auto-detected from the repo-root skills/ tree when present,
+                        otherwise from the package's skills/ directory.
+                        Displayed in banner for AI agents to know where to read skill info.
+        """
+        self.software = software.lower().replace("-", "_")
+        self.display_name = software.replace("_", " ").title()
+        self.version = version
+        software_aliases = {"iterm2_ctl": "iterm2"}
+        self.skill_slug = software_aliases.get(self.software, self.software).replace("_", "-")
+        self.skill_id = f"cli-anything-{self.skill_slug}"
+        self.skill_install_cmd = (
+            f"npx skills add {_SKILL_SOURCE_REPO} --skill {self.skill_id} -g -y"
+        )
+        global_skill_root = Path(
+            os.environ.get(
+                "CLI_ANYTHING_GLOBAL_SKILLS_DIR",
+                str(Path.home() / ".agents" / "skills"),
+            )
+        ).expanduser()
+        self.global_skill_path = str(global_skill_root / self.skill_id / "SKILL.md")
+
+        # Prefer repo-root canonical skills/<skill-id>/SKILL.md when running
+        # inside the CLI-Anything monorepo. Fall back to the packaged
+        # cli_anything/<software>/skills/SKILL.md for installed harnesses.
+        if skill_path is None:
+            package_skill = Path(__file__).resolve().parent.parent / "skills" / "SKILL.md"
+            repo_skill = None
+            for parent in Path(__file__).resolve().parents:
+                candidate = parent / "skills" / self.skill_id / "SKILL.md"
+                if candidate.is_file():
+                    repo_skill = candidate
+                    break
+            if repo_skill and repo_skill.is_file():
+                skill_path = str(repo_skill)
+            elif package_skill.is_file():
+                skill_path = str(package_skill)
+        self.skill_path = skill_path
+        self.accent = _ACCENT_COLORS.get(self.software, _DEFAULT_ACCENT)
+
+        # History file
+        if history_file is None:
+            hist_dir = Path.home() / f".cli-anything-{self.software}"
+            hist_dir.mkdir(parents=True, exist_ok=True)
+            self.history_file = str(hist_dir / "history")
+        else:
+            self.history_file = history_file
+
+        # Detect terminal capabilities
+        self._color = self._detect_color_support()
+
+    def _detect_color_support(self) -> bool:
+        """Check if terminal supports color."""
+        if os.environ.get("NO_COLOR"):
+            return False
+        if os.environ.get("CLI_ANYTHING_NO_COLOR"):
+            return False
+        if not hasattr(sys.stdout, "isatty"):
+            return False
+        return sys.stdout.isatty()
+
+    def _c(self, code: str, text: str) -> str:
+        """Apply color code if colors are supported."""
+        if not self._color:
+            return text
+        return f"{code}{text}{_RESET}"
+
+    # ── Banner ────────────────────────────────────────────────────────
+
+    def print_banner(self):
+        """Print the startup banner with branding."""
+        import textwrap
+
+        inner = 72
+
+        def _box_line(content: str) -> str:
+            """Wrap content in box drawing, padding to inner width."""
+            pad = inner - _visible_len(content)
+            vl = self._c(_DARK_GRAY, _V_LINE)
+            return f"{vl}{content}{' ' * max(0, pad)}{vl}"
+
+        def _meta_lines(label: str, value: str) -> list[str]:
+            """Wrap a metadata line for the banner box."""
+            icon = self._c(_MAGENTA, "◇")
+            label_text = self._c(_DARK_GRAY, label)
+            prefix = f" {icon} {label_text} "
+            available = max(12, inner - _visible_len(prefix))
+            wrapped = textwrap.wrap(
+                value,
+                width=available,
+                break_long_words=True,
+                break_on_hyphens=False,
+            ) or [""]
+            lines = [f"{prefix}{self._c(_LIGHT_GRAY, wrapped[0])}"]
+            continuation_prefix = " " * _visible_len(prefix)
+            for chunk in wrapped[1:]:
+                lines.append(f"{continuation_prefix}{self._c(_LIGHT_GRAY, chunk)}")
+            return lines
+
+        top = self._c(_DARK_GRAY, f"{_TL}{_H_LINE * inner}{_TR}")
+        bot = self._c(_DARK_GRAY, f"{_BL}{_H_LINE * inner}{_BR}")
+
+        # Title:  ◆  cli-anything · Marvelous
+        icon = self._c(_CYAN + _BOLD, "◆")
+        brand = self._c(_CYAN + _BOLD, "cli-anything")
+        dot = self._c(_DARK_GRAY, "·")
+        name = self._c(self.accent + _BOLD, self.display_name)
+        title = f" {icon}  {brand} {dot} {name}"
+
+        ver = f" {self._c(_DARK_GRAY, f'   v{self.version}')}"
+        tip = f" {self._c(_DARK_GRAY, '   Type help for commands, quit to exit')}"
+        empty = ""
+
+        meta_lines: list[str] = []
+        meta_lines.extend(_meta_lines("Install:", self.skill_install_cmd))
+        meta_lines.extend(_meta_lines("Global skill:", _display_home_path(self.global_skill_path)))
+        print(top)
+        print(_box_line(title))
+        print(_box_line(ver))
+        for line in meta_lines:
+            print(_box_line(line))
+        print(_box_line(empty))
+        print(_box_line(tip))
+        print(bot)
+        print()
+
+    # ── Prompt ────────────────────────────────────────────────────────
+
+    def prompt(
+        self,
+        project_name: str = "",
+        modified: bool = False,
+        context: str = "",
+    ) -> str:
+        """Build a styled prompt string for prompt_toolkit or input().
+
+        Args:
+            project_name: Current project name (empty if none open).
+            modified: Whether the project has unsaved changes.
+            context: Optional extra context to show in prompt.
+
+        Returns:
+            Formatted prompt string.
+        """
+        parts = []
+
+        # Icon
+        if self._color:
+            parts.append(f"{_CYAN}◆{_RESET} ")
+        else:
+            parts.append("> ")
+
+        # Software name
+        parts.append(self._c(self.accent + _BOLD, self.software))
+
+        # Project context
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            parts.append(f" {self._c(_DARK_GRAY, '[')}")
+            parts.append(self._c(_LIGHT_GRAY, f"{ctx}{mod}"))
+            parts.append(self._c(_DARK_GRAY, "]"))
+
+        parts.append(self._c(_GRAY, " ❯ "))
+
+        return "".join(parts)
+
+    def prompt_tokens(
+        self,
+        project_name: str = "",
+        modified: bool = False,
+        context: str = "",
+    ):
+        """Build prompt_toolkit formatted text tokens for the prompt.
+
+        Use with prompt_toolkit's FormattedText for proper ANSI handling.
+
+        Returns:
+            list of (style, text) tuples for prompt_toolkit.
+        """
+        tokens = []
+
+        tokens.append(("class:icon", "◆ "))
+        tokens.append(("class:software", self.software))
+
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            tokens.append(("class:bracket", " ["))
+            tokens.append(("class:context", f"{ctx}{mod}"))
+            tokens.append(("class:bracket", "]"))
+
+        tokens.append(("class:arrow", " ❯ "))
+
+        return tokens
+
+    def get_prompt_style(self):
+        """Get a prompt_toolkit Style object matching the skin.
+
+        Returns:
+            prompt_toolkit.styles.Style
+        """
+        try:
+            from prompt_toolkit.styles import Style
+        except ImportError:
+            return None
+
+        accent_hex = _ANSI_256_TO_HEX.get(self.accent, "#5fafff")
+
+        return Style.from_dict(
+            {
+                "icon": "#5fdfdf bold",  # cyan brand color
+                "software": f"{accent_hex} bold",
+                "bracket": "#585858",
+                "context": "#bcbcbc",
+                "arrow": "#808080",
+                # Completion menu
+                "completion-menu.completion": "bg:#303030 #bcbcbc",
+                "completion-menu.completion.current": f"bg:{accent_hex} #000000",
+                "completion-menu.meta.completion": "bg:#303030 #808080",
+                "completion-menu.meta.completion.current": f"bg:{accent_hex} #000000",
+                # Auto-suggest
+                "auto-suggest": "#585858",
+                # Bottom toolbar
+                "bottom-toolbar": "bg:#1c1c1c #808080",
+                "bottom-toolbar.text": "#808080",
+            }
+        )
+
+    # ── Messages ──────────────────────────────────────────────────────
+
+    def success(self, message: str):
+        """Print a success message with green checkmark."""
+        icon = self._c(_GREEN + _BOLD, "✓")
+        print(f"  {icon} {self._c(_GREEN, message)}")
+
+    def error(self, message: str):
+        """Print an error message with red cross."""
+        icon = self._c(_RED + _BOLD, "✗")
+        print(f"  {icon} {self._c(_RED, message)}", file=sys.stderr)
+
+    def warning(self, message: str):
+        """Print a warning message with yellow triangle."""
+        icon = self._c(_YELLOW + _BOLD, "⚠")
+        print(f"  {icon} {self._c(_YELLOW, message)}")
+
+    def info(self, message: str):
+        """Print an info message with blue dot."""
+        icon = self._c(_BLUE, "●")
+        print(f"  {icon} {self._c(_LIGHT_GRAY, message)}")
+
+    def hint(self, message: str):
+        """Print a subtle hint message."""
+        print(f"  {self._c(_DARK_GRAY, message)}")
+
+    def section(self, title: str):
+        """Print a section header."""
+        print()
+        print(f"  {self._c(self.accent + _BOLD, title)}")
+        print(f"  {self._c(_DARK_GRAY, _H_LINE * len(title))}")
+
+    # ── Status display ────────────────────────────────────────────────
+
+    def status(self, label: str, value: str):
+        """Print a key-value status line."""
+        lbl = self._c(_GRAY, f"  {label}:")
+        val = self._c(_WHITE, f" {value}")
+        print(f"{lbl}{val}")
+
+    def status_block(self, items: dict[str, str], title: str = ""):
+        """Print a block of status key-value pairs.
+
+        Args:
+            items: Dict of label -> value pairs.
+            title: Optional title for the block.
+        """
+        if title:
+            self.section(title)
+
+        max_key = max(len(k) for k in items) if items else 0
+        for label, value in items.items():
+            lbl = self._c(_GRAY, f"  {label:<{max_key}}")
+            val = self._c(_WHITE, f"  {value}")
+            print(f"{lbl}{val}")
+
+    def progress(self, current: int, total: int, label: str = ""):
+        """Print a simple progress indicator.
+
+        Args:
+            current: Current step number.
+            total: Total number of steps.
+            label: Optional label for the progress.
+        """
+        pct = int(current / total * 100) if total > 0 else 0
+        bar_width = 20
+        filled = int(bar_width * current / total) if total > 0 else 0
+        bar = "█" * filled + "░" * (bar_width - filled)
+        text = f"  {self._c(_CYAN, bar)} {self._c(_GRAY, f'{pct:3d}%')}"
+        if label:
+            text += f" {self._c(_LIGHT_GRAY, label)}"
+        print(text)
+
+    # ── Table display ─────────────────────────────────────────────────
+
+    def table(
+        self,
+        headers: list[str],
+        rows: list[list[str]],
+        max_col_width: int = 40,
+    ):
+        """Print a formatted table with box-drawing characters.
+
+        Args:
+            headers: Column header strings.
+            rows: List of rows, each a list of cell strings.
+            max_col_width: Maximum column width before truncation.
+        """
+        if not headers:
+            return
+
+        # Calculate column widths
+        col_widths = [min(len(h), max_col_width) for h in headers]
+        for row in rows:
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    col_widths[i] = min(max(col_widths[i], len(str(cell))), max_col_width)
+
+        def pad(text: str, width: int) -> str:
+            t = str(text)[:width]
+            return t + " " * (width - len(t))
+
+        # Header
+        header_cells = [
+            self._c(_CYAN + _BOLD, pad(h, col_widths[i])) for i, h in enumerate(headers)
+        ]
+        sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+        header_line = f"  {sep.join(header_cells)}"
+        print(header_line)
+
+        # Separator
+        sep_line = self._c(_DARK_GRAY, f"  {'───'.join([_H_LINE * w for w in col_widths])}")
+        print(sep_line)
+
+        # Rows
+        for row in rows:
+            cells = []
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    cells.append(self._c(_LIGHT_GRAY, pad(str(cell), col_widths[i])))
+            row_sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+            print(f"  {row_sep.join(cells)}")
+
+    # ── Help display ──────────────────────────────────────────────────
+
+    def help(self, commands: dict[str, str]):
+        """Print a formatted help listing.
+
+        Args:
+            commands: Dict of command -> description pairs.
+        """
+        self.section("Commands")
+        max_cmd = max(len(c) for c in commands) if commands else 0
+        for cmd, desc in commands.items():
+            cmd_styled = self._c(self.accent, f"  {cmd:<{max_cmd}}")
+            desc_styled = self._c(_GRAY, f"  {desc}")
+            print(f"{cmd_styled}{desc_styled}")
+        print()
+
+    # ── Goodbye ───────────────────────────────────────────────────────
+
+    def print_goodbye(self):
+        """Print a styled goodbye message."""
+        print(f"\n  {_ICON_SMALL} {self._c(_GRAY, 'Goodbye!')}\n")
+
+    # ── Prompt toolkit session factory ────────────────────────────────
+
+    def create_prompt_session(self):
+        """Create a prompt_toolkit PromptSession with skin styling.
+
+        Returns:
+            A configured PromptSession, or None if prompt_toolkit unavailable.
+        """
+        try:
+            from prompt_toolkit import PromptSession
+            from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+            from prompt_toolkit.history import FileHistory
+
+            style = self.get_prompt_style()
+
+            session = PromptSession(
+                history=FileHistory(self.history_file),
+                auto_suggest=AutoSuggestFromHistory(),
+                style=style,
+                enable_history_search=True,
+            )
+            return session
+        except ImportError:
+            return None
+
+    def get_input(
+        self,
+        pt_session,
+        project_name: str = "",
+        modified: bool = False,
+        context: str = "",
+    ) -> str:
+        """Get input from user using prompt_toolkit or fallback.
+
+        Args:
+            pt_session: A prompt_toolkit PromptSession (or None).
+            project_name: Current project name.
+            modified: Whether project has unsaved changes.
+            context: Optional context string.
+
+        Returns:
+            User input string (stripped).
+        """
+        if pt_session is not None:
+            from prompt_toolkit.formatted_text import FormattedText
+
+            tokens = self.prompt_tokens(project_name, modified, context)
+            return pt_session.prompt(FormattedText(tokens)).strip()
+        else:
+            raw_prompt = self.prompt(project_name, modified, context)
+            return input(raw_prompt).strip()
+
+    # ── Toolbar builder ───────────────────────────────────────────────
+
+    def bottom_toolbar(self, items: dict[str, str]):
+        """Create a bottom toolbar callback for prompt_toolkit.
+
+        Args:
+            items: Dict of label -> value pairs to show in toolbar.
+
+        Returns:
+            A callable that returns FormattedText for the toolbar.
+        """
+
+        def toolbar():
+            from prompt_toolkit.formatted_text import FormattedText
+
+            parts = []
+            for i, (k, v) in enumerate(items.items()):
+                if i > 0:
+                    parts.append(("class:bottom-toolbar.text", "  │  "))
+                parts.append(("class:bottom-toolbar.text", f" {k}: "))
+                parts.append(("class:bottom-toolbar", v))
+            return FormattedText(parts)
+
+        return toolbar
+
+
+# ── ANSI 256-color to hex mapping (for prompt_toolkit styles) ─────────
+
+_ANSI_256_TO_HEX = {
+    "\033[38;5;33m": "#0087ff",  # audacity navy blue
+    "\033[38;5;35m": "#00af5f",  # shotcut teal
+    "\033[38;5;39m": "#00afff",  # inkscape bright blue
+    "\033[38;5;40m": "#00d700",  # libreoffice green
+    "\033[38;5;55m": "#5f00af",  # obs purple
+    "\033[38;5;69m": "#5f87ff",  # kdenlive slate blue
+    "\033[38;5;75m": "#5fafff",  # default sky blue
+    "\033[38;5;80m": "#5fd7d7",  # brand cyan
+    "\033[38;5;171m": "#d75fff",  # marvelous violet
+    "\033[38;5;208m": "#ff8700",  # blender deep orange
+    "\033[38;5;214m": "#ffaf00",  # gimp warm orange
+}

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/setup.py
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/setup.py
@@ -1,0 +1,43 @@
+"""cli-anything-marvelous — Marvelous Designer CLI harness."""
+
+from setuptools import find_namespace_packages, setup
+
+setup(
+    name="cli-anything-marvelous",
+    version="1.0.0",
+    description="CLI harness for Marvelous Designer (CLO Virtual Fashion)",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    author="cli-anything contributors",
+    python_requires=">=3.10",
+    packages=find_namespace_packages(include=["cli_anything.*"]),
+    include_package_data=True,
+    package_data={
+        "cli_anything.marvelous": [
+            "resources/scripts/*.tpl",
+            "skills/SKILL.md",
+        ],
+    },
+    install_requires=[
+        "click>=8.1",
+        "prompt-toolkit>=3.0",
+    ],
+    extras_require={
+        "dev": [
+            "pytest>=7.0",
+            "pytest-cov>=4.0",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "cli-anything-marvelous=cli_anything.marvelous.marvelous_cli:main",
+        ],
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: MacOS :: MacOS X",
+        "Environment :: Console",
+        "Topic :: Utilities",
+    ],
+)

--- a/skyyrose/cli_harnesses/marvelous/agent-harness/skills/cli-anything-marvelous/SKILL.md
+++ b/skyyrose/cli_harnesses/marvelous/agent-harness/skills/cli-anything-marvelous/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: cli-anything-marvelous
+description: >
+  Operate the cli-anything-marvelous harness for Marvelous Designer.
+  Use when the user wants to parse .zpac/.zprj files, run simulations,
+  export garments, manage sessions, or interact with the local garment library.
+---
+
+# cli-anything-marvelous Skill
+
+## When to Use
+
+- User wants to inspect a `.zpac` or `.zprj` project file
+- User wants to simulate, export, or add fabrics via Marvelous Designer
+- User wants to manage garment sessions or the local template library
+- User wants to run the interactive REPL
+
+## Package Location
+
+```
+/Users/theceo/DevSkyy/vendor/cli-anything/marvelous/agent-harness/
+```
+
+Key files:
+- `cli_anything/marvelous/marvelous_cli.py` — all Click commands
+- `cli_anything/marvelous/core/` — project, garment, session, library modules
+- `cli_anything/marvelous/utils/marvelous_backend.py` — subprocess + script runner
+- `cli_anything/marvelous/resources/scripts/` — MD script templates
+
+## Command Reference
+
+```bash
+cli-anything-marvelous project info <file.zpac>          # Parse metadata
+cli-anything-marvelous --json project info <file.zpac>   # JSON output
+cli-anything-marvelous export run <file.zpac> --format obj --output ./out
+cli-anything-marvelous simulate run <file.zpac> --frames 30 --output ./sim.zpac
+cli-anything-marvelous garment add-fabric <file.zpac> \
+  --pattern "Front Bodice" --fabric "Cotton" --texture ./t.jpg --output ./out.zpac
+cli-anything-marvelous library import <file.zpac> --slug my-shirt --name "My Shirt"
+cli-anything-marvelous library list
+cli-anything-marvelous session save --project /path/to.zpac --garment "Shirt"
+cli-anything-marvelous session list
+cli-anything-marvelous session status <session-id>
+cli-anything-marvelous session delete <session-id>
+cli-anything-marvelous config doctor
+cli-anything-marvelous              # launches REPL
+```
+
+## Commands That Need MD Installed
+
+`export run`, `simulate run`, `garment add-fabric` — all require Marvelous Designer.
+
+All other commands work without MD.
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `MARVELOUS_DESIGNER_BIN` | Override MD binary path |
+| `MARVELOUS_E2E=1` | Enable live E2E tests |
+| `MARVELOUS_TEST_ZPAC` | Real .zpac path for live tests |
+
+## Running Tests
+
+```bash
+cd /Users/theceo/DevSkyy/vendor/cli-anything/marvelous/agent-harness
+pytest cli_anything/marvelous/tests/test_core.py -v           # unit only
+pytest cli_anything/marvelous/tests/ -v                       # + smoke E2E
+pytest cli_anything/marvelous/tests/ --cov=cli_anything.marvelous
+```
+
+## Python API (for programmatic use)
+
+```python
+from cli_anything.marvelous.core.project import read_project_meta
+from cli_anything.marvelous.core.garment import Garment
+from cli_anything.marvelous.core.session import new_session, save_session, load_session
+from cli_anything.marvelous.core.library import import_project, list_library
+from cli_anything.marvelous.utils.marvelous_backend import (
+    find_marvelous_binary,
+    load_script_template,
+    render_script_template,
+    run_md_script,
+)
+
+# Parse a .zpac without MD
+meta = read_project_meta(Path("shirt.zpac"))
+print(meta.name, meta.pattern_count, meta.fabric_count)
+
+# Run a script (requires MD)
+binary = find_marvelous_binary()
+tpl = load_script_template("export")
+script = render_script_template(tpl, {
+    "project_path": "/path/to/shirt.zpac",
+    "output_path": "/out/shirt",
+    "export_format": "obj",
+})
+run_md_script(script, binary=binary)
+```
+
+## Exceptions
+
+```python
+from cli_anything.marvelous.utils.marvelous_backend import (
+    MarvelousNotFoundError,   # MD binary not on PATH / not installed
+    MarvelousScriptError,     # MD ran but script exited non-zero
+    MarvelousTimeoutError,    # MD exceeded timeout
+)
+```
+
+## Key Design Decisions
+
+- `.zpac`/`.zprj` parsing uses stdlib `zipfile` — no MD required
+- Session writes are atomic (`fcntl.flock` + `tempfile` + `os.replace`)
+- Script templates use `string.Template` with `${var}` — no Jinja2 dependency
+- REPL dispatches back into Click via `main.main(args=parts, standalone_mode=False)`
+- Export formats: obj, fbx, alembic, usd, zpac, zprj (GLB is NOT in MD API)
+- `--script` invocation is unconfirmed in MD 12 official docs; update `run_md_script()` if syntax differs

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/SKYYROSE-THEME.md
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/SKYYROSE-THEME.md
@@ -1,0 +1,140 @@
+# SKYYROSE-THEME — CLI Harness Design Document
+
+## Phase 1: Analysis
+
+### Theme Dev Loop — Current State
+
+The SkyyRose theme dev loop spans four distinct operations, each with a separate
+invocation path:
+
+| Operation | Current path | Pain points |
+|-----------|-------------|-------------|
+| Deploy | `bash scripts/deploy-theme.sh` or `npm run deploy` | No manifest preview, no --dry-run UX outside npm |
+| PHP lint | `cd wordpress-theme/skyyrose-flagship && vendor/bin/phpcs --standard=.phpcs.xml` | Long path, no single-command fix |
+| Version bump | Manual edit of 3 files: functions.php, style.css, readme.txt | Error-prone, files can drift |
+| Cache flush | `ssh skyyrose.wordpress.com@ssh.wp.com "/usr/local/bin/wp cache flush --path=/srv/htdocs"` | Raw SSH, easy to typo |
+
+**Version drift is the highest-risk gap.** All three files must agree on the
+version string, but they're independent. A deploy with a mismatch version shows
+the wrong version in WP Admin and the ThemeForest changelog.
+
+**No single verify command.** After deploy, manual `curl` is needed to check
+the live site. The deploy script has `verify_live()` but it's internal to bash.
+
+### Template Discovery Gap
+
+`inc/enqueue.php` has a `$template_map` PHP array mapping template filenames
+to slugs. No tooling exists to query it programmatically. Agents writing
+template-specific CSS/JS rules have to read PHP manually.
+
+### Confirmation Gap
+
+`deploy-theme.sh` has no interactive confirmation step — it just executes. The
+only safety is `--dry-run`. The STOP-AND-SHOW protocol in CLAUDE.md plugs this
+at the CLI layer.
+
+---
+
+## Phase 2: Architecture
+
+### Design Decisions
+
+**Namespace package.** `cli_anything/` has no `__init__.py`. Uses
+`find_namespace_packages(include=["cli_anything.*"])` so multiple cli-anything
+harnesses can coexist in the same Python environment.
+
+**Backend orchestration strategy.** The CLI is a thin orchestration layer —
+it constructs subprocess argv lists, validates preconditions, and reports
+results. It never reimplements deploy logic, PHPCS rules, or WordPress cache
+invalidation. The real tools own those semantics.
+
+**Version atomicity.** Three files are written sequentially (not in a true
+3-phase commit). Precondition: all three must agree before any write starts.
+On partial failure: re-run `version bump --to <old-version>` to restore
+consistency. Atomic per-file writes (temp + fsync + os.replace) prevent
+torn files.
+
+**STOP-AND-SHOW at the CLI layer.** `build_deploy_manifest()` always returns
+a structured dict. `run_deploy(confirmed=False)` raises `DeployNotConfirmedError`
+before touching subprocess. The CLI prints the manifest and exits 0 unless
+`--confirm` is present. This mirrors the protocol defined in CLAUDE.md.
+
+**REPL default.** `invoke_without_command=True` on the root Click group falls
+through to `ctx.invoke(repl)`. The REPL dispatches lines as `cli.main(args, ...)`,
+giving full command access without spawning subprocesses.
+
+**Session persistence.** `_locked_save_json` (fcntl.flock + temp + fsync +
+os.replace) prevents corruption from concurrent REPL instances. Sessions live
+in `~/.cli_anything/skyyrose_theme/sessions/`.
+
+### Module Map
+
+```
+skyyrose_theme_cli.py     Click root group, REPL, CliState, emit()
+core/version.py           VersionState, read_version(), write_version()
+core/template.py          TemplateInfo, TemplateMap, load_templates()
+core/deploy.py            DeployManifest, build_deploy_manifest(), run_deploy()
+core/verify.py            UrlCheckResult, VerifyReport, verify_live()
+core/session.py           Session, _locked_save_json(), CRUD helpers
+utils/theme_backend.py    ThemeContext, DoctorReport, run_phpcs(), run_wp_ssh()
+utils/php_parser.py       Regex extractors for PHP source text
+utils/repl_skin.py        ReplSkin — ANSI rose-gold terminal UI
+```
+
+### Exception Hierarchy
+
+```
+BackendError
+  PHPCSNotFoundError
+  PHPNotFoundError
+  SSHNotReachableError
+  WPCliError
+
+DeployError
+  DeployScriptNotFoundError
+  DeployNotConfirmedError
+  DeployFailedError
+
+VerifyError
+  VerifyFailedError
+
+VersionError
+  VersionMismatchError
+
+SessionError
+  SessionNotFoundError
+
+TemplateError
+```
+
+### Known Gaps
+
+1. **wp-cli cache flush not tested offline.** `run_wp_ssh()` requires a live
+   SSH connection. Unit tests mock `subprocess.run`. E2E test is gated on
+   `SKYYROSE_E2E=1` + SSH reachability.
+
+2. **Version rollback is manual.** If `write_version("1.6.0")` succeeds on
+   functions.php but fails on style.css, the user must run
+   `version bump --to 1.5.20` to restore consistency. No auto-rollback.
+
+3. **REPL line parsing is naïve split.** `line.split()` doesn't handle quoted
+   arguments (e.g., `version bump --to "1.5.21"`). Use `shlex.split()` in a
+   future iteration.
+
+4. **No completion.** Tab-completion via `click_completion` or
+   `shell_complete` is not wired. Add `COMP_WORDS` integration as Phase 3.
+
+5. **No deploy lock.** Concurrent deploys from two terminals can race.
+   A `~/.cli_anything/skyyrose_theme/deploy.lock` file with `fcntl.flock`
+   would close this.
+
+### Deploy Prerequisites Checklist
+
+Before `deploy --confirm` is safe to run:
+
+- [ ] `doctor` — all critical checks pass (theme_root, style_css, functions_php, deploy_script)
+- [ ] `version current` — all three sources agree
+- [ ] SSH key `~/.ssh/skyyrose-deploy` loaded and authorized on `ssh.wp.com`
+- [ ] `SKYYROSE_DEPLOY_SCRIPT` points to the real `scripts/deploy-theme.sh`
+- [ ] Last `lint php` returned zero violations (or violations are acknowledged)
+- [ ] `verify` passes against current production (pre-deploy baseline)

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/README.md
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/README.md
@@ -1,0 +1,119 @@
+# cli-anything-skyyrose-theme
+
+Meta-CLI unifying the SkyyRose WordPress theme dev loop.
+
+Wraps `deploy-theme.sh`, PHPCS/PHPCBF, `wp-cli` over SSH, and version management
+into a single scriptable interface with an optional interactive REPL.
+
+**Real software is a hard dependency.** This CLI does not reimplement deployment,
+PHP linting, or WordPress cache management — it orchestrates the real tools:
+
+| Capability | Tool |
+|-----------|------|
+| Deploy | `scripts/deploy-theme.sh` (hot-swap default) |
+| PHP lint | `vendor/bin/phpcs` + `vendor/bin/phpcbf` |
+| Cache flush | `wp cache flush` over SSH |
+| Version management | Atomic writes to `functions.php`, `style.css`, `readme.txt` |
+| Live HTTP verify | `requests` — mirrors `verify_live()` in deploy script |
+
+---
+
+## Install
+
+```bash
+python3 -m venv /tmp/cli-anything-skyyrose-theme-venv
+/tmp/cli-anything-skyyrose-theme-venv/bin/pip install --upgrade pip
+pip install -e ".[dev]"   # from agent-harness/
+```
+
+## Usage
+
+```bash
+# Interactive REPL (default — no subcommand)
+cli-anything-skyyrose-theme
+
+# Version management
+cli-anything-skyyrose-theme version current
+cli-anything-skyyrose-theme version bump --to 1.5.21
+
+# Template discovery
+cli-anything-skyyrose-theme template list
+cli-anything-skyyrose-theme template render about
+
+# Deploy (STOP-AND-SHOW required)
+cli-anything-skyyrose-theme deploy --dry-run               # print manifest, exit
+cli-anything-skyyrose-theme deploy --dry-run --confirm     # execute dry run
+cli-anything-skyyrose-theme deploy --confirm               # hot-swap deploy
+cli-anything-skyyrose-theme deploy --with-maintenance --confirm
+
+# Live HTTP checks
+cli-anything-skyyrose-theme verify
+cli-anything-skyyrose-theme verify --url https://staging.skyyrose.co
+
+# Cache
+cli-anything-skyyrose-theme cache purge --confirm
+
+# PHP lint
+cli-anything-skyyrose-theme lint php
+cli-anything-skyyrose-theme lint fix --confirm
+
+# Health check
+cli-anything-skyyrose-theme doctor
+
+# Sessions
+cli-anything-skyyrose-theme session status
+cli-anything-skyyrose-theme session save
+cli-anything-skyyrose-theme session list
+cli-anything-skyyrose-theme session delete <id>
+
+# JSON output (all commands)
+cli-anything-skyyrose-theme --json version current
+```
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SKYYROSE_THEME_ROOT` | `~/DevSkyy/wordpress-theme/skyyrose-flagship` | Theme directory |
+| `SKYYROSE_DEPLOY_SCRIPT` | `~/DevSkyy/scripts/deploy-theme.sh` | Deploy script |
+| `SKYYROSE_SSH_HOST` | `skyyrose.wordpress.com@ssh.wp.com` | SSH target |
+| `SKYYROSE_WP_ROOT` | `/srv/htdocs` | WP root on server |
+| `SKYYROSE_WP_CLI` | `/usr/local/bin/wp` | wp-cli path on server |
+| `PUBLIC_URL` | `https://skyyrose.co` | Verify base URL |
+
+## Deploy prerequisites
+
+Before `deploy --confirm` works:
+
+1. `SKYYROSE_DEPLOY_SCRIPT` must point to the real `scripts/deploy-theme.sh`
+2. SSH key `~/.ssh/skyyrose-deploy` must be loaded and authorized on `ssh.wp.com`
+3. `doctor` must pass all critical checks
+4. `version current` must show consistent version across all three files
+
+## Architecture
+
+```
+skyyrose_theme_cli.py   — Click root + REPL entry point
+core/
+  version.py            — Atomic version reads/writes (3 files)
+  template.py           — PHP regex template discovery
+  deploy.py             — deploy-theme.sh wrapper + STOP-AND-SHOW
+  verify.py             — HTTP live checks
+  session.py            — fcntl-locked session persistence
+utils/
+  theme_backend.py      — PHPCS, php -l, wp-cli SSH wrappers
+  php_parser.py         — Regex PHP source parsers
+  repl_skin.py          — ANSI rose-gold REPL UI
+tests/
+  test_core.py          — 58 offline unit tests
+  test_full_e2e.py      — 5 live tests (SKYYROSE_E2E=1)
+```
+
+## STOP-AND-SHOW contract
+
+Commands that touch production always:
+1. Print a manifest (action, target, cost, irreversible flag)
+2. Exit 0 if `--confirm` is absent
+3. Execute only when `--confirm` is present
+
+This mirrors the `STOP AND SHOW` protocol in `CLAUDE.md`.

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/__init__.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/__init__.py
@@ -1,0 +1,1 @@
+"""cli-anything-skyyrose-theme — SkyyRose WordPress theme dev loop CLI."""

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/__main__.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/__main__.py
@@ -1,0 +1,6 @@
+"""Allow `python -m cli_anything.skyyrose_theme` invocation."""
+
+from cli_anything.skyyrose_theme.skyyrose_theme_cli import main
+
+if __name__ == "__main__":
+    main()

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/__init__.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core modules for cli-anything-skyyrose-theme."""

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/deploy.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/deploy.py
@@ -1,0 +1,227 @@
+"""
+Deploy orchestration for the SkyyRose theme.
+
+Wraps scripts/deploy-theme.sh (hot-swap by default, --with-maintenance flag).
+All production-touching operations require:
+  1. build_deploy_manifest() → caller prints and waits for --confirm
+  2. run_deploy(manifest, confirmed=True)
+
+STOP-AND-SHOW contract:
+  - build_deploy_manifest() never touches the site — returns a structured dict.
+  - run_deploy() raises DeployNotConfirmedError if confirmed=False.
+  - Subprocess args are always lists; shell=True is never used.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+_DEFAULT_THEME_ROOT = Path(
+    os.environ.get(
+        "SKYYROSE_THEME_ROOT",
+        str(Path.home() / "DevSkyy/wordpress-theme/skyyrose-flagship"),
+    )
+)
+_DEFAULT_DEPLOY_SCRIPT = Path(
+    os.environ.get(
+        "SKYYROSE_DEPLOY_SCRIPT",
+        str(Path.home() / "DevSkyy/scripts/deploy-theme.sh"),
+    )
+)
+_DEFAULT_PUBLIC_URL = os.environ.get("PUBLIC_URL", "https://skyyrose.co")
+
+# ---------------------------------------------------------------------------
+# Typed exceptions
+# ---------------------------------------------------------------------------
+
+
+class DeployError(RuntimeError):
+    """Base class for deploy errors."""
+
+
+class DeployScriptNotFoundError(DeployError):
+    """Raised when deploy-theme.sh cannot be found."""
+
+
+class DeployNotConfirmedError(DeployError):
+    """Raised when run_deploy is called without explicit confirmation."""
+
+
+class DeployFailedError(DeployError):
+    """Raised when deploy-theme.sh exits non-zero."""
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeployManifest:
+    theme_root: Path
+    deploy_script: Path
+    dry_run: bool
+    with_maintenance: bool
+    public_url: str
+    mode: str  # "hot-swap" | "maintenance"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": "deploy",
+            "theme_root": str(self.theme_root),
+            "deploy_script": str(self.deploy_script),
+            "dry_run": self.dry_run,
+            "mode": self.mode,
+            "public_url": self.public_url,
+            "cost": "$0 (no paid API calls)",
+            "irreversible": not self.dry_run,
+        }
+
+
+def build_deploy_manifest(
+    dry_run: bool = False,
+    with_maintenance: bool = False,
+    theme_root: Path | None = None,
+    deploy_script: Path | None = None,
+    public_url: str | None = None,
+) -> DeployManifest:
+    """
+    Build a DeployManifest describing what would happen.
+
+    Never touches the live site — pure data construction.
+
+    Args:
+        dry_run: If True, pass --dry-run to deploy-theme.sh.
+        with_maintenance: If True, pass --with-maintenance (site lock during deploy).
+        theme_root: Override SKYYROSE_THEME_ROOT.
+        deploy_script: Override SKYYROSE_DEPLOY_SCRIPT.
+        public_url: Override PUBLIC_URL.
+
+    Returns:
+        DeployManifest
+
+    Raises:
+        DeployScriptNotFoundError: if the deploy script doesn't exist.
+    """
+    script = deploy_script or _DEFAULT_DEPLOY_SCRIPT
+    if not script.exists():
+        raise DeployScriptNotFoundError(
+            f"deploy-theme.sh not found at {script}. "
+            "Set SKYYROSE_DEPLOY_SCRIPT env var or ensure DevSkyy repo is checked out."
+        )
+
+    root = theme_root or _DEFAULT_THEME_ROOT
+    url = public_url or _DEFAULT_PUBLIC_URL
+    mode = "maintenance" if with_maintenance else "hot-swap"
+
+    return DeployManifest(
+        theme_root=root,
+        deploy_script=script,
+        dry_run=dry_run,
+        with_maintenance=with_maintenance,
+        public_url=url,
+        mode=mode,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+
+def run_deploy(
+    manifest: DeployManifest,
+    confirmed: bool = False,
+) -> subprocess.CompletedProcess:
+    """
+    Execute deploy-theme.sh according to *manifest*.
+
+    Args:
+        manifest: Built by build_deploy_manifest().
+        confirmed: Must be True. DeployNotConfirmedError otherwise.
+
+    Returns:
+        subprocess.CompletedProcess
+
+    Raises:
+        DeployNotConfirmedError: if confirmed=False.
+        DeployFailedError: if the script exits non-zero.
+    """
+    if not confirmed:
+        raise DeployNotConfirmedError(
+            "run_deploy requires confirmed=True. "
+            "Print the manifest and get explicit user confirmation first."
+        )
+
+    cmd: list[str] = ["bash", str(manifest.deploy_script)]
+    if manifest.dry_run:
+        cmd.append("--dry-run")
+    if manifest.with_maintenance:
+        cmd.append("--with-maintenance")
+
+    env = {**os.environ, "PUBLIC_URL": manifest.public_url}
+
+    result = subprocess.run(
+        cmd,
+        capture_output=False,  # stream to terminal
+        text=True,
+        cwd=str(manifest.theme_root),
+        env=env,
+    )
+
+    if result.returncode != 0:
+        raise DeployFailedError(
+            f"deploy-theme.sh exited {result.returncode}. Check terminal output for details."
+        )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Cache purge (wp-cli over SSH)
+# ---------------------------------------------------------------------------
+
+_SSH_HOST = os.environ.get("SKYYROSE_SSH_HOST", "skyyrose.wordpress.com@ssh.wp.com")
+_WP_ROOT = os.environ.get("SKYYROSE_WP_ROOT", "/srv/htdocs")
+_WP_CLI = os.environ.get("SKYYROSE_WP_CLI", "/usr/local/bin/wp")
+_ADMIN_USER = os.environ.get("SKYYROSE_ADMIN_USER", "corey@skyyrose.co")
+
+
+def purge_cache(
+    ssh_host: str | None = None,
+    wp_root: str | None = None,
+    wp_cli: str | None = None,
+) -> subprocess.CompletedProcess:
+    """
+    Flush Jetpack / server-side caches via wp-cli over SSH.
+
+    Runs: ssh <host> "wp cache flush --path=<root> --allow-root"
+
+    Raises:
+        DeployFailedError: if ssh/wp-cli exits non-zero.
+    """
+    host = ssh_host or _SSH_HOST
+    root = wp_root or _WP_ROOT
+    cli = wp_cli or _WP_CLI
+
+    remote_cmd = f"{cli} cache flush --path={root} --allow-root"
+    cmd = ["ssh", host, remote_cmd]
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise DeployFailedError(
+            f"wp cache flush failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    return result

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/session.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/session.py
@@ -1,0 +1,181 @@
+"""
+Session persistence for cli-anything-skyyrose-theme.
+
+Sessions store: name, timestamps, command history, and arbitrary metadata.
+All writes are atomic via _locked_save_json (temp file + fcntl.flock + fsync
++ os.replace — same pattern as cli-anything-elementor).
+
+SESSIONS_DIR: ~/.cli_anything/skyyrose_theme/sessions/
+SCHEMA: cli-anything-skyyrose-theme/session/v1
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "cli-anything-skyyrose-theme/session/v1"
+MAX_HISTORY = 50
+SESSIONS_DIR = Path.home() / ".cli_anything" / "skyyrose_theme" / "sessions"
+
+
+# ---------------------------------------------------------------------------
+# Typed exceptions
+# ---------------------------------------------------------------------------
+
+
+class SessionError(RuntimeError):
+    """Base class for session errors."""
+
+
+class SessionNotFoundError(SessionError):
+    """Raised when a session file cannot be found."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Session:
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    name: str = "default"
+    schema: str = SCHEMA
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    history: list[str] = field(default_factory=list)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def add_history(self, command: str) -> None:
+        """Append *command* to history, trimming to MAX_HISTORY."""
+        self.history = [*self.history, command][-MAX_HISTORY:]
+        self.updated_at = time.time()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Session":
+        return cls(
+            id=data.get("id", str(uuid.uuid4())),
+            name=data.get("name", "default"),
+            schema=data.get("schema", SCHEMA),
+            created_at=data.get("created_at", time.time()),
+            updated_at=data.get("updated_at", time.time()),
+            history=data.get("history", []),
+            meta=data.get("meta", {}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Atomic file writer
+# ---------------------------------------------------------------------------
+
+
+def _locked_save_json(path: Path, data: dict[str, Any]) -> None:
+    """
+    Write *data* as JSON to *path* atomically.
+
+    Uses a sibling lock file + fcntl.flock to prevent concurrent writers,
+    then writes to a temp file in the same directory, fsyncs, and
+    os.replaces into the final path.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(".lock")
+
+    with open(lock_path, "w") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            dir_ = path.parent
+            fd, tmp_path_str = tempfile.mkstemp(dir=dir_, prefix=".session-")
+            tmp_path = Path(tmp_path_str)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    json.dump(data, fh, indent=2)
+                    fh.write("\n")
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                os.replace(tmp_path, path)
+            except Exception:
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
+                raise
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+def _session_path(session_id: str, sessions_dir: Path | None = None) -> Path:
+    d = sessions_dir or SESSIONS_DIR
+    return d / f"{session_id}.json"
+
+
+def save_session(session: Session, sessions_dir: Path | None = None) -> Path:
+    """Persist *session* and return its file path."""
+    path = _session_path(session.id, sessions_dir)
+    session.updated_at = time.time()
+    _locked_save_json(path, session.to_dict())
+    return path
+
+
+def load_session(session_id: str, sessions_dir: Path | None = None) -> Session:
+    """Load session by ID. Raises SessionNotFoundError if missing."""
+    path = _session_path(session_id, sessions_dir)
+    if not path.exists():
+        raise SessionNotFoundError(f"Session not found: {session_id} ({path})")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return Session.from_dict(data)
+
+
+def list_sessions(sessions_dir: Path | None = None) -> list[Session]:
+    """Return all sessions sorted by updated_at descending."""
+    d = sessions_dir or SESSIONS_DIR
+    if not d.exists():
+        return []
+    sessions = []
+    for p in d.glob("*.json"):
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+            sessions.append(Session.from_dict(data))
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return sorted(sessions, key=lambda s: s.updated_at, reverse=True)
+
+
+def delete_session(session_id: str, sessions_dir: Path | None = None) -> bool:
+    """Delete session file. Returns True if deleted, False if not found."""
+    path = _session_path(session_id, sessions_dir)
+    if not path.exists():
+        return False
+    path.unlink()
+    lock_path = path.with_suffix(".lock")
+    if lock_path.exists():
+        lock_path.unlink()
+    return True
+
+
+def get_or_create_session(name: str = "default", sessions_dir: Path | None = None) -> Session:
+    """
+    Return the most-recently-updated session with *name*, creating one if
+    none exists.
+    """
+    existing = [s for s in list_sessions(sessions_dir) if s.name == name]
+    if existing:
+        return existing[0]
+    session = Session(name=name)
+    save_session(session, sessions_dir)
+    return session

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/template.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/template.py
@@ -1,0 +1,128 @@
+"""
+Template discovery for the SkyyRose theme.
+
+Parses the $template_map array from inc/enqueue.php to build a
+slug → template-file mapping, then enriches it by globbing all
+template-*.php files in the theme root.
+
+No PHP interpreter needed — pure regex against the PHP source text.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_DEFAULT_THEME_ROOT = Path(
+    os.environ.get(
+        "SKYYROSE_THEME_ROOT",
+        str(Path.home() / "DevSkyy/wordpress-theme/skyyrose-flagship"),
+    )
+)
+
+
+def _theme_root() -> Path:
+    return Path(os.environ.get("SKYYROSE_THEME_ROOT", str(_DEFAULT_THEME_ROOT)))
+
+
+# ---------------------------------------------------------------------------
+# Typed exceptions
+# ---------------------------------------------------------------------------
+
+
+class TemplateError(RuntimeError):
+    """Raised when template discovery fails."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TemplateInfo:
+    slug: str | None  # None if not in enqueue.php $template_map
+    filename: str  # e.g. "template-about.php"
+    path: Path  # absolute path
+
+    @property
+    def exists(self) -> bool:
+        return self.path.exists()
+
+
+@dataclass
+class TemplateMap:
+    templates: list[TemplateInfo] = field(default_factory=list)
+
+    def by_slug(self, slug: str) -> TemplateInfo | None:
+        for t in self.templates:
+            if t.slug == slug:
+                return t
+        return None
+
+    def by_filename(self, filename: str) -> TemplateInfo | None:
+        for t in self.templates:
+            if t.filename == filename:
+                return t
+        return None
+
+    def slugged(self) -> list[TemplateInfo]:
+        return [t for t in self.templates if t.slug is not None]
+
+    def unregistered(self) -> list[TemplateInfo]:
+        return [t for t in self.templates if t.slug is None]
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+# Matches lines like:  'template-about.php'   => 'about',
+_MAP_ENTRY_RE = re.compile(r"""['"](template-[^'"]+\.php)['"]\s*=>\s*['"]([^'"]+)['"]""")
+
+
+def _parse_enqueue_map(enqueue_php: Path) -> dict[str, str]:
+    """Return {filename: slug} from $template_map in enqueue.php."""
+    if not enqueue_php.exists():
+        return {}
+    text = enqueue_php.read_text(encoding="utf-8")
+    result: dict[str, str] = {}
+    for m in _MAP_ENTRY_RE.finditer(text):
+        filename, slug = m.group(1), m.group(2)
+        result[filename] = slug
+    return result
+
+
+def load_templates(theme_root: Path | None = None) -> TemplateMap:
+    """
+    Discover all template-*.php files in the theme root and annotate
+    each with its registered slug (from inc/enqueue.php $template_map).
+
+    Files not found in the map get slug=None.
+    """
+    root = theme_root or _theme_root()
+    enqueue_php = root / "inc" / "enqueue.php"
+    filename_to_slug = _parse_enqueue_map(enqueue_php)
+
+    template_files = sorted(root.glob("template-*.php"))
+    if not template_files:
+        # Fallback: check if root even exists
+        if not root.exists():
+            raise TemplateError(f"Theme root not found: {root}")
+
+    infos: list[TemplateInfo] = []
+    for path in template_files:
+        filename = path.name
+        slug = filename_to_slug.get(filename)
+        infos.append(TemplateInfo(slug=slug, filename=filename, path=path))
+
+    # Also surface slugs that appear in the map but have no matching file
+    # (useful for diagnosing orphaned registrations)
+    found_files = {t.filename for t in infos}
+    for filename, slug in filename_to_slug.items():
+        if filename not in found_files:
+            infos.append(TemplateInfo(slug=slug, filename=filename, path=root / filename))
+
+    return TemplateMap(templates=infos)

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/verify.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/verify.py
@@ -1,0 +1,181 @@
+"""
+Live HTTP verification for the SkyyRose production site.
+
+Mirrors the verify_live() gate in deploy-theme.sh:
+  - HTTP 200 on each URL
+  - Response body >= MIN_BODY_BYTES
+  - No PHP error markers in response body
+
+Does NOT touch the live site — read-only HTTP GETs only.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Literal
+
+import requests
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_PUBLIC_URL = os.environ.get("PUBLIC_URL", "https://skyyrose.co")
+MIN_BODY_BYTES = 50_000
+
+_PHP_ERROR_MARKERS = (
+    "Fatal error",
+    "Parse error",
+    "Call to undefined",
+    "There has been a critical error",
+    "Warning: include(",
+    "Warning: require(",
+)
+
+_VERIFY_PATHS = [
+    "/",
+    "/?s=test",
+    "/404-check-skyyrose-nonexistent",
+    "/?add-to-cart=1&quantity=1",  # cart page (WC redirect)
+    "/shop/",
+]
+
+
+# ---------------------------------------------------------------------------
+# Typed exceptions
+# ---------------------------------------------------------------------------
+
+
+class VerifyError(RuntimeError):
+    """Base class for verification errors."""
+
+
+class VerifyFailedError(VerifyError):
+    """Raised when one or more URL checks fail."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class UrlCheckResult:
+    url: str
+    status_code: int | None
+    body_bytes: int
+    php_error: str | None  # first matching marker, or None
+    error: str | None  # network/request error, or None
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code in (200, 301, 302) and self.php_error is None and self.error is None
+
+    @property
+    def verdict(self) -> Literal["pass", "fail"]:
+        return "pass" if self.ok else "fail"
+
+
+@dataclass
+class VerifyReport:
+    base_url: str
+    results: list[UrlCheckResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return all(r.ok for r in self.results)
+
+    @property
+    def summary(self) -> str:
+        total = len(self.results)
+        failed = sum(1 for r in self.results if not r.ok)
+        return f"{total - failed}/{total} checks passed"
+
+
+# ---------------------------------------------------------------------------
+# Core check
+# ---------------------------------------------------------------------------
+
+
+def _check_url(url: str, timeout: int = 15) -> UrlCheckResult:
+    try:
+        resp = requests.get(
+            url,
+            timeout=timeout,
+            allow_redirects=True,
+            headers={"User-Agent": "cli-anything-skyyrose-theme/verify"},
+        )
+        body = resp.text
+        body_bytes = len(resp.content)
+
+        # Only check body size on 200s (redirects won't have full content)
+        if resp.status_code == 200 and body_bytes < MIN_BODY_BYTES:
+            return UrlCheckResult(
+                url=url,
+                status_code=resp.status_code,
+                body_bytes=body_bytes,
+                php_error=None,
+                error=f"Response too small: {body_bytes} bytes (min {MIN_BODY_BYTES})",
+            )
+
+        php_error = next((marker for marker in _PHP_ERROR_MARKERS if marker in body), None)
+
+        return UrlCheckResult(
+            url=url,
+            status_code=resp.status_code,
+            body_bytes=body_bytes,
+            php_error=php_error,
+            error=None,
+        )
+    except requests.RequestException as exc:
+        return UrlCheckResult(
+            url=url,
+            status_code=None,
+            body_bytes=0,
+            php_error=None,
+            error=str(exc),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def verify_live(
+    base_url: str | None = None,
+    paths: list[str] | None = None,
+    timeout: int = 15,
+) -> VerifyReport:
+    """
+    Run HTTP checks against the live site.
+
+    Args:
+        base_url: Override PUBLIC_URL env var or default https://skyyrose.co
+        paths: URL paths to check (defaults to _VERIFY_PATHS)
+        timeout: Per-request timeout in seconds
+
+    Returns:
+        VerifyReport with per-URL results.
+
+    Raises:
+        VerifyFailedError: if any check fails (includes report in message)
+    """
+    base = (base_url or DEFAULT_PUBLIC_URL).rstrip("/")
+    check_paths = paths or _VERIFY_PATHS
+    report = VerifyReport(base_url=base)
+
+    for path in check_paths:
+        url = base + path
+        result = _check_url(url, timeout=timeout)
+        report.results.append(result)
+
+    if not report.passed:
+        failures = [r for r in report.results if not r.ok]
+        msg = f"verify_live failed ({len(failures)} checks): " + "; ".join(
+            f"{r.url} → {r.error or r.php_error or r.status_code}" for r in failures
+        )
+        raise VerifyFailedError(msg)
+
+    return report

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/version.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/core/version.py
@@ -1,0 +1,213 @@
+"""
+Version management for the SkyyRose theme.
+
+Reads and writes the version string across three canonical files:
+  - wordpress-theme/skyyrose-flagship/functions.php  (SKYYROSE_VERSION constant)
+  - wordpress-theme/skyyrose-flagship/style.css       (Version: header)
+  - wordpress-theme/skyyrose-flagship/readme.txt      (Stable tag: line)
+
+All writes are atomic: temp file → fsync → os.replace (same directory).
+The three files are written sequentially; on failure the caller can roll back
+by re-running version bump --to <old-version>.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Theme root resolution
+# ---------------------------------------------------------------------------
+
+_DEFAULT_THEME_ROOT = Path(
+    os.environ.get(
+        "SKYYROSE_THEME_ROOT",
+        str(Path.home() / "DevSkyy/wordpress-theme/skyyrose-flagship"),
+    )
+)
+
+
+def _theme_root() -> Path:
+    """Return the resolved theme root directory."""
+    root = Path(os.environ.get("SKYYROSE_THEME_ROOT", str(_DEFAULT_THEME_ROOT)))
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+_FUNCTIONS_PHP_RE = re.compile(r"(define\s*\(\s*'SKYYROSE_VERSION'\s*,\s*')[^']+('\s*\))")
+_STYLE_CSS_RE = re.compile(r"^(Version:\s*)(.+)$", re.MULTILINE)
+_README_TXT_RE = re.compile(r"^(Stable tag:\s*)(.+)$", re.MULTILINE)
+
+
+# ---------------------------------------------------------------------------
+# Typed exceptions
+# ---------------------------------------------------------------------------
+
+
+class VersionError(RuntimeError):
+    """Raised when version read/write fails."""
+
+
+class VersionMismatchError(VersionError):
+    """Raised when the three canonical version sources disagree."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VersionState:
+    functions_php: str
+    style_css: str
+    readme_txt: str
+
+    @property
+    def consistent(self) -> bool:
+        return self.functions_php == self.style_css == self.readme_txt
+
+    @property
+    def current(self) -> str:
+        """Return the version if consistent, else raise."""
+        if not self.consistent:
+            raise VersionMismatchError(
+                f"Version sources disagree: functions.php={self.functions_php!r}, "
+                f"style.css={self.style_css!r}, readme.txt={self.readme_txt!r}"
+            )
+        return self.functions_php
+
+
+# ---------------------------------------------------------------------------
+# Readers
+# ---------------------------------------------------------------------------
+
+
+def _read_functions_php(theme_root: Path) -> str:
+    path = theme_root / "functions.php"
+    text = path.read_text(encoding="utf-8")
+    m = _FUNCTIONS_PHP_RE.search(text)
+    if not m:
+        raise VersionError(f"SKYYROSE_VERSION constant not found in {path}")
+    return m.group(0).split("'")[3]  # value between inner quotes
+
+
+def _read_style_css(theme_root: Path) -> str:
+    path = theme_root / "style.css"
+    text = path.read_text(encoding="utf-8")
+    m = _STYLE_CSS_RE.search(text)
+    if not m:
+        raise VersionError(f"Version: header not found in {path}")
+    return m.group(2).strip()
+
+
+def _read_readme_txt(theme_root: Path) -> str:
+    path = theme_root / "readme.txt"
+    text = path.read_text(encoding="utf-8")
+    m = _README_TXT_RE.search(text)
+    if not m:
+        raise VersionError(f"Stable tag: line not found in {path}")
+    return m.group(2).strip()
+
+
+def read_version(theme_root: Path | None = None) -> VersionState:
+    """Read version from all three canonical sources and return VersionState."""
+    root = theme_root or _theme_root()
+    return VersionState(
+        functions_php=_read_functions_php(root),
+        style_css=_read_style_css(root),
+        readme_txt=_read_readme_txt(root),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atomic writer
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write *content* to *path* atomically (temp + fsync + os.replace)."""
+    dir_ = path.parent
+    fd, tmp_path = tempfile.mkstemp(dir=dir_, prefix=".skyyrose-ver-")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Writers
+# ---------------------------------------------------------------------------
+
+
+def _write_functions_php(theme_root: Path, new_version: str) -> None:
+    path = theme_root / "functions.php"
+    original = path.read_text(encoding="utf-8")
+    updated, count = _FUNCTIONS_PHP_RE.subn(
+        lambda m: m.group(1) + new_version + m.group(2),
+        original,
+    )
+    if count == 0:
+        raise VersionError(f"SKYYROSE_VERSION pattern not found in {path}")
+    _atomic_write(path, updated)
+
+
+def _write_style_css(theme_root: Path, new_version: str) -> None:
+    path = theme_root / "style.css"
+    original = path.read_text(encoding="utf-8")
+    updated, count = _STYLE_CSS_RE.subn(
+        lambda m: m.group(1) + new_version,
+        original,
+    )
+    if count == 0:
+        raise VersionError(f"Version: header not found in {path}")
+    _atomic_write(path, updated)
+
+
+def _write_readme_txt(theme_root: Path, new_version: str) -> None:
+    path = theme_root / "readme.txt"
+    original = path.read_text(encoding="utf-8")
+    updated, count = _README_TXT_RE.subn(
+        lambda m: m.group(1) + new_version,
+        original,
+    )
+    if count == 0:
+        raise VersionError(f"Stable tag: line not found in {path}")
+    _atomic_write(path, updated)
+
+
+def write_version(new_version: str, theme_root: Path | None = None) -> VersionState:
+    """
+    Atomically write *new_version* to all three canonical files.
+
+    Precondition: the three files must currently agree on version.
+    On any write failure the exception propagates; caller can roll back
+    by calling write_version(<old_version>).
+
+    Returns the resulting VersionState.
+    """
+    root = theme_root or _theme_root()
+    # Precondition: sources must agree before we write.
+    current = read_version(root)
+    current.current  # raises VersionMismatchError if inconsistent
+
+    _write_functions_php(root, new_version)
+    _write_style_css(root, new_version)
+    _write_readme_txt(root, new_version)
+
+    return read_version(root)

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/skills/SKILL.md
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/skills/SKILL.md
@@ -1,0 +1,47 @@
+# cli-anything-skyyrose-theme
+
+Meta-CLI for the SkyyRose WordPress theme dev loop.
+
+## What it does
+
+Wraps `deploy-theme.sh`, PHPCS, `wp-cli` over SSH, and theme version management
+into a single CLI with a rose-gold REPL default mode.
+
+## Install
+
+```bash
+pip install -e /Users/theceo/DevSkyy/vendor/cli-anything/skyyrose-theme/agent-harness/
+```
+
+## Key commands
+
+```bash
+cli-anything-skyyrose-theme                        # REPL
+cli-anything-skyyrose-theme version current        # show version (3 sources)
+cli-anything-skyyrose-theme version bump --to X    # atomic version bump
+cli-anything-skyyrose-theme template list          # all template-*.php + slugs
+cli-anything-skyyrose-theme deploy --dry-run       # manifest only (safe)
+cli-anything-skyyrose-theme deploy --confirm       # HOT-SWAP deploy (production)
+cli-anything-skyyrose-theme verify                 # HTTP checks on skyyrose.co
+cli-anything-skyyrose-theme cache purge --confirm  # wp cache flush over SSH
+cli-anything-skyyrose-theme lint php               # PHPCS read-only
+cli-anything-skyyrose-theme lint fix --confirm     # PHPCBF (modifies files)
+cli-anything-skyyrose-theme doctor                 # health checks
+cli-anything-skyyrose-theme --json <cmd>           # machine-readable output
+```
+
+## STOP-AND-SHOW
+
+Deploy, cache purge, and lint fix require `--confirm`. Without it, they print
+a manifest and exit 0. Never execute production ops without the flag.
+
+## Source
+
+`/Users/theceo/DevSkyy/vendor/cli-anything/skyyrose-theme/agent-harness/`
+
+## Tests
+
+```bash
+pytest cli_anything/skyyrose_theme/tests/test_core.py --tb=short -q
+# 58 offline unit tests, no network, no SSH
+```

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/skyyrose_theme_cli.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/skyyrose_theme_cli.py
@@ -1,0 +1,713 @@
+"""
+cli-anything-skyyrose-theme — main Click CLI entry point.
+
+Default mode: REPL (invoked with no subcommand).
+All production-touching commands require --confirm after printing a manifest.
+--json flag on every command emits machine-readable output.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import click
+
+# ---------------------------------------------------------------------------
+# CLI State
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CliState:
+    json_output: bool = False
+    theme_root: Path | None = None
+    _skin: Any = None  # ReplSkin, lazy
+
+    @property
+    def skin(self) -> Any:
+        if self._skin is None:
+            from cli_anything.skyyrose_theme.utils.repl_skin import ReplSkin
+
+            self._skin = ReplSkin()
+        return self._skin
+
+
+pass_state = click.make_pass_decorator(CliState, ensure=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def emit(state: CliState, payload: dict[str, Any], human: str | None = None) -> None:
+    """Print payload as JSON or human-readable depending on state.json_output."""
+    if state.json_output:
+        click.echo(json.dumps(payload, indent=2, default=str))
+    else:
+        if human is not None:
+            click.echo(human)
+        else:
+            # Fallback: pretty-print key: value pairs
+            for k, v in payload.items():
+                click.echo(f"  {k}: {v}")
+
+
+def handle_error(state: CliState, exc: Exception, exit_code: int = 1) -> None:
+    """Print error and exit."""
+    msg = str(exc)
+    if state.json_output:
+        click.echo(json.dumps({"error": msg, "ok": False}, indent=2), err=True)
+    else:
+        state.skin.error(msg)
+    sys.exit(exit_code)
+
+
+# ---------------------------------------------------------------------------
+# Root group
+# ---------------------------------------------------------------------------
+
+
+@click.group(invoke_without_command=True)
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON output.")
+@click.option(
+    "--theme-root",
+    envvar="SKYYROSE_THEME_ROOT",
+    type=click.Path(),
+    help="Override theme root directory.",
+)
+@click.version_option(package_name="cli-anything-skyyrose-theme")
+@click.pass_context
+def cli(ctx: click.Context, json_output: bool, theme_root: str | None) -> None:
+    """SkyyRose Theme CLI — meta-CLI for the SkyyRose WordPress theme dev loop."""
+    ctx.ensure_object(CliState)
+    state: CliState = ctx.obj
+    state.json_output = json_output
+    if theme_root:
+        state.theme_root = Path(theme_root)
+
+    if ctx.invoked_subcommand is None:
+        # Default: launch REPL
+        ctx.invoke(repl)
+
+
+# ---------------------------------------------------------------------------
+# version group
+# ---------------------------------------------------------------------------
+
+
+@cli.group("version")
+def version_group() -> None:
+    """Read or bump the theme version across functions.php, style.css, readme.txt."""
+
+
+@version_group.command("current")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def version_current(state: CliState, json_output: bool) -> None:
+    """Show the current version from all three canonical sources."""
+    if json_output:
+        state.json_output = True
+    from cli_anything.skyyrose_theme.core.version import (VersionMismatchError,
+                                                          read_version)
+
+    try:
+        vs = read_version(state.theme_root)
+    except Exception as exc:
+        handle_error(state, exc)
+        return
+
+    payload = {
+        "functions_php": vs.functions_php,
+        "style_css": vs.style_css,
+        "readme_txt": vs.readme_txt,
+        "consistent": vs.consistent,
+    }
+    human = None
+    if not state.json_output:
+        skin = state.skin
+        if vs.consistent:
+            skin.success(f"Version: {vs.functions_php}  (all sources agree)")
+        else:
+            skin.warning("Version mismatch detected:")
+            skin.status("functions.php", vs.functions_php)
+            skin.status("style.css", vs.style_css)
+            skin.status("readme.txt", vs.readme_txt)
+    emit(state, payload, human)
+
+
+@version_group.command("bump")
+@click.option("--to", "new_version", required=True, help="New version string, e.g. 1.5.21")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def version_bump(state: CliState, new_version: str, json_output: bool) -> None:
+    """Bump the theme version atomically across all three files."""
+    if json_output:
+        state.json_output = True
+    from cli_anything.skyyrose_theme.core.version import write_version
+
+    try:
+        vs = write_version(new_version, state.theme_root)
+    except Exception as exc:
+        handle_error(state, exc)
+        return
+
+    payload = {
+        "ok": True,
+        "new_version": vs.current,
+        "functions_php": vs.functions_php,
+        "style_css": vs.style_css,
+        "readme_txt": vs.readme_txt,
+    }
+    if not state.json_output:
+        state.skin.success(f"Bumped to {vs.current}")
+    emit(state, payload)
+
+
+# ---------------------------------------------------------------------------
+# template group
+# ---------------------------------------------------------------------------
+
+
+@cli.group("template")
+def template_group() -> None:
+    """Discover and inspect theme templates."""
+
+
+@template_group.command("list")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def template_list(state: CliState, json_output: bool) -> None:
+    """List all template-*.php files and their registered slugs."""
+    if json_output:
+        state.json_output = True
+    from cli_anything.skyyrose_theme.core.template import load_templates
+
+    try:
+        tmap = load_templates(state.theme_root)
+    except Exception as exc:
+        handle_error(state, exc)
+        return
+
+    rows = [
+        {
+            "filename": t.filename,
+            "slug": t.slug or "(unregistered)",
+            "exists": "yes" if t.exists else "MISSING",
+        }
+        for t in sorted(tmap.templates, key=lambda x: x.filename)
+    ]
+    payload = {"templates": rows, "total": len(rows)}
+    if not state.json_output:
+        state.skin.table(rows, headers=["filename", "slug", "exists"])
+        click.echo(f"  {len(rows)} templates found.")
+    emit(state, payload)
+
+
+@template_group.command("render")
+@click.argument("slug_or_file")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def template_render(state: CliState, slug_or_file: str, json_output: bool) -> None:
+    """Show template metadata for a given slug or filename."""
+    if json_output:
+        state.json_output = True
+    from cli_anything.skyyrose_theme.core.template import load_templates
+
+    try:
+        tmap = load_templates(state.theme_root)
+    except Exception as exc:
+        handle_error(state, exc)
+        return
+
+    t = tmap.by_slug(slug_or_file) or tmap.by_filename(slug_or_file)
+    if t is None:
+        handle_error(state, ValueError(f"Template not found: {slug_or_file!r}"))
+        return
+
+    payload = {
+        "filename": t.filename,
+        "slug": t.slug,
+        "path": str(t.path),
+        "exists": t.exists,
+    }
+    if not state.json_output:
+        skin = state.skin
+        skin.status("filename", t.filename)
+        skin.status("slug", t.slug or "(unregistered)")
+        skin.status("path", str(t.path))
+        skin.status("exists", "yes" if t.exists else "MISSING", ok=t.exists)
+    emit(state, payload)
+
+
+# ---------------------------------------------------------------------------
+# deploy command
+# ---------------------------------------------------------------------------
+
+
+@cli.command("deploy")
+@click.option("--dry-run", is_flag=True, help="Pass --dry-run to deploy-theme.sh (no upload).")
+@click.option(
+    "--with-maintenance",
+    is_flag=True,
+    help="Lock site during deploy (slower, safer for DB migrations).",
+)
+@click.option(
+    "--confirm",
+    is_flag=True,
+    help="Required to actually deploy. Without this, prints manifest and exits.",
+)
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def deploy(
+    state: CliState,
+    dry_run: bool,
+    with_maintenance: bool,
+    confirm: bool,
+    json_output: bool,
+) -> None:
+    """Deploy the theme to skyyrose.co via deploy-theme.sh.
+
+    Always prints a STOP-AND-SHOW manifest. Requires --confirm to proceed.
+    """
+    if json_output:
+        state.json_output = True
+
+    from cli_anything.skyyrose_theme.core.deploy import (
+        DeployNotConfirmedError, DeployScriptNotFoundError,
+        build_deploy_manifest, run_deploy)
+
+    try:
+        manifest = build_deploy_manifest(
+            dry_run=dry_run,
+            with_maintenance=with_maintenance,
+            theme_root=state.theme_root,
+        )
+    except DeployScriptNotFoundError as exc:
+        handle_error(state, exc)
+        return
+
+    manifest_dict = manifest.to_dict()
+
+    if state.json_output:
+        emit(state, {"manifest": manifest_dict, "confirmed": confirm})
+    else:
+        state.skin.print_manifest(manifest_dict)
+
+    if not confirm:
+        if not state.json_output:
+            click.echo("  Pass --confirm to execute the deploy.")
+        sys.exit(0)
+
+    # confirmed=True — execute
+    try:
+        run_deploy(manifest, confirmed=True)
+    except Exception as exc:
+        handle_error(state, exc)
+        return
+
+    if not state.json_output:
+        state.skin.success("Deploy completed.")
+    emit(state, {"ok": True, "mode": manifest.mode})
+
+
+# ---------------------------------------------------------------------------
+# verify command
+# ---------------------------------------------------------------------------
+
+
+@cli.command("verify")
+@click.option("--url", "base_url", default=None, help="Override PUBLIC_URL.")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def verify(state: CliState, base_url: str | None, json_output: bool) -> None:
+    """Run live HTTP checks against skyyrose.co."""
+    if json_output:
+        state.json_output = True
+
+    from cli_anything.skyyrose_theme.core.verify import (VerifyFailedError,
+                                                         verify_live)
+
+    try:
+        report = verify_live(base_url=base_url)
+    except VerifyFailedError as exc:
+        if state.json_output:
+            emit(state, {"ok": False, "error": str(exc)})
+        else:
+            state.skin.error(str(exc))
+        sys.exit(1)
+    except Exception as exc:
+        handle_error(state, exc)
+        return
+
+    rows = [
+        {
+            "url": r.url,
+            "status": r.status_code,
+            "bytes": r.body_bytes,
+            "verdict": r.verdict,
+        }
+        for r in report.results
+    ]
+    payload = {"ok": report.passed, "summary": report.summary, "results": rows}
+
+    if not state.json_output:
+        state.skin.table(rows, headers=["url", "status", "bytes", "verdict"])
+        if report.passed:
+            state.skin.success(report.summary)
+        else:
+            state.skin.error(report.summary)
+    emit(state, payload)
+
+
+# ---------------------------------------------------------------------------
+# cache group
+# ---------------------------------------------------------------------------
+
+
+@cli.group("cache")
+def cache_group() -> None:
+    """Manage server-side caches via wp-cli over SSH."""
+
+
+@cache_group.command("purge")
+@click.option("--confirm", is_flag=True, help="Required to actually purge.")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def cache_purge(state: CliState, confirm: bool, json_output: bool) -> None:
+    """Flush all caches on the production server."""
+    if json_output:
+        state.json_output = True
+
+    manifest_dict = {
+        "action": "cache purge (wp cache flush)",
+        "target": "skyyrose.co production",
+        "method": "wp-cli over SSH",
+        "cost": "$0",
+        "irreversible": False,
+    }
+
+    if not state.json_output:
+        state.skin.print_manifest(manifest_dict)
+
+    if not confirm:
+        if not state.json_output:
+            click.echo("  Pass --confirm to execute.")
+        emit(state, {"manifest": manifest_dict, "confirmed": False})
+        sys.exit(0)
+
+    from cli_anything.skyyrose_theme.core.deploy import purge_cache
+
+    try:
+        result = purge_cache()
+    except Exception as exc:
+        handle_error(state, exc)
+        return
+
+    payload = {"ok": True, "stdout": result.stdout.strip()}
+    if not state.json_output:
+        state.skin.success("Cache purged.")
+    emit(state, payload)
+
+
+# ---------------------------------------------------------------------------
+# lint group
+# ---------------------------------------------------------------------------
+
+
+@cli.group("lint")
+def lint_group() -> None:
+    """PHP linting via PHPCS and php -l."""
+
+
+@lint_group.command("php")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def lint_php(state: CliState, json_output: bool) -> None:
+    """Run PHPCS against the theme (read-only, no changes)."""
+    if json_output:
+        state.json_output = True
+
+    from cli_anything.skyyrose_theme.utils.theme_backend import (
+        PHPCSNotFoundError, run_phpcs)
+
+    try:
+        result = run_phpcs(state.theme_root, fix=False)
+    except PHPCSNotFoundError as exc:
+        handle_error(state, exc)
+        return
+    except Exception as exc:
+        handle_error(state, exc)
+        return
+
+    payload = {"ok": result.ok, "returncode": result.returncode, "output": result.stdout}
+    if not state.json_output:
+        if result.ok:
+            state.skin.success("No PHPCS violations found.")
+        else:
+            click.echo(result.stdout)
+            state.skin.error(f"PHPCS found violations (exit {result.returncode}).")
+    emit(state, payload)
+
+
+@lint_group.command("fix")
+@click.option("--confirm", is_flag=True, help="Required to run PHPCBF (modifies files).")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def lint_fix(state: CliState, confirm: bool, json_output: bool) -> None:
+    """Run PHPCBF to auto-fix PHPCS violations (modifies PHP files)."""
+    if json_output:
+        state.json_output = True
+
+    manifest_dict = {
+        "action": "phpcbf --standard=.phpcs.xml (auto-fix PHP files)",
+        "target": str(state.theme_root or "SKYYROSE_THEME_ROOT"),
+        "modifies_files": True,
+        "cost": "$0",
+    }
+
+    if not state.json_output:
+        state.skin.print_manifest(manifest_dict)
+
+    if not confirm:
+        if not state.json_output:
+            click.echo("  Pass --confirm to run PHPCBF.")
+        emit(state, {"manifest": manifest_dict, "confirmed": False})
+        sys.exit(0)
+
+    from cli_anything.skyyrose_theme.utils.theme_backend import (
+        PHPCSNotFoundError, run_phpcs)
+
+    try:
+        result = run_phpcs(state.theme_root, fix=True)
+    except PHPCSNotFoundError as exc:
+        handle_error(state, exc)
+        return
+    except Exception as exc:
+        handle_error(state, exc)
+        return
+
+    payload = {"ok": result.ok, "returncode": result.returncode, "output": result.stdout}
+    if not state.json_output:
+        if result.returncode == 0:
+            state.skin.success("PHPCBF: no fixable violations or all fixed.")
+        else:
+            click.echo(result.stdout)
+            state.skin.warning(f"PHPCBF exited {result.returncode} (some violations may remain).")
+    emit(state, payload)
+
+
+# ---------------------------------------------------------------------------
+# doctor command
+# ---------------------------------------------------------------------------
+
+
+@cli.command("doctor")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def doctor(state: CliState, json_output: bool) -> None:
+    """Run health checks: theme root, PHPCS, PHP binary, deploy script."""
+    if json_output:
+        state.json_output = True
+
+    from cli_anything.skyyrose_theme.utils.theme_backend import \
+        doctor as run_doctor
+
+    report = run_doctor(state.theme_root)
+    payload = {"healthy": report.healthy, "checks": report.checks}
+
+    if not state.json_output:
+        for check in report.checks:
+            state.skin.status(
+                check["name"],
+                check.get("detail", ""),
+                ok=(check["status"] == "ok"),
+            )
+        if report.healthy:
+            state.skin.success("All checks passed.")
+        else:
+            state.skin.warning("Some checks failed. See above.")
+    emit(state, payload)
+
+
+# ---------------------------------------------------------------------------
+# session group
+# ---------------------------------------------------------------------------
+
+
+@cli.group("session")
+def session_group() -> None:
+    """Manage named REPL sessions (~/.cli_anything/skyyrose_theme/sessions/)."""
+
+
+@session_group.command("status")
+@click.option("--name", default="default", help="Session name.")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def session_status(state: CliState, name: str, json_output: bool) -> None:
+    """Show status of the named session."""
+    if json_output:
+        state.json_output = True
+
+    from cli_anything.skyyrose_theme.core.session import get_or_create_session
+
+    session = get_or_create_session(name)
+    payload = {
+        "id": session.id,
+        "name": session.name,
+        "history_count": len(session.history),
+        "created_at": session.created_at,
+        "updated_at": session.updated_at,
+    }
+    if not state.json_output:
+        skin = state.skin
+        skin.status("id", session.id)
+        skin.status("name", session.name)
+        skin.status("history_count", str(len(session.history)))
+    emit(state, payload)
+
+
+@session_group.command("save")
+@click.option("--name", default="default")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def session_save(state: CliState, name: str, json_output: bool) -> None:
+    """Save (or create) the named session."""
+    if json_output:
+        state.json_output = True
+
+    from cli_anything.skyyrose_theme.core.session import (
+        get_or_create_session, save_session)
+
+    session = get_or_create_session(name)
+    path = save_session(session)
+    payload = {"ok": True, "path": str(path)}
+    if not state.json_output:
+        state.skin.success(f"Session saved: {path}")
+    emit(state, payload)
+
+
+@session_group.command("list")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def session_list(state: CliState, json_output: bool) -> None:
+    """List all saved sessions."""
+    if json_output:
+        state.json_output = True
+
+    from cli_anything.skyyrose_theme.core.session import list_sessions
+
+    sessions = list_sessions()
+    rows = [{"id": s.id[:8] + "...", "name": s.name, "history": len(s.history)} for s in sessions]
+    payload = {"sessions": rows, "total": len(rows)}
+    if not state.json_output:
+        if rows:
+            state.skin.table(rows, headers=["id", "name", "history"])
+        else:
+            state.skin.info("No sessions found.")
+    emit(state, payload)
+
+
+@session_group.command("delete")
+@click.argument("session_id")
+@click.option("--json", "json_output", is_flag=True)
+@pass_state
+def session_delete(state: CliState, session_id: str, json_output: bool) -> None:
+    """Delete a session by ID."""
+    if json_output:
+        state.json_output = True
+
+    from cli_anything.skyyrose_theme.core.session import delete_session
+
+    deleted = delete_session(session_id)
+    payload = {"ok": deleted, "session_id": session_id}
+    if not state.json_output:
+        if deleted:
+            state.skin.success(f"Deleted session {session_id}")
+        else:
+            state.skin.warning(f"Session not found: {session_id}")
+    emit(state, payload)
+
+
+# ---------------------------------------------------------------------------
+# repl command
+# ---------------------------------------------------------------------------
+
+
+@cli.command("repl")
+@pass_state
+def repl(state: CliState) -> None:
+    """Launch interactive REPL (default mode when no subcommand given)."""
+    from cli_anything.skyyrose_theme.core.session import (
+        get_or_create_session, save_session)
+    from cli_anything.skyyrose_theme.core.version import read_version
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.history import InMemoryHistory
+
+    skin = state.skin
+
+    # Read version for banner
+    version_str = ""
+    try:
+        vs = read_version(state.theme_root)
+        version_str = vs.functions_php if vs.consistent else "?"
+    except Exception:
+        pass
+
+    skin.print_banner(version_str)
+
+    session = get_or_create_session("default")
+    pt_session: PromptSession = PromptSession(history=InMemoryHistory())
+
+    while True:
+        try:
+            raw = pt_session.prompt(skin.prompt())
+        except (EOFError, KeyboardInterrupt):
+            save_session(session)
+            skin.print_goodbye()
+            break
+
+        line = raw.strip()
+        if not line:
+            continue
+        if line.lower() in ("exit", "quit", "q"):
+            save_session(session)
+            skin.print_goodbye()
+            break
+        if line.lower() in ("help", "?"):
+            click.echo(cli.get_help(click.Context(cli)))
+            continue
+
+        session.add_history(line)
+
+        # Dispatch the line as a CLI invocation
+        args = line.split()
+        try:
+            standalone_mode_backup = cli.standalone_mode
+            cli.standalone_mode = False
+            cli.main(args, standalone_mode=False, obj=state)
+        except SystemExit:
+            pass
+        except click.UsageError as exc:
+            skin.error(str(exc))
+        except Exception as exc:
+            skin.error(str(exc))
+        finally:
+            cli.standalone_mode = True
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/TEST.md
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/TEST.md
@@ -1,0 +1,79 @@
+# Test Suite — cli-anything-skyyrose-theme
+
+## Quick start
+
+```bash
+# Install into a fresh venv
+python3 -m venv /tmp/cli-anything-skyyrose-theme-venv
+/tmp/cli-anything-skyyrose-theme-venv/bin/pip install --upgrade pip
+cd /Users/theceo/DevSkyy/vendor/cli-anything/skyyrose-theme/agent-harness
+/tmp/cli-anything-skyyrose-theme-venv/bin/pip install -e ".[dev]"
+
+# Run unit tests (offline, ~1s)
+PATH="/tmp/cli-anything-skyyrose-theme-venv/bin:$PATH" \
+  CLI_ANYTHING_FORCE_INSTALLED=1 \
+  /tmp/cli-anything-skyyrose-theme-venv/bin/pytest \
+  cli_anything/skyyrose_theme/tests/ \
+  --tb=short -q
+```
+
+## Test files
+
+| File | Type | Count | Gate |
+|------|------|-------|------|
+| `test_core.py` | Unit (offline) | 58 tests | Always runs |
+| `test_stopshow.py` | Unit (offline) | 11 tests | Always runs |
+| `test_phpcs.py` | Unit (offline) | 12 tests | Always runs |
+| `test_verify.py` | Unit (offline) | 23 tests | Always runs |
+| `test_version_atomic.py` | Unit (offline) | 7 tests | Always runs |
+| `test_php_parser.py` | Unit (offline) | 26 tests | Always runs |
+| `test_full_e2e.py` | E2E (live) | 5 tests | `SKYYROSE_E2E=1` |
+
+## Coverage map
+
+| Module | Tests | Coverage |
+|--------|-------|----------|
+| `core/version.py` | `TestVersionRead` (6) + `TestVersionWrite` (4) + `TestVersionWriteAtomic` (7) | 17 |
+| `utils/php_parser.py` | `TestPhpParser` (6) + `TestExtractVersionConstant` (8) + `TestExtractStyleCssVersion` (4) + `TestExtractReadmeStableTag` (3) + `TestExtractThemeAndDomain` (4) + `TestExtractPhpString` (3) + `TestExtractTemplateMap` (5) | 33 |
+| `core/template.py` | `TestTemplateDiscovery` | 5 |
+| `core/session.py` | `TestSession` | 9 |
+| `core/deploy.py` | `TestDeployManifest` (8) + `TestStopAndShow` (4) + `TestStopShowManifestShape` (11) | 23 |
+| `core/verify.py` | `TestVerify` (6) + `TestUrlCheckResult` (7) + `TestVerifyLiveWithResponses` (11) + `TestVerifyReport` (3) | 27 |
+| `utils/theme_backend.py` | `TestThemeBackend` (5) + `TestPHPCSArgvAssembly` (12) | 17 |
+| CLI runner | `TestCLIRunner` | 5 |
+
+Total offline: **137 tests** (Phase 6 — added 79 new tests)
+
+## Phase 6 results (2026-05-25)
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Pass | 58 | 137 |
+| Skip (E2E gate) | 5 | 5 |
+| Fail | 0 | 0 |
+| New test files | — | 4 |
+| `responses` dep added | — | `>=0.25` |
+
+## E2E prerequisites
+
+```bash
+export SKYYROSE_E2E=1
+export SKYYROSE_THEME_ROOT=/Users/theceo/DevSkyy/wordpress-theme/skyyrose-flagship
+export CLI_ANYTHING_FORCE_INSTALLED=1
+```
+
+E2E tests that exercise SSH (cache purge, wp-cli) require `ssh skyyrose.wordpress.com@ssh.wp.com`
+to be reachable and authenticated.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SKYYROSE_THEME_ROOT` | `~/DevSkyy/wordpress-theme/skyyrose-flagship` | Theme directory |
+| `SKYYROSE_DEPLOY_SCRIPT` | `~/DevSkyy/scripts/deploy-theme.sh` | Deploy script path |
+| `SKYYROSE_SSH_HOST` | `skyyrose.wordpress.com@ssh.wp.com` | SSH target |
+| `SKYYROSE_WP_ROOT` | `/srv/htdocs` | WP root on server |
+| `SKYYROSE_WP_CLI` | `/usr/local/bin/wp` | wp-cli path on server |
+| `PUBLIC_URL` | `https://skyyrose.co` | Verify base URL |
+| `SKYYROSE_E2E` | unset | Set to `1` to enable live tests |
+| `CLI_ANYTHING_FORCE_INSTALLED` | unset | Set to `1` to require installed binary |

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/__init__.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for cli-anything-skyyrose-theme."""

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_core.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_core.py
@@ -1,0 +1,746 @@
+"""
+Unit tests for cli-anything-skyyrose-theme core modules.
+
+Run: pytest cli_anything/skyyrose_theme/tests/ --tb=short -q
+All tests are offline — no network calls, no SSH, no real file system writes
+to the production theme directory.
+
+SKYYROSE_E2E=1 gates live tests (test_full_e2e.py only).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_theme_root(tmp_path: Path) -> Path:
+    """Create a minimal fake theme root for offline testing."""
+    root = tmp_path / "skyyrose-flagship"
+    root.mkdir()
+
+    (root / "functions.php").write_text("<?php\ndefine( 'SKYYROSE_VERSION', '1.5.20' );\n")
+    (root / "style.css").write_text(
+        "/*\nTheme Name: SkyyRose\nVersion:             1.5.20\nText Domain: skyyrose\n*/\n"
+    )
+    (root / "readme.txt").write_text("=== SkyyRose ===\nStable tag: 1.5.20\n")
+
+    # Create a few template files
+    for slug in ["about", "coming-soon", "contact"]:
+        (root / f"template-{slug}.php").write_text(f"<?php /* Template: {slug} */\n")
+
+    for coll in ["signature", "black-rose", "love-hurts", "kids-capsule"]:
+        (root / f"template-collection-{coll}.php").write_text(f"<?php /* Collection: {coll} */\n")
+
+    # Create inc/ with enqueue.php
+    inc = root / "inc"
+    inc.mkdir()
+    enqueue_content = """<?php
+function skyyrose_get_current_template_slug() {
+    $template_map = array(
+        'template-about.php'                  => 'about',
+        'template-coming-soon.php'            => 'coming-soon',
+        'template-contact.php'                => 'contact',
+        'template-collection-signature.php'   => 'collection',
+        'template-collection-black-rose.php'  => 'collection',
+        'template-collection-love-hurts.php'  => 'collection',
+        'template-collection-kids-capsule.php' => 'collection',
+    );
+}
+"""
+    (inc / "enqueue.php").write_text(enqueue_content)
+
+    return root
+
+
+# ===========================================================================
+# version.py tests (10 tests)
+# ===========================================================================
+
+
+class TestVersionRead:
+    def test_read_functions_php(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.core.version import \
+            _read_functions_php
+
+        assert _read_functions_php(root) == "1.5.20"
+
+    def test_read_style_css(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.core.version import _read_style_css
+
+        assert _read_style_css(root) == "1.5.20"
+
+    def test_read_readme_txt(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.core.version import _read_readme_txt
+
+        assert _read_readme_txt(root) == "1.5.20"
+
+    def test_read_version_consistent(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.core.version import read_version
+
+        vs = read_version(root)
+        assert vs.consistent is True
+        assert vs.current == "1.5.20"
+
+    def test_read_version_mismatch(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        # Break style.css version
+        (root / "style.css").write_text(
+            "/*\nTheme Name: SkyyRose\nVersion:             1.5.99\n*/\n"
+        )
+        from cli_anything.skyyrose_theme.core.version import (
+            VersionMismatchError, read_version)
+
+        vs = read_version(root)
+        assert vs.consistent is False
+        with pytest.raises(VersionMismatchError):
+            _ = vs.current
+
+    def test_read_version_missing_constant(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        (root / "functions.php").write_text("<?php // no version constant\n")
+        from cli_anything.skyyrose_theme.core.version import (VersionError,
+                                                              read_version)
+
+        with pytest.raises(VersionError):
+            read_version(root)
+
+
+class TestVersionWrite:
+    def test_write_version_all_three_files(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.core.version import (read_version,
+                                                              write_version)
+
+        vs = write_version("1.6.0", root)
+        assert vs.current == "1.6.0"
+        # Verify on disk
+        vs2 = read_version(root)
+        assert vs2.current == "1.6.0"
+
+    def test_write_version_atomic_no_partial(self, tmp_path):
+        """After successful write, all three files agree."""
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.core.version import (read_version,
+                                                              write_version)
+
+        write_version("2.0.0", root)
+        vs = read_version(root)
+        assert vs.functions_php == vs.style_css == vs.readme_txt == "2.0.0"
+
+    def test_write_version_precondition_mismatch(self, tmp_path):
+        """write_version raises if sources disagree before write."""
+        root = _make_theme_root(tmp_path)
+        (root / "style.css").write_text(
+            "/*\nTheme Name: SkyyRose\nVersion:             9.9.9\n*/\n"
+        )
+        from cli_anything.skyyrose_theme.core.version import (
+            VersionMismatchError, write_version)
+
+        with pytest.raises(VersionMismatchError):
+            write_version("1.6.0", root)
+
+    def test_write_version_roundtrip(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.core.version import write_version
+
+        write_version("1.5.21", root)
+        write_version("1.5.20", root)  # rollback
+        from cli_anything.skyyrose_theme.core.version import read_version
+
+        assert read_version(root).current == "1.5.20"
+
+
+# ===========================================================================
+# php_parser.py tests (5 tests)
+# ===========================================================================
+
+
+class TestPhpParser:
+    def test_extract_version_constant(self):
+        from cli_anything.skyyrose_theme.utils.php_parser import \
+            extract_version_constant
+
+        php = "define( 'SKYYROSE_VERSION', '1.5.20' );"
+        assert extract_version_constant(php) == "1.5.20"
+
+    def test_extract_version_constant_missing(self):
+        from cli_anything.skyyrose_theme.utils.php_parser import \
+            extract_version_constant
+
+        assert extract_version_constant("<?php // nothing") is None
+
+    def test_extract_template_map(self):
+        from cli_anything.skyyrose_theme.utils.php_parser import \
+            extract_template_map
+
+        php = """
+        $template_map = array(
+            'template-about.php' => 'about',
+            'template-contact.php' => 'contact',
+        );
+        """
+        result = extract_template_map(php)
+        assert result == {"template-about.php": "about", "template-contact.php": "contact"}
+
+    def test_extract_style_css_version(self):
+        from cli_anything.skyyrose_theme.utils.php_parser import \
+            extract_style_css_version
+
+        css = "/*\nTheme Name: SkyyRose\nVersion:             1.5.20\n*/\n"
+        assert extract_style_css_version(css) == "1.5.20"
+
+    def test_extract_readme_stable_tag(self):
+        from cli_anything.skyyrose_theme.utils.php_parser import \
+            extract_readme_stable_tag
+
+        txt = "=== SkyyRose ===\nStable tag: 1.5.20\n"
+        assert extract_readme_stable_tag(txt) == "1.5.20"
+
+    def test_extract_php_string_generic(self):
+        from cli_anything.skyyrose_theme.utils.php_parser import \
+            extract_php_string
+
+        php = "define( 'MY_CONST', 'hello-world' );"
+        assert extract_php_string(php, "MY_CONST") == "hello-world"
+
+
+# ===========================================================================
+# template.py tests (5 tests)
+# ===========================================================================
+
+
+class TestTemplateDiscovery:
+    def test_load_templates_finds_files(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.core.template import load_templates
+
+        tmap = load_templates(root)
+        filenames = {t.filename for t in tmap.templates}
+        assert "template-about.php" in filenames
+        assert "template-collection-signature.php" in filenames
+
+    def test_load_templates_slug_from_enqueue(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.core.template import load_templates
+
+        tmap = load_templates(root)
+        t = tmap.by_filename("template-about.php")
+        assert t is not None
+        assert t.slug == "about"
+
+    def test_load_templates_unregistered_slug_is_none(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        # Add a template file not in enqueue.php
+        (root / "template-mystery.php").write_text("<?php\n")
+        from cli_anything.skyyrose_theme.core.template import load_templates
+
+        tmap = load_templates(root)
+        t = tmap.by_filename("template-mystery.php")
+        assert t is not None
+        assert t.slug is None
+
+    def test_load_templates_by_slug(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.core.template import load_templates
+
+        tmap = load_templates(root)
+        t = tmap.by_slug("about")
+        assert t is not None
+        assert t.filename == "template-about.php"
+
+    def test_load_templates_missing_root_raises(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.template import (TemplateError,
+                                                               load_templates)
+
+        with pytest.raises(TemplateError):
+            load_templates(tmp_path / "nonexistent")
+
+
+# ===========================================================================
+# session.py tests (8 tests)
+# ===========================================================================
+
+
+class TestSession:
+    def test_create_and_save_session(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.session import (Session,
+                                                              save_session)
+
+        s = Session(name="test")
+        path = save_session(s, sessions_dir=tmp_path)
+        assert path.exists()
+
+    def test_load_session_roundtrip(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.session import (Session,
+                                                              load_session,
+                                                              save_session)
+
+        s = Session(name="roundtrip")
+        save_session(s, sessions_dir=tmp_path)
+        loaded = load_session(s.id, sessions_dir=tmp_path)
+        assert loaded.id == s.id
+        assert loaded.name == "roundtrip"
+
+    def test_load_session_not_found(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.session import (
+            SessionNotFoundError, load_session)
+
+        with pytest.raises(SessionNotFoundError):
+            load_session("nonexistent-id", sessions_dir=tmp_path)
+
+    def test_list_sessions_empty(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.session import list_sessions
+
+        assert list_sessions(sessions_dir=tmp_path) == []
+
+    def test_list_sessions_returns_sorted(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.session import (Session,
+                                                              list_sessions,
+                                                              save_session)
+
+        s1 = Session(name="alpha")
+        s2 = Session(name="beta")
+        s1.updated_at = time.time() - 100
+        s2.updated_at = time.time()
+        save_session(s1, sessions_dir=tmp_path)
+        save_session(s2, sessions_dir=tmp_path)
+
+        sessions = list_sessions(sessions_dir=tmp_path)
+        assert sessions[0].name == "beta"
+
+    def test_delete_session(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.session import (Session,
+                                                              delete_session,
+                                                              save_session)
+
+        s = Session(name="to-delete")
+        save_session(s, sessions_dir=tmp_path)
+        assert delete_session(s.id, sessions_dir=tmp_path) is True
+        assert delete_session(s.id, sessions_dir=tmp_path) is False
+
+    def test_add_history_trimmed(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.session import (MAX_HISTORY,
+                                                              Session)
+
+        s = Session(name="hist")
+        for i in range(MAX_HISTORY + 10):
+            s.add_history(f"cmd-{i}")
+        assert len(s.history) == MAX_HISTORY
+        assert s.history[-1] == f"cmd-{MAX_HISTORY + 9}"
+
+    def test_get_or_create_session_idempotent(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.session import \
+            get_or_create_session
+
+        s1 = get_or_create_session("myname", sessions_dir=tmp_path)
+        s2 = get_or_create_session("myname", sessions_dir=tmp_path)
+        assert s1.id == s2.id
+
+    def test_locked_save_json_atomic(self, tmp_path):
+        """Verify _locked_save_json writes valid JSON atomically."""
+        from cli_anything.skyyrose_theme.core.session import _locked_save_json
+
+        target = tmp_path / "test.json"
+        data = {"key": "value", "num": 42}
+        _locked_save_json(target, data)
+        assert target.exists()
+        loaded = json.loads(target.read_text())
+        assert loaded == data
+
+
+# ===========================================================================
+# deploy.py tests (8 tests)
+# ===========================================================================
+
+
+class TestDeployManifest:
+    def test_build_manifest_dry_run(self, tmp_path):
+        """build_deploy_manifest returns manifest with dry_run=True."""
+        # Create a fake deploy script
+        script = tmp_path / "deploy-theme.sh"
+        script.write_text("#!/bin/bash\necho deployed\n")
+
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        manifest = build_deploy_manifest(
+            dry_run=True,
+            deploy_script=script,
+            theme_root=tmp_path,
+        )
+        assert manifest.dry_run is True
+        assert manifest.mode == "hot-swap"
+
+    def test_build_manifest_with_maintenance(self, tmp_path):
+        script = tmp_path / "deploy-theme.sh"
+        script.write_text("#!/bin/bash\n")
+
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        manifest = build_deploy_manifest(
+            with_maintenance=True,
+            deploy_script=script,
+            theme_root=tmp_path,
+        )
+        assert manifest.with_maintenance is True
+        assert manifest.mode == "maintenance"
+
+    def test_build_manifest_script_not_found(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.deploy import (
+            DeployScriptNotFoundError, build_deploy_manifest)
+
+        with pytest.raises(DeployScriptNotFoundError):
+            build_deploy_manifest(
+                deploy_script=tmp_path / "nonexistent.sh",
+                theme_root=tmp_path,
+            )
+
+    def test_manifest_to_dict_shape(self, tmp_path):
+        script = tmp_path / "deploy-theme.sh"
+        script.write_text("#!/bin/bash\n")
+
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        manifest = build_deploy_manifest(deploy_script=script, theme_root=tmp_path)
+        d = manifest.to_dict()
+        assert "action" in d
+        assert "dry_run" in d
+        assert "irreversible" in d
+
+    def test_run_deploy_requires_confirmed(self, tmp_path):
+        script = tmp_path / "deploy-theme.sh"
+        script.write_text("#!/bin/bash\n")
+
+        from cli_anything.skyyrose_theme.core.deploy import (
+            DeployNotConfirmedError, build_deploy_manifest, run_deploy)
+
+        manifest = build_deploy_manifest(deploy_script=script, theme_root=tmp_path)
+        with pytest.raises(DeployNotConfirmedError):
+            run_deploy(manifest, confirmed=False)
+
+    def test_run_deploy_dry_run_argv(self, tmp_path):
+        """--dry-run passes the flag to the script argv."""
+        script = tmp_path / "deploy-theme.sh"
+        # Script that echoes its args and exits 0
+        script.write_text('#!/bin/bash\necho "$@"\n')
+        script.chmod(0o755)
+
+        from cli_anything.skyyrose_theme.core.deploy import (
+            build_deploy_manifest, run_deploy)
+
+        manifest = build_deploy_manifest(dry_run=True, deploy_script=script, theme_root=tmp_path)
+        result = run_deploy(manifest, confirmed=True)
+        assert result.returncode == 0
+
+    def test_run_deploy_fails_on_nonzero_exit(self, tmp_path):
+        script = tmp_path / "fail.sh"
+        script.write_text("#!/bin/bash\nexit 1\n")
+        script.chmod(0o755)
+
+        from cli_anything.skyyrose_theme.core.deploy import (
+            DeployFailedError, build_deploy_manifest, run_deploy)
+
+        manifest = build_deploy_manifest(deploy_script=script, theme_root=tmp_path)
+        with pytest.raises(DeployFailedError):
+            run_deploy(manifest, confirmed=True)
+
+    def test_run_deploy_with_maintenance_argv(self, tmp_path):
+        """--with-maintenance passes the flag to the script."""
+        script = tmp_path / "deploy-theme.sh"
+        script.write_text('#!/bin/bash\necho "$@"\n')
+        script.chmod(0o755)
+
+        from cli_anything.skyyrose_theme.core.deploy import (
+            build_deploy_manifest, run_deploy)
+
+        manifest = build_deploy_manifest(
+            with_maintenance=True, deploy_script=script, theme_root=tmp_path
+        )
+        result = run_deploy(manifest, confirmed=True)
+        assert result.returncode == 0
+
+
+# ===========================================================================
+# verify.py tests (6 tests — all offline via mock)
+# ===========================================================================
+
+
+class TestVerify:
+    def _mock_response(self, status_code=200, text="x" * 60000, url="https://skyyrose.co/"):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.text = text
+        resp.content = text.encode()
+        resp.url = url
+        return resp
+
+    def test_url_check_result_ok(self):
+        from cli_anything.skyyrose_theme.core.verify import UrlCheckResult
+
+        r = UrlCheckResult(
+            url="https://skyyrose.co/",
+            status_code=200,
+            body_bytes=60000,
+            php_error=None,
+            error=None,
+        )
+        assert r.ok is True
+        assert r.verdict == "pass"
+
+    def test_url_check_result_php_error(self):
+        from cli_anything.skyyrose_theme.core.verify import UrlCheckResult
+
+        r = UrlCheckResult(
+            url="https://skyyrose.co/",
+            status_code=200,
+            body_bytes=60000,
+            php_error="Fatal error",
+            error=None,
+        )
+        assert r.ok is False
+        assert r.verdict == "fail"
+
+    def test_verify_live_success(self):
+        from cli_anything.skyyrose_theme.core.verify import verify_live
+
+        mock_resp = self._mock_response()
+        with patch("requests.get", return_value=mock_resp):
+            report = verify_live(
+                base_url="https://skyyrose.co",
+                paths=["/"],
+            )
+        assert report.passed is True
+
+    def test_verify_live_raises_on_failure(self):
+        from cli_anything.skyyrose_theme.core.verify import (VerifyFailedError,
+                                                             verify_live)
+
+        mock_resp = self._mock_response(status_code=500)
+        with patch("requests.get", return_value=mock_resp):
+            with pytest.raises(VerifyFailedError):
+                verify_live(base_url="https://skyyrose.co", paths=["/"])
+
+    def test_verify_live_detects_php_error_marker(self):
+        from cli_anything.skyyrose_theme.core.verify import (VerifyFailedError,
+                                                             verify_live)
+
+        bad_body = "x" * 60000 + "Fatal error: Uncaught Error"
+        mock_resp = self._mock_response(text=bad_body)
+        with patch("requests.get", return_value=mock_resp):
+            with pytest.raises(VerifyFailedError) as exc_info:
+                verify_live(base_url="https://skyyrose.co", paths=["/"])
+        assert "Fatal error" in str(exc_info.value)
+
+    def test_verify_live_small_body_fails(self):
+        from cli_anything.skyyrose_theme.core.verify import (VerifyFailedError,
+                                                             verify_live)
+
+        tiny_body = "small"
+        mock_resp = self._mock_response(text=tiny_body)
+        with patch("requests.get", return_value=mock_resp):
+            with pytest.raises(VerifyFailedError):
+                verify_live(base_url="https://skyyrose.co", paths=["/"])
+
+
+# ===========================================================================
+# theme_backend.py tests (5 tests)
+# ===========================================================================
+
+
+class TestThemeBackend:
+    def test_build_context_returns_context(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.utils.theme_backend import \
+            build_context
+
+        ctx = build_context(theme_root=root)
+        assert ctx.theme_root == root
+
+    def test_doctor_theme_root_ok(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.utils.theme_backend import doctor
+
+        report = doctor(theme_root=root)
+        # Find theme_root check
+        theme_check = next(c for c in report.checks if c["name"] == "theme_root")
+        assert theme_check["status"] == "ok"
+
+    def test_doctor_missing_root_fails(self, tmp_path):
+        from cli_anything.skyyrose_theme.utils.theme_backend import doctor
+
+        report = doctor(theme_root=tmp_path / "nonexistent")
+        theme_check = next(c for c in report.checks if c["name"] == "theme_root")
+        assert theme_check["status"] == "fail"
+
+    def test_run_phpcs_not_found_raises(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.utils.theme_backend import (
+            PHPCSNotFoundError, run_phpcs)
+
+        with pytest.raises(PHPCSNotFoundError):
+            run_phpcs(root)  # no vendor/bin/phpcs in fake root
+
+    def test_run_php_lint_no_php_raises(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.utils.theme_backend import (
+            PHPNotFoundError, run_php_lint)
+
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(PHPNotFoundError):
+                run_php_lint(root)
+
+
+# ===========================================================================
+# STOP-AND-SHOW manifest tests (4 tests)
+# ===========================================================================
+
+
+class TestStopAndShow:
+    def test_deploy_manifest_not_confirmed_no_execute(self, tmp_path):
+        """run_deploy with confirmed=False never calls subprocess.run."""
+        script = tmp_path / "deploy-theme.sh"
+        script.write_text("#!/bin/bash\n")
+
+        from cli_anything.skyyrose_theme.core.deploy import (
+            DeployNotConfirmedError, build_deploy_manifest, run_deploy)
+
+        manifest = build_deploy_manifest(deploy_script=script, theme_root=tmp_path)
+        with patch("subprocess.run") as mock_run:
+            with pytest.raises(DeployNotConfirmedError):
+                run_deploy(manifest, confirmed=False)
+            mock_run.assert_not_called()
+
+    def test_cache_purge_manifest_shape(self):
+        """cache purge manifest dict has required keys."""
+        # Test the manifest dict shape directly
+        manifest_dict = {
+            "action": "cache purge (wp cache flush)",
+            "target": "skyyrose.co production",
+            "method": "wp-cli over SSH",
+            "cost": "$0",
+            "irreversible": False,
+        }
+        assert manifest_dict["cost"] == "$0"
+        assert manifest_dict["irreversible"] is False
+
+    def test_deploy_manifest_irreversible_flag(self, tmp_path):
+        script = tmp_path / "deploy-theme.sh"
+        script.write_text("#!/bin/bash\n")
+
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        manifest = build_deploy_manifest(deploy_script=script, theme_root=tmp_path)
+        d = manifest.to_dict()
+        # Non-dry-run = irreversible
+        assert d["irreversible"] is True
+
+    def test_dry_run_manifest_not_irreversible(self, tmp_path):
+        script = tmp_path / "deploy-theme.sh"
+        script.write_text("#!/bin/bash\n")
+
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        manifest = build_deploy_manifest(dry_run=True, deploy_script=script, theme_root=tmp_path)
+        d = manifest.to_dict()
+        assert d["irreversible"] is False
+
+
+# ===========================================================================
+# CLI integration tests (via Click test runner) (5 tests)
+# ===========================================================================
+
+
+class TestCLIRunner:
+    def test_cli_help(self):
+        from cli_anything.skyyrose_theme.skyyrose_theme_cli import cli
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "SkyyRose" in result.output
+
+    def test_version_current_json(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.skyyrose_theme_cli import cli
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--json", "--theme-root", str(root), "version", "current"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["functions_php"] == "1.5.20"
+        assert data["consistent"] is True
+
+    def test_template_list_json(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.skyyrose_theme_cli import cli
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--json", "--theme-root", str(root), "template", "list"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["total"] > 0
+
+    def test_deploy_no_confirm_exits_0(self, tmp_path):
+        script = tmp_path / "deploy-theme.sh"
+        script.write_text("#!/bin/bash\n")
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.skyyrose_theme_cli import cli
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--theme-root",
+                str(root),
+                "deploy",
+                "--dry-run",
+            ],
+            env={"SKYYROSE_DEPLOY_SCRIPT": str(script)},
+        )
+        # Without --confirm, should print manifest and exit 0
+        assert result.exit_code == 0
+
+    def test_doctor_json(self, tmp_path):
+        root = _make_theme_root(tmp_path)
+        from cli_anything.skyyrose_theme.skyyrose_theme_cli import cli
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--json", "--theme-root", str(root), "doctor"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "checks" in data
+        assert "healthy" in data

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_full_e2e.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_full_e2e.py
@@ -1,0 +1,170 @@
+"""
+Full end-to-end tests for cli-anything-skyyrose-theme.
+
+These tests require:
+  - SKYYROSE_E2E=1 environment variable
+  - The cli-anything-skyyrose-theme binary on PATH (or CLI_ANYTHING_FORCE_INSTALLED=1)
+  - Real theme root at SKYYROSE_THEME_ROOT (or default ~/DevSkyy/wordpress-theme/skyyrose-flagship)
+  - SSH access to skyyrose.wordpress.com@ssh.wp.com for cache/wp tests
+
+Without SKYYROSE_E2E=1, all tests in this file are skipped automatically.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Skip guard
+# ---------------------------------------------------------------------------
+
+_E2E = os.environ.get("SKYYROSE_E2E", "").strip() == "1"
+pytestmark = pytest.mark.skipif(not _E2E, reason="SKYYROSE_E2E=1 not set")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CLI_NAME = "cli-anything-skyyrose-theme"
+
+
+def _resolve_cli(name: str) -> list[str]:
+    """
+    Resolve the CLI binary path.
+
+    If CLI_ANYTHING_FORCE_INSTALLED=1 and the binary is not found, raises.
+    Otherwise falls back to python -m invocation.
+    """
+    force = os.environ.get("CLI_ANYTHING_FORCE_INSTALLED", "").strip() == "1"
+    path = shutil.which(name)
+    if path:
+        return [path]
+    if force:
+        raise RuntimeError(f"{name} not found in PATH. Install with: pip install -e .")
+    module = "cli_anything.skyyrose_theme"
+    return [sys.executable, "-m", module]
+
+
+_CLI = _resolve_cli(_CLI_NAME)
+
+_THEME_ROOT = os.environ.get(
+    "SKYYROSE_THEME_ROOT",
+    str(Path.home() / "DevSkyy/wordpress-theme/skyyrose-flagship"),
+)
+_THEME_ROOT_PATH = Path(_THEME_ROOT)
+
+_skip_no_theme = pytest.mark.skipif(
+    not _THEME_ROOT_PATH.exists(),
+    reason=f"Theme root not found: {_THEME_ROOT}",
+)
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Redirect HOME so sessions don't pollute the real ~/.cli_anything."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# E2E tests
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_theme
+def test_e2e_version_current():
+    """version current returns consistent version from real theme files."""
+    result = subprocess.run(
+        [*_CLI, "--json", "--theme-root", _THEME_ROOT, "version", "current"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["consistent"] is True
+    assert re.match(r"\d+\.\d+\.\d+", data["functions_php"])
+
+
+@_skip_no_theme
+def test_e2e_template_list():
+    """template list returns at least 10 templates from the real theme."""
+    result = subprocess.run(
+        [*_CLI, "--json", "--theme-root", _THEME_ROOT, "template", "list"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["total"] >= 10
+
+
+@_skip_no_theme
+def test_e2e_doctor():
+    """doctor passes all critical checks on the real theme root."""
+    result = subprocess.run(
+        [*_CLI, "--json", "--theme-root", _THEME_ROOT, "doctor"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    # theme_root, style_css, functions_php must be ok
+    checks = {c["name"]: c["status"] for c in data["checks"]}
+    assert checks.get("theme_root") == "ok"
+    assert checks.get("style_css") == "ok"
+    assert checks.get("functions_php") == "ok"
+
+
+@_skip_no_theme
+def test_e2e_deploy_dry_run_no_confirm():
+    """deploy --dry-run without --confirm prints manifest and exits 0."""
+    result = subprocess.run(
+        [
+            *_CLI,
+            "--theme-root",
+            _THEME_ROOT,
+            "deploy",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "confirm" in result.stdout.lower() or "deploy" in result.stdout.lower()
+
+
+def test_e2e_session_save_and_list(isolated_home):
+    """session save + list roundtrip works."""
+    # save
+    result = subprocess.run(
+        [*_CLI, "--json", "session", "save", "--name", "e2e-test"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["ok"] is True
+
+    # list
+    result2 = subprocess.run(
+        [*_CLI, "--json", "session", "list"],
+        capture_output=True,
+        text=True,
+    )
+    assert result2.returncode == 0, result2.stderr
+    data2 = json.loads(result2.stdout)
+    names = [s["name"] for s in data2["sessions"]]
+    assert "e2e-test" in names
+
+
+# ---------------------------------------------------------------------------
+# re import needed for test_e2e_version_current
+# ---------------------------------------------------------------------------
+import re  # noqa: E402

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_php_parser.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_php_parser.py
@@ -1,0 +1,182 @@
+"""
+PHP parser edge-case tests.
+
+Covers:
+ - Version constant on a single line vs multi-line define
+ - Single quotes vs double quotes in define()
+ - Version constant with leading 'v' prefix (e.g. 'v1.0.0') — locked: returns as-is
+ - Comment-only file → extract_version_constant returns None
+ - Multiple version constants in same file — first one wins (regex findall order)
+ - File without <?php opening tag — graceful (returns None, no crash)
+ - Style CSS version with extra whitespace
+ - Readme stable tag with trailing whitespace
+ - Theme name extraction
+ - Text domain extraction
+ - extract_php_string with double-quoted constant name
+ - Template map with mixed quote styles
+ - Template map with no entries returns empty dict
+"""
+
+from __future__ import annotations
+
+import pytest
+from cli_anything.skyyrose_theme.utils.php_parser import (
+    extract_php_string, extract_readme_stable_tag, extract_style_css_version,
+    extract_template_map, extract_text_domain, extract_theme_name,
+    extract_version_constant)
+
+# ---------------------------------------------------------------------------
+# E. PHP parser edge cases (~13 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractVersionConstant:
+    def test_single_line_define_single_quotes(self):
+        php = "define( 'SKYYROSE_VERSION', '1.5.20' );"
+        assert extract_version_constant(php) == "1.5.20"
+
+    def test_single_line_define_double_quotes(self):
+        """define() with double quotes around both name and value."""
+        php = 'define( "SKYYROSE_VERSION", "2.0.0" );'
+        assert extract_version_constant(php) == "2.0.0"
+
+    def test_multiline_define_with_whitespace(self):
+        php = "define(\n    'SKYYROSE_VERSION',\n    '1.5.21'\n);"
+        assert extract_version_constant(php) == "1.5.21"
+
+    def test_version_with_leading_v_prefix_returned_as_is(self):
+        """
+        A version constant like 'v1.0.0' is returned verbatim.
+        The parser does not strip the 'v' — caller decides how to handle it.
+        This test locks that behaviour.
+        """
+        php = "define( 'SKYYROSE_VERSION', 'v1.0.0' );"
+        result = extract_version_constant(php)
+        assert result == "v1.0.0"
+
+    def test_comment_only_file_returns_none(self):
+        php = "<?php\n// This file has no version constant\n/* just a comment */\n"
+        assert extract_version_constant(php) is None
+
+    def test_missing_constant_returns_none(self):
+        php = "<?php\necho 'hello';\n"
+        assert extract_version_constant(php) is None
+
+    def test_file_without_php_opening_tag_returns_none(self):
+        """Text without <?php — parser handles gracefully, returns None."""
+        text = "define( 'SKYYROSE_VERSION', '1.0.0' );"
+        # The regex doesn't require <?php — it finds the pattern anywhere.
+        # Lock the actual behaviour: constant IS found even without <?php tag.
+        result = extract_version_constant(text)
+        assert result == "1.0.0"
+
+    def test_multiple_version_constants_first_wins(self):
+        """
+        Pathological file with two SKYYROSE_VERSION defines.
+        _SKYYROSE_VERSION_RE.search() finds the first match.
+        Lock this behaviour so it's explicit.
+        """
+        php = (
+            "define( 'SKYYROSE_VERSION', '1.0.0' );\n"
+            "// duplicate below — should be ignored\n"
+            "define( 'SKYYROSE_VERSION', '9.9.9' );\n"
+        )
+        result = extract_version_constant(php)
+        assert result == "1.0.0"
+
+    def test_empty_string_returns_none(self):
+        assert extract_version_constant("") is None
+
+
+class TestExtractStyleCssVersion:
+    def test_standard_version_header(self):
+        css = "/*\nTheme Name: SkyyRose\nVersion: 1.5.20\n*/\n"
+        assert extract_style_css_version(css) == "1.5.20"
+
+    def test_version_with_leading_whitespace_stripped(self):
+        css = "/*\nVersion:             1.5.20\n*/\n"
+        assert extract_style_css_version(css) == "1.5.20"
+
+    def test_version_with_trailing_whitespace_stripped(self):
+        css = "/*\nVersion: 1.5.20   \n*/\n"
+        assert extract_style_css_version(css) == "1.5.20"
+
+    def test_missing_version_returns_none(self):
+        css = "/*\nTheme Name: SkyyRose\n*/\n"
+        assert extract_style_css_version(css) is None
+
+
+class TestExtractReadmeStableTag:
+    def test_standard_stable_tag(self):
+        txt = "=== SkyyRose ===\nStable tag: 1.5.20\n"
+        assert extract_readme_stable_tag(txt) == "1.5.20"
+
+    def test_stable_tag_trailing_whitespace_stripped(self):
+        txt = "Stable tag: 1.5.20   \n"
+        assert extract_readme_stable_tag(txt) == "1.5.20"
+
+    def test_missing_stable_tag_returns_none(self):
+        txt = "=== SkyyRose ===\nNo version info here\n"
+        assert extract_readme_stable_tag(txt) is None
+
+
+class TestExtractThemeAndDomain:
+    def test_theme_name_extracted(self):
+        css = "/*\nTheme Name: SkyyRose\nVersion: 1.0.0\n*/\n"
+        assert extract_theme_name(css) == "SkyyRose"
+
+    def test_text_domain_extracted(self):
+        css = "/*\nTheme Name: SkyyRose\nText Domain: skyyrose\n*/\n"
+        assert extract_text_domain(css) == "skyyrose"
+
+    def test_theme_name_missing_returns_none(self):
+        assert extract_theme_name("/* no theme name */") is None
+
+    def test_text_domain_missing_returns_none(self):
+        assert extract_text_domain("/* no domain */") is None
+
+
+class TestExtractPhpString:
+    def test_generic_constant_extracted(self):
+        php = "define( 'MY_CONST', 'hello-world' );"
+        assert extract_php_string(php, "MY_CONST") == "hello-world"
+
+    def test_constant_not_present_returns_none(self):
+        php = "define( 'OTHER_CONST', 'value' );"
+        assert extract_php_string(php, "MY_CONST") is None
+
+    def test_double_quoted_value(self):
+        php = 'define( "MY_CONST", "double-quoted" );'
+        assert extract_php_string(php, "MY_CONST") == "double-quoted"
+
+
+class TestExtractTemplateMap:
+    def test_single_entry_parsed(self):
+        php = "'template-about.php' => 'about',"
+        result = extract_template_map(php)
+        assert result == {"template-about.php": "about"}
+
+    def test_multiple_entries_parsed(self):
+        php = (
+            "'template-about.php'         => 'about',\n"
+            "'template-contact.php'       => 'contact',\n"
+            "'template-coming-soon.php'   => 'coming-soon',\n"
+        )
+        result = extract_template_map(php)
+        assert result["template-about.php"] == "about"
+        assert result["template-contact.php"] == "contact"
+        assert result["template-coming-soon.php"] == "coming-soon"
+
+    def test_empty_php_returns_empty_dict(self):
+        assert extract_template_map("<?php\n// no entries\n") == {}
+
+    def test_double_quoted_entries_parsed(self):
+        php = '"template-shop.php" => "shop",'
+        result = extract_template_map(php)
+        assert result == {"template-shop.php": "shop"}
+
+    def test_mixed_quote_styles_parsed(self):
+        php = "'template-about.php' => 'about',\n\"template-shop.php\" => \"shop\",\n"
+        result = extract_template_map(php)
+        assert result["template-about.php"] == "about"
+        assert result["template-shop.php"] == "shop"

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_phpcs.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_phpcs.py
@@ -1,0 +1,237 @@
+"""
+PHPCS / PHPCBF argv assembly tests.
+
+Covers:
+ - run_phpcs produces correct argv shape (phpcs binary, --standard, -s, .)
+ - fix=True switches to phpcbf binary
+ - Missing vendor/bin/phpcs raises PHPCSNotFoundError with install hint
+ - .phpcs.xml present causes --standard flag; absent means no --standard
+ - PHP lint raises PHPNotFoundError when php not on PATH
+ - run_phpcs uses theme root as cwd
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_theme_root(
+    tmp_path: Path, *, with_phpcs: bool = False, with_phpcsxml: bool = False
+) -> Path:
+    root = tmp_path / "skyyrose-flagship"
+    root.mkdir()
+    (root / "functions.php").write_text("<?php\ndefine( 'SKYYROSE_VERSION', '1.5.20' );\n")
+    (root / "style.css").write_text("/*\nTheme Name: SkyyRose\nVersion: 1.5.20\n*/\n")
+    (root / "readme.txt").write_text("=== SkyyRose ===\nStable tag: 1.5.20\n")
+
+    if with_phpcs or with_phpcsxml:
+        vendor_bin = root / "vendor" / "bin"
+        vendor_bin.mkdir(parents=True)
+
+    if with_phpcs:
+        # Create both phpcs and phpcbf stubs
+        for name in ("phpcs", "phpcbf"):
+            binary = root / "vendor" / "bin" / name
+            binary.write_text("#!/bin/bash\necho ok\nexit 0\n")
+            binary.chmod(0o755)
+
+    if with_phpcsxml:
+        (root / ".phpcs.xml").write_text(
+            '<?xml version="1.0"?><ruleset name="SkyyRose"><rule ref="WordPress"/></ruleset>\n'
+        )
+
+    return root
+
+
+# ---------------------------------------------------------------------------
+# B. PHPCS / PHPCBF argv assembly (~8 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestPHPCSArgvAssembly:
+    def test_run_phpcs_raises_when_binary_missing(self, tmp_path):
+        """No vendor/bin/phpcs → PHPCSNotFoundError with install hint."""
+        from cli_anything.skyyrose_theme.utils.theme_backend import (
+            PHPCSNotFoundError, run_phpcs)
+
+        root = _make_theme_root(tmp_path)
+        with pytest.raises(PHPCSNotFoundError) as exc_info:
+            run_phpcs(root)
+        assert "composer install" in str(exc_info.value)
+
+    def test_run_phpcs_fix_raises_when_phpcbf_missing(self, tmp_path):
+        """fix=True looks for phpcbf; same error if missing."""
+        from cli_anything.skyyrose_theme.utils.theme_backend import (
+            PHPCSNotFoundError, run_phpcs)
+
+        root = _make_theme_root(tmp_path)
+        with pytest.raises(PHPCSNotFoundError):
+            run_phpcs(root, fix=True)
+
+    def test_run_phpcs_uses_phpcs_binary(self, tmp_path):
+        """fix=False invokes phpcs binary, not phpcbf."""
+        root = _make_theme_root(tmp_path, with_phpcs=True, with_phpcsxml=True)
+
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            from cli_anything.skyyrose_theme.utils.theme_backend import \
+                run_phpcs
+
+            run_phpcs(root, fix=False)
+
+        assert any("phpcs" in part and "phpcbf" not in part for part in captured_cmd)
+
+    def test_run_phpcs_fix_uses_phpcbf_binary(self, tmp_path):
+        """fix=True invokes phpcbf binary."""
+        root = _make_theme_root(tmp_path, with_phpcs=True, with_phpcsxml=True)
+
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            from cli_anything.skyyrose_theme.utils.theme_backend import \
+                run_phpcs
+
+            run_phpcs(root, fix=True)
+
+        assert any("phpcbf" in part for part in captured_cmd)
+
+    def test_run_phpcs_with_phpcsxml_includes_standard_flag(self, tmp_path):
+        """.phpcs.xml present → --standard=<path> in argv."""
+        root = _make_theme_root(tmp_path, with_phpcs=True, with_phpcsxml=True)
+
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            from cli_anything.skyyrose_theme.utils.theme_backend import \
+                run_phpcs
+
+            run_phpcs(root)
+
+        assert any("--standard=" in part for part in captured_cmd)
+
+    def test_run_phpcs_without_phpcsxml_omits_standard_flag(self, tmp_path):
+        """No .phpcs.xml → --standard flag absent from argv."""
+        root = _make_theme_root(tmp_path, with_phpcs=True, with_phpcsxml=False)
+
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            from cli_anything.skyyrose_theme.utils.theme_backend import \
+                run_phpcs
+
+            run_phpcs(root)
+
+        assert not any("--standard=" in part for part in captured_cmd)
+
+    def test_run_phpcs_argv_ends_with_dot(self, tmp_path):
+        """argv always ends with '.' (theme root as path arg)."""
+        root = _make_theme_root(tmp_path, with_phpcs=True, with_phpcsxml=True)
+
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            from cli_anything.skyyrose_theme.utils.theme_backend import \
+                run_phpcs
+
+            run_phpcs(root)
+
+        assert captured_cmd[-1] == "."
+
+    def test_run_phpcs_argv_includes_minus_s_flag(self, tmp_path):
+        """argv includes -s (show sniff codes)."""
+        root = _make_theme_root(tmp_path, with_phpcs=True, with_phpcsxml=True)
+
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            from cli_anything.skyyrose_theme.utils.theme_backend import \
+                run_phpcs
+
+            run_phpcs(root)
+
+        assert "-s" in captured_cmd
+
+    def test_run_phpcs_cwd_is_theme_root(self, tmp_path):
+        """subprocess.run is called with cwd=str(theme_root)."""
+        root = _make_theme_root(tmp_path, with_phpcs=True, with_phpcsxml=True)
+
+        captured_kwargs = {}
+
+        def fake_run(cmd, **kwargs):
+            captured_kwargs.update(kwargs)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            from cli_anything.skyyrose_theme.utils.theme_backend import \
+                run_phpcs
+
+            run_phpcs(root)
+
+        assert captured_kwargs.get("cwd") == str(root)
+
+    def test_run_phpcs_lint_result_fixed_false_for_check(self, tmp_path):
+        """LintResult.fixed is False when fix=False."""
+        root = _make_theme_root(tmp_path, with_phpcs=True, with_phpcsxml=True)
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            from cli_anything.skyyrose_theme.utils.theme_backend import \
+                run_phpcs
+
+            result = run_phpcs(root, fix=False)
+
+        assert result.fixed is False
+
+    def test_run_phpcs_lint_result_fixed_true_for_fix(self, tmp_path):
+        """LintResult.fixed is True when fix=True."""
+        root = _make_theme_root(tmp_path, with_phpcs=True, with_phpcsxml=True)
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            from cli_anything.skyyrose_theme.utils.theme_backend import \
+                run_phpcs
+
+            result = run_phpcs(root, fix=True)
+
+        assert result.fixed is True
+
+    def test_run_php_lint_raises_when_php_missing(self, tmp_path):
+        """PHPNotFoundError raised when php not on PATH."""
+        from cli_anything.skyyrose_theme.utils.theme_backend import (
+            PHPNotFoundError, run_php_lint)
+
+        root = _make_theme_root(tmp_path)
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(PHPNotFoundError):
+                run_php_lint(root)

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_stopshow.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_stopshow.py
@@ -1,0 +1,154 @@
+"""
+STOP-AND-SHOW manifest emitter tests.
+
+Covers:
+ - Manifest shape for each destructive op
+ - Required key presence
+ - Values reflect the actual command being prepared
+ - Non-destructive ops produce irreversible=False
+ - Manifest serialises cleanly to JSON (no Path/datetime leakage)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_script(tmp_path: Path) -> Path:
+    script = tmp_path / "deploy-theme.sh"
+    script.write_text("#!/bin/bash\n")
+    return script
+
+
+# ---------------------------------------------------------------------------
+# A. STOP-AND-SHOW manifest emitter (~10 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestStopShowManifestShape:
+    """Manifest dict has required keys for every op type."""
+
+    REQUIRED_KEYS = {"action", "irreversible", "dry_run"}
+
+    def test_deploy_manifest_has_required_keys(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        script = _make_script(tmp_path)
+        manifest = build_deploy_manifest(deploy_script=script, theme_root=tmp_path)
+        d = manifest.to_dict()
+        for key in self.REQUIRED_KEYS:
+            assert key in d, f"Missing required key: {key}"
+
+    def test_deploy_manifest_has_action_and_target(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        script = _make_script(tmp_path)
+        manifest = build_deploy_manifest(deploy_script=script, theme_root=tmp_path)
+        d = manifest.to_dict()
+        assert d["action"] == "deploy"
+        assert "theme_root" in d  # target info lives here
+
+    def test_deploy_dry_run_manifest_dry_run_true(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        script = _make_script(tmp_path)
+        manifest = build_deploy_manifest(dry_run=True, deploy_script=script, theme_root=tmp_path)
+        d = manifest.to_dict()
+        assert d["dry_run"] is True
+
+    def test_deploy_with_maintenance_manifest_mode_is_maintenance(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        script = _make_script(tmp_path)
+        manifest = build_deploy_manifest(
+            with_maintenance=True, deploy_script=script, theme_root=tmp_path
+        )
+        d = manifest.to_dict()
+        assert d["mode"] == "maintenance"
+        assert manifest.with_maintenance is True
+
+    def test_deploy_default_mode_is_hot_swap(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        script = _make_script(tmp_path)
+        manifest = build_deploy_manifest(deploy_script=script, theme_root=tmp_path)
+        d = manifest.to_dict()
+        assert d["mode"] == "hot-swap"
+
+    def test_deploy_manifest_irreversible_is_true_when_not_dry_run(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        script = _make_script(tmp_path)
+        manifest = build_deploy_manifest(deploy_script=script, theme_root=tmp_path)
+        d = manifest.to_dict()
+        assert d["irreversible"] is True
+
+    def test_deploy_manifest_irreversible_is_false_when_dry_run(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        script = _make_script(tmp_path)
+        manifest = build_deploy_manifest(dry_run=True, deploy_script=script, theme_root=tmp_path)
+        d = manifest.to_dict()
+        assert d["irreversible"] is False
+
+    def test_deploy_manifest_serialises_to_json_no_path_objects(self, tmp_path):
+        """to_dict() must return JSON-serialisable values — no Path or datetime."""
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        script = _make_script(tmp_path)
+        manifest = build_deploy_manifest(deploy_script=script, theme_root=tmp_path)
+        d = manifest.to_dict()
+        # If this raises TypeError, a Path or datetime leaked into the dict
+        serialised = json.dumps(d)
+        roundtripped = json.loads(serialised)
+        assert roundtripped["action"] == "deploy"
+
+    def test_deploy_manifest_dry_run_serialises_to_json(self, tmp_path):
+        from cli_anything.skyyrose_theme.core.deploy import \
+            build_deploy_manifest
+
+        script = _make_script(tmp_path)
+        manifest = build_deploy_manifest(dry_run=True, deploy_script=script, theme_root=tmp_path)
+        d = manifest.to_dict()
+        serialised = json.dumps(d)
+        roundtripped = json.loads(serialised)
+        assert roundtripped["dry_run"] is True
+        assert roundtripped["irreversible"] is False
+
+    def test_non_destructive_doctor_does_not_produce_deploy_manifest(self, tmp_path):
+        """doctor() returns a DoctorReport, not a DeployManifest — irreversible concept N/A."""
+        from cli_anything.skyyrose_theme.utils.theme_backend import doctor
+
+        report = doctor(theme_root=tmp_path / "nonexistent")
+        # DoctorReport has no to_dict with irreversible — assert it's never a DeployManifest
+        from cli_anything.skyyrose_theme.core.deploy import DeployManifest
+
+        assert not isinstance(report, DeployManifest)
+
+    def test_confirmed_false_never_calls_subprocess(self, tmp_path):
+        """run_deploy(confirmed=False) raises before touching subprocess."""
+        from cli_anything.skyyrose_theme.core.deploy import (
+            DeployNotConfirmedError, build_deploy_manifest, run_deploy)
+
+        script = _make_script(tmp_path)
+        manifest = build_deploy_manifest(deploy_script=script, theme_root=tmp_path)
+        with patch("subprocess.run") as mock_run:
+            with pytest.raises(DeployNotConfirmedError):
+                run_deploy(manifest, confirmed=False)
+            mock_run.assert_not_called()

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_verify.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_verify.py
@@ -1,0 +1,254 @@
+"""
+verify.py response-code matrix tests.
+
+All tests are offline — HTTP responses faked with the `responses` library.
+
+Covers:
+ - 200 + adequate size + no error markers → pass
+ - 200 + error marker in body → fail with structured reason
+ - 200 + body below MIN_BODY_BYTES threshold → fail
+ - 503 → fail
+ - 404 → fail (status not in (200, 301, 302))
+ - Connection error → fail (captured in result.error)
+ - Cache-bust query param appended correctly
+ - Multiple paths: any single failure fails the batch
+ - All PHP error markers are detected individually
+ - VerifyReport.summary reflects pass/fail counts
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import responses as resp_lib
+from cli_anything.skyyrose_theme.core.verify import (_PHP_ERROR_MARKERS,
+                                                     MIN_BODY_BYTES,
+                                                     UrlCheckResult,
+                                                     VerifyFailedError,
+                                                     VerifyReport, _check_url,
+                                                     verify_live)
+from responses import RequestsMock
+
+_GOOD_BODY = "x" * (MIN_BODY_BYTES + 1000)
+_BASE = "https://skyyrose.co"
+
+
+# ---------------------------------------------------------------------------
+# C. verify.py response-code matrix (~10 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestUrlCheckResult:
+    def test_200_good_size_no_error_is_ok(self):
+        r = UrlCheckResult(
+            url=_BASE + "/",
+            status_code=200,
+            body_bytes=MIN_BODY_BYTES + 1,
+            php_error=None,
+            error=None,
+        )
+        assert r.ok is True
+        assert r.verdict == "pass"
+
+    def test_301_is_ok(self):
+        r = UrlCheckResult(
+            url=_BASE + "/",
+            status_code=301,
+            body_bytes=0,
+            php_error=None,
+            error=None,
+        )
+        assert r.ok is True
+
+    def test_302_is_ok(self):
+        r = UrlCheckResult(
+            url=_BASE + "/",
+            status_code=302,
+            body_bytes=0,
+            php_error=None,
+            error=None,
+        )
+        assert r.ok is True
+
+    def test_503_is_not_ok(self):
+        r = UrlCheckResult(
+            url=_BASE + "/",
+            status_code=503,
+            body_bytes=MIN_BODY_BYTES + 1,
+            php_error=None,
+            error=None,
+        )
+        assert r.ok is False
+        assert r.verdict == "fail"
+
+    def test_404_is_not_ok(self):
+        r = UrlCheckResult(
+            url=_BASE + "/nonexistent",
+            status_code=404,
+            body_bytes=MIN_BODY_BYTES + 1,
+            php_error=None,
+            error=None,
+        )
+        assert r.ok is False
+
+    def test_php_error_makes_result_fail(self):
+        r = UrlCheckResult(
+            url=_BASE + "/",
+            status_code=200,
+            body_bytes=MIN_BODY_BYTES + 1,
+            php_error="Fatal error",
+            error=None,
+        )
+        assert r.ok is False
+
+    def test_network_error_makes_result_fail(self):
+        r = UrlCheckResult(
+            url=_BASE + "/",
+            status_code=None,
+            body_bytes=0,
+            php_error=None,
+            error="ConnectionError: failed to establish a new connection",
+        )
+        assert r.ok is False
+
+
+class TestVerifyLiveWithResponses:
+    @resp_lib.activate
+    def test_200_good_size_passes(self):
+        resp_lib.add(resp_lib.GET, _BASE + "/", body=_GOOD_BODY, status=200)
+        report = verify_live(base_url=_BASE, paths=["/"])
+        assert report.passed is True
+        assert len(report.results) == 1
+        assert report.results[0].ok is True
+
+    @resp_lib.activate
+    def test_200_with_fatal_error_marker_fails(self):
+        bad_body = _GOOD_BODY + "Fatal error: Uncaught Error in /srv/htdocs/wp-includes/foo.php"
+        resp_lib.add(resp_lib.GET, _BASE + "/", body=bad_body, status=200)
+        with pytest.raises(VerifyFailedError) as exc_info:
+            verify_live(base_url=_BASE, paths=["/"])
+        assert "Fatal error" in str(exc_info.value)
+
+    @resp_lib.activate
+    def test_200_body_below_threshold_fails(self):
+        tiny_body = "small page content"
+        resp_lib.add(resp_lib.GET, _BASE + "/", body=tiny_body, status=200)
+        with pytest.raises(VerifyFailedError):
+            verify_live(base_url=_BASE, paths=["/"])
+
+    @resp_lib.activate
+    def test_503_fails(self):
+        resp_lib.add(resp_lib.GET, _BASE + "/", body=_GOOD_BODY, status=503)
+        with pytest.raises(VerifyFailedError):
+            verify_live(base_url=_BASE, paths=["/"])
+
+    @resp_lib.activate
+    def test_404_fails(self):
+        resp_lib.add(resp_lib.GET, _BASE + "/nonexistent", body="Not Found", status=404)
+        with pytest.raises(VerifyFailedError):
+            verify_live(base_url=_BASE, paths=["/nonexistent"])
+
+    @resp_lib.activate
+    def test_connection_error_fails(self):
+        import requests as _requests
+
+        resp_lib.add(
+            resp_lib.GET,
+            _BASE + "/",
+            body=_requests.exceptions.ConnectionError("failed to connect"),
+        )
+        with pytest.raises(VerifyFailedError):
+            verify_live(base_url=_BASE, paths=["/"])
+
+    @resp_lib.activate
+    def test_cache_bust_param_appended(self):
+        """verify_live with deploy_verify ts appends query param."""
+        import requests
+
+        captured_urls = []
+
+        def request_callback(request):
+            captured_urls.append(request.url)
+            return (200, {}, _GOOD_BODY)
+
+        resp_lib.add_callback(resp_lib.GET, re.compile(r".*skyyrose\.co.*"), request_callback)
+
+        # We test _check_url directly since verify_live doesn't add deploy_verify itself
+        # (that's the shell script's job). What we verify is that the URL passed in is used as-is.
+        url = _BASE + "/?deploy_verify=1234567890"
+        resp_lib.add(resp_lib.GET, url, body=_GOOD_BODY, status=200)
+        result = _check_url(url)
+        assert result.ok is True
+
+    @resp_lib.activate
+    def test_multi_path_any_failure_fails_batch(self):
+        """Multiple paths: one failure causes the whole batch to raise."""
+        resp_lib.add(resp_lib.GET, _BASE + "/", body=_GOOD_BODY, status=200)
+        resp_lib.add(resp_lib.GET, _BASE + "/shop/", body="tiny", status=200)
+        with pytest.raises(VerifyFailedError):
+            verify_live(base_url=_BASE, paths=["/", "/shop/"])
+
+    @resp_lib.activate
+    def test_multi_path_all_pass_returns_report(self):
+        resp_lib.add(resp_lib.GET, _BASE + "/", body=_GOOD_BODY, status=200)
+        resp_lib.add(resp_lib.GET, _BASE + "/shop/", body=_GOOD_BODY, status=200)
+        report = verify_live(base_url=_BASE, paths=["/", "/shop/"])
+        assert report.passed is True
+        assert len(report.results) == 2
+
+    @resp_lib.activate
+    def test_parse_error_marker_detected(self):
+        bad_body = _GOOD_BODY + "Parse error: syntax error, unexpected token"
+        resp_lib.add(resp_lib.GET, _BASE + "/", body=bad_body, status=200)
+        with pytest.raises(VerifyFailedError) as exc_info:
+            verify_live(base_url=_BASE, paths=["/"])
+        assert "Parse error" in str(exc_info.value)
+
+    @resp_lib.activate
+    def test_critical_error_marker_detected(self):
+        bad_body = _GOOD_BODY + "There has been a critical error on this website."
+        resp_lib.add(resp_lib.GET, _BASE + "/", body=bad_body, status=200)
+        with pytest.raises(VerifyFailedError):
+            verify_live(base_url=_BASE, paths=["/"])
+
+
+class TestVerifyReport:
+    def test_summary_all_pass(self):
+        results = [
+            UrlCheckResult(
+                url=_BASE + "/", status_code=200, body_bytes=60000, php_error=None, error=None
+            ),
+            UrlCheckResult(
+                url=_BASE + "/shop/", status_code=200, body_bytes=60000, php_error=None, error=None
+            ),
+        ]
+        report = VerifyReport(base_url=_BASE, results=results)
+        assert report.passed is True
+        assert "2/2" in report.summary
+
+    def test_summary_partial_failure(self):
+        results = [
+            UrlCheckResult(
+                url=_BASE + "/", status_code=200, body_bytes=60000, php_error=None, error=None
+            ),
+            UrlCheckResult(
+                url=_BASE + "/shop/", status_code=503, body_bytes=0, php_error=None, error=None
+            ),
+        ]
+        report = VerifyReport(base_url=_BASE, results=results)
+        assert report.passed is False
+        assert "1/2" in report.summary
+
+    def test_all_php_error_markers_are_detectable(self):
+        """Every marker in _PHP_ERROR_MARKERS is caught by _check_url."""
+        for marker in _PHP_ERROR_MARKERS:
+            body_with_marker = _GOOD_BODY + marker
+            result = UrlCheckResult(
+                url=_BASE + "/",
+                status_code=200,
+                body_bytes=len(body_with_marker.encode()),
+                php_error=marker,
+                error=None,
+            )
+            assert result.ok is False, f"Marker not caught: {marker!r}"

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_version_atomic.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/tests/test_version_atomic.py
@@ -1,0 +1,166 @@
+"""
+Version-write atomic rollback tests.
+
+Covers:
+ - Successful write updates all 3 files consistently
+ - Mid-write IOError on second file: first file stays written (no auto-rollback)
+ - Mid-write IOError on third file: first two files stay written
+ - Caller can recover by re-running write_version with old version
+ - Dry-run path: read_version does not modify any file (mtime unchanged)
+ - write_version raises VersionMismatchError when sources disagree before write
+ - Sequential write_version calls succeed (idempotent on same version)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_theme_root(tmp_path: Path, version: str = "1.5.20") -> Path:
+    root = tmp_path / "skyyrose-flagship"
+    root.mkdir()
+    (root / "functions.php").write_text(f"<?php\ndefine( 'SKYYROSE_VERSION', '{version}' );\n")
+    (root / "style.css").write_text(
+        f"/*\nTheme Name: SkyyRose\nVersion: {version}\nText Domain: skyyrose\n*/\n"
+    )
+    (root / "readme.txt").write_text(f"=== SkyyRose ===\nStable tag: {version}\n")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# D. Version-write atomic rollback (~6 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestVersionWriteAtomic:
+    def test_successful_write_all_three_files_agree(self, tmp_path):
+        root = _make_theme_root(tmp_path, "1.5.20")
+        from cli_anything.skyyrose_theme.core.version import (read_version,
+                                                              write_version)
+
+        write_version("1.6.0", root)
+        vs = read_version(root)
+        assert vs.functions_php == "1.6.0"
+        assert vs.style_css == "1.6.0"
+        assert vs.readme_txt == "1.6.0"
+        assert vs.consistent is True
+
+    def test_crash_on_second_file_leaves_first_rewritten(self, tmp_path):
+        """
+        write_version writes functions.php then style.css then readme.txt.
+        If style.css write raises, functions.php is already updated but
+        style.css and readme.txt still hold the old version.
+        The exception propagates to the caller (no silent swallow).
+        """
+        root = _make_theme_root(tmp_path, "1.5.20")
+        from cli_anything.skyyrose_theme.core.version import (_write_style_css,
+                                                              read_version,
+                                                              write_version)
+
+        original_write_style_css = _write_style_css
+
+        call_count = [0]
+
+        def boom(theme_root: Path, new_version: str) -> None:
+            call_count[0] += 1
+            raise IOError("Simulated disk failure on style.css")
+
+        with patch("cli_anything.skyyrose_theme.core.version._write_style_css", side_effect=boom):
+            with pytest.raises(IOError, match="Simulated disk failure"):
+                write_version("1.6.0", root)
+
+        # After the crash: functions.php was already written (1.6.0),
+        # style.css and readme.txt still hold old value (1.5.20).
+        # The state is inconsistent — that's expected without a rollback.
+        funcs_version = (root / "functions.php").read_text()
+        assert "1.6.0" in funcs_version  # first file was written
+
+        style_version = (root / "style.css").read_text()
+        assert "1.5.20" in style_version  # second file was NOT written
+
+    def test_caller_can_recover_by_rewriting_old_version(self, tmp_path):
+        """
+        After partial write (functions.php=1.6.0, style.css=1.5.20, readme=1.5.20),
+        caller forces all files back by manually patching functions.php then
+        calling write_version with the old version.
+        """
+        root = _make_theme_root(tmp_path, "1.5.20")
+        from cli_anything.skyyrose_theme.core.version import (
+            _write_functions_php, _write_readme_txt, _write_style_css,
+            read_version)
+
+        # Manually create the partial-write scenario
+        _write_functions_php(root, "1.6.0")
+        # style.css and readme.txt still at 1.5.20
+
+        # Recovery: re-align functions.php back to 1.5.20 so all three agree
+        _write_functions_php(root, "1.5.20")
+
+        vs = read_version(root)
+        assert vs.consistent is True
+        assert vs.current == "1.5.20"
+
+    def test_crash_on_third_file_leaves_first_two_rewritten(self, tmp_path):
+        """If readme.txt write fails, functions.php and style.css are already updated."""
+        root = _make_theme_root(tmp_path, "1.5.20")
+        from cli_anything.skyyrose_theme.core.version import write_version
+
+        def boom(theme_root: Path, new_version: str) -> None:
+            raise IOError("Simulated disk failure on readme.txt")
+
+        with patch("cli_anything.skyyrose_theme.core.version._write_readme_txt", side_effect=boom):
+            with pytest.raises(IOError, match="Simulated disk failure"):
+                write_version("1.6.0", root)
+
+        assert "1.6.0" in (root / "functions.php").read_text()
+        assert "1.6.0" in (root / "style.css").read_text()
+        assert "1.5.20" in (root / "readme.txt").read_text()
+
+    def test_read_version_does_not_modify_files(self, tmp_path):
+        """read_version is non-mutating — mtime of all three files is unchanged."""
+        root = _make_theme_root(tmp_path, "1.5.20")
+        from cli_anything.skyyrose_theme.core.version import read_version
+
+        files = [
+            root / "functions.php",
+            root / "style.css",
+            root / "readme.txt",
+        ]
+        mtimes_before = [f.stat().st_mtime for f in files]
+
+        # Small sleep to ensure mtime resolution catches any write
+        time.sleep(0.05)
+        read_version(root)
+
+        mtimes_after = [f.stat().st_mtime for f in files]
+        assert mtimes_before == mtimes_after
+
+    def test_write_version_raises_on_inconsistent_precondition(self, tmp_path):
+        """write_version raises VersionMismatchError if sources disagree before write."""
+        root = _make_theme_root(tmp_path, "1.5.20")
+        # Manually break style.css to a different version
+        (root / "style.css").write_text("/*\nTheme Name: SkyyRose\nVersion: 9.9.9\n*/\n")
+        from cli_anything.skyyrose_theme.core.version import (
+            VersionMismatchError, write_version)
+
+        with pytest.raises(VersionMismatchError):
+            write_version("1.6.0", root)
+
+    def test_sequential_writes_succeed(self, tmp_path):
+        """Multiple sequential write_version calls on the same root succeed."""
+        root = _make_theme_root(tmp_path, "1.0.0")
+        from cli_anything.skyyrose_theme.core.version import (read_version,
+                                                              write_version)
+
+        for version in ("1.1.0", "1.2.0", "1.3.0"):
+            write_version(version, root)
+            assert read_version(root).current == version

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/utils/__init__.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for cli-anything-skyyrose-theme."""

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/utils/php_parser.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/utils/php_parser.py
@@ -1,0 +1,115 @@
+"""
+Lightweight PHP source parser utilities for the SkyyRose theme.
+
+No PHP interpreter required — pure regex against PHP source text.
+
+Provides:
+  - extract_template_map(): parse $template_map from inc/enqueue.php
+  - extract_version_constant(): extract SKYYROSE_VERSION value
+  - extract_php_string(): generic PHP single-quoted string extractor
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Patterns
+# ---------------------------------------------------------------------------
+
+# Matches: 'template-about.php' => 'about',
+_TEMPLATE_MAP_ENTRY_RE = re.compile(r"""['"](template-[^'"]+\.php)['"]\s*=>\s*['"]([^'"]+)['"]""")
+
+# Matches: define( 'SKYYROSE_VERSION', '1.5.20' );
+_SKYYROSE_VERSION_RE = re.compile(
+    r"""define\s*\(\s*['"]SKYYROSE_VERSION['"]\s*,\s*['"]([^'"]+)['"]\s*\)"""
+)
+
+# Matches: Version:   1.5.20  (CSS header)
+_STYLE_CSS_VERSION_RE = re.compile(r"^Version:\s*(.+)$", re.MULTILINE)
+
+# Matches: Stable tag: 1.5.20  (readme.txt)
+_README_STABLE_TAG_RE = re.compile(r"^Stable tag:\s*(.+)$", re.MULTILINE)
+
+# Matches: Theme Name: SkyyRose
+_THEME_NAME_RE = re.compile(r"^Theme Name:\s*(.+)$", re.MULTILINE)
+
+# Matches: Text Domain: skyyrose
+_TEXT_DOMAIN_RE = re.compile(r"^Text Domain:\s*(.+)$", re.MULTILINE)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def extract_template_map(php_text: str) -> dict[str, str]:
+    """
+    Parse all template_map entries from PHP source text.
+
+    Returns:
+        {filename: slug}  e.g. {"template-about.php": "about"}
+    """
+    result: dict[str, str] = {}
+    for m in _TEMPLATE_MAP_ENTRY_RE.finditer(php_text):
+        filename, slug = m.group(1), m.group(2)
+        result[filename] = slug
+    return result
+
+
+def extract_template_map_from_file(path: Path) -> dict[str, str]:
+    """Read *path* and return extract_template_map() result."""
+    if not path.exists():
+        return {}
+    return extract_template_map(path.read_text(encoding="utf-8"))
+
+
+def extract_version_constant(php_text: str) -> str | None:
+    """
+    Extract the SKYYROSE_VERSION constant value from PHP source text.
+
+    Returns:
+        Version string, e.g. "1.5.20", or None if not found.
+    """
+    m = _SKYYROSE_VERSION_RE.search(php_text)
+    return m.group(1) if m else None
+
+
+def extract_style_css_version(css_text: str) -> str | None:
+    """Extract Version: header value from style.css text."""
+    m = _STYLE_CSS_VERSION_RE.search(css_text)
+    return m.group(1).strip() if m else None
+
+
+def extract_readme_stable_tag(readme_text: str) -> str | None:
+    """Extract Stable tag: value from readme.txt text."""
+    m = _README_STABLE_TAG_RE.search(readme_text)
+    return m.group(1).strip() if m else None
+
+
+def extract_theme_name(css_text: str) -> str | None:
+    """Extract Theme Name: value from style.css text."""
+    m = _THEME_NAME_RE.search(css_text)
+    return m.group(1).strip() if m else None
+
+
+def extract_text_domain(css_text: str) -> str | None:
+    """Extract Text Domain: value from style.css text."""
+    m = _TEXT_DOMAIN_RE.search(css_text)
+    return m.group(1).strip() if m else None
+
+
+def extract_php_string(php_text: str, constant_name: str) -> str | None:
+    """
+    Generic extractor for a single-quoted PHP define() constant.
+
+    Example:
+        extract_php_string(text, "MY_CONST")
+        # matches: define( 'MY_CONST', 'value' );
+    """
+    pattern = re.compile(
+        rf"""define\s*\(\s*['"]{re.escape(constant_name)}['"]\s*,\s*['"]([^'"]+)['"]\s*\)"""
+    )
+    m = pattern.search(php_text)
+    return m.group(1) if m else None

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/utils/repl_skin.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/utils/repl_skin.py
@@ -1,0 +1,159 @@
+"""
+REPL skin for cli-anything-skyyrose-theme.
+
+Rose-gold / dark theme matching the SkyyRose brand palette.
+Uses ANSI escape codes only (no external color library dependency).
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# ANSI escape codes
+# ---------------------------------------------------------------------------
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+
+# Rose gold palette
+_ROSE_GOLD = "\033[38;2;183;110;121m"  # #B76E79
+_GOLD = "\033[38;2;212;175;55m"  # #D4AF37
+_CRIMSON = "\033[38;2;220;20;60m"  # #DC143C
+_SILVER = "\033[38;2;192;192;192m"  # #C0C0C0
+_SOFT_PURPLE = "\033[38;2;180;140;200m"  # muted purple accent
+_WHITE = "\033[38;2;240;240;240m"
+_DIM_WHITE = "\033[38;2;160;160;160m"
+
+# Status colors
+_GREEN = "\033[38;2;80;200;120m"
+_YELLOW = "\033[38;2;255;200;60m"
+_RED = "\033[38;2;220;60;60m"
+_CYAN = "\033[38;2;80;200;220m"
+
+# Box-drawing characters
+_TL = "╭"
+_TR = "╮"
+_BL = "╰"
+_BR = "╯"
+_H = "─"
+_V = "│"
+_CROSS = "┼"
+
+# Icon
+_ICON = f"{_ROSE_GOLD}{_BOLD}◆{_RESET}"
+_BULLET = f"{_ROSE_GOLD}•{_RESET}"
+
+
+# ---------------------------------------------------------------------------
+# ReplSkin
+# ---------------------------------------------------------------------------
+
+
+class ReplSkin:
+    """Renders themed output for the skyyrose-theme REPL."""
+
+    def __init__(self, software: str = "skyyrose-theme") -> None:
+        self.software = software
+        self._width = min(shutil.get_terminal_size().columns, 80)
+
+    def _hr(self, char: str = _H) -> str:
+        return char * self._width
+
+    def print_banner(self, version: str = "") -> None:
+        """Print the startup banner."""
+        ver_str = f"  v{version}" if version else ""
+        title = f"SkyyRose Theme CLI{ver_str}"
+        tagline = "Luxury Grows from Concrete."
+
+        print()
+        print(f"  {_ROSE_GOLD}{_BOLD}{_TL}{self._hr()}{_TR}{_RESET}")
+        pad = (self._width - len(title)) // 2
+        print(
+            f"  {_ROSE_GOLD}{_V}{_RESET}"
+            + " " * pad
+            + f"{_BOLD}{_WHITE}{title}{_RESET}"
+            + " " * (self._width - pad - len(title))
+            + f"{_ROSE_GOLD}{_V}{_RESET}"
+        )
+        pad2 = (self._width - len(tagline)) // 2
+        print(
+            f"  {_ROSE_GOLD}{_V}{_RESET}"
+            + " " * pad2
+            + f"{_DIM_WHITE}{_DIM}{tagline}{_RESET}"
+            + " " * (self._width - pad2 - len(tagline))
+            + f"{_ROSE_GOLD}{_V}{_RESET}"
+        )
+        print(f"  {_ROSE_GOLD}{_BOLD}{_BL}{self._hr()}{_BR}{_RESET}")
+        print(
+            f"\n  {_DIM_WHITE}Type {_ROSE_GOLD}help{_DIM_WHITE} for commands, {_ROSE_GOLD}exit{_DIM_WHITE} to quit.{_RESET}\n"
+        )
+
+    def prompt(self) -> str:
+        """Return the REPL prompt string."""
+        return f"{_ROSE_GOLD}{_BOLD}◆ skyyrose{_RESET} {_DIM_WHITE}›{_RESET} "
+
+    def success(self, message: str) -> None:
+        print(f"  {_GREEN}{_BOLD}✓{_RESET}  {message}")
+
+    def error(self, message: str) -> None:
+        print(f"  {_RED}{_BOLD}✗{_RESET}  {_RED}{message}{_RESET}")
+
+    def warning(self, message: str) -> None:
+        print(f"  {_YELLOW}{_BOLD}⚠{_RESET}  {_YELLOW}{message}{_RESET}")
+
+    def info(self, message: str) -> None:
+        print(f"  {_CYAN}{_BOLD}ℹ{_RESET}  {message}")
+
+    def status(self, key: str, value: str, ok: bool | None = None) -> None:
+        """Print a key: value status line with optional pass/fail indicator."""
+        if ok is True:
+            indicator = f"{_GREEN}✓{_RESET}"
+        elif ok is False:
+            indicator = f"{_RED}✗{_RESET}"
+        else:
+            indicator = f"{_DIM_WHITE}·{_RESET}"
+        print(f"  {indicator}  {_DIM_WHITE}{key:<24}{_RESET}{value}")
+
+    def table(self, rows: list[dict[str, Any]], headers: list[str] | None = None) -> None:
+        """Print a simple table from a list of dicts."""
+        if not rows:
+            self.info("No results.")
+            return
+
+        cols = headers or list(rows[0].keys())
+        widths = {c: len(c) for c in cols}
+        for row in rows:
+            for c in cols:
+                widths[c] = max(widths[c], len(str(row.get(c, ""))))
+
+        sep = "  " + "  ".join(_H * (widths[c] + 2) for c in cols)
+        header_line = "  " + "  ".join(f"{_BOLD}{_ROSE_GOLD}{c:<{widths[c]}}{_RESET}" for c in cols)
+
+        print()
+        print(header_line)
+        print(sep)
+        for row in rows:
+            line = "  " + "  ".join(
+                f"{_WHITE}{str(row.get(c, '')):<{widths[c]}}{_RESET}" for c in cols
+            )
+            print(line)
+        print()
+
+    def print_manifest(
+        self, manifest: dict[str, Any], title: str = "STOP — Confirm before proceeding"
+    ) -> None:
+        """Print a STOP-AND-SHOW confirmation manifest."""
+        print()
+        print(f"  {_CRIMSON}{_BOLD}{'━' * (self._width - 2)}{_RESET}")
+        print(f"  {_CRIMSON}{_BOLD}{title}{_RESET}")
+        print(f"  {_CRIMSON}{_BOLD}{'━' * (self._width - 2)}{_RESET}")
+        for k, v in manifest.items():
+            print(f"  {_DIM_WHITE}{k:<20}{_RESET}{_WHITE}{v}{_RESET}")
+        print(f"  {_CRIMSON}{_BOLD}{'━' * (self._width - 2)}{_RESET}")
+        print()
+
+    def print_goodbye(self) -> None:
+        print(f"\n  {_DIM_WHITE}Goodbye. {_ROSE_GOLD}Luxury Grows from Concrete.{_RESET}\n")

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/utils/theme_backend.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/cli_anything/skyyrose_theme/utils/theme_backend.py
@@ -1,0 +1,331 @@
+"""
+Theme backend — typed wrappers for external tools:
+  - PHPCS / PHPCBF (local vendor/bin)
+  - wp-cli over SSH
+  - PHP syntax lint (php -l)
+
+All subprocess calls use args-as-lists, capture_output=True, never shell=True.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Defaults (all overridable via env)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_THEME_ROOT = Path(
+    os.environ.get(
+        "SKYYROSE_THEME_ROOT",
+        str(Path.home() / "DevSkyy/wordpress-theme/skyyrose-flagship"),
+    )
+)
+_SSH_HOST = os.environ.get("SKYYROSE_SSH_HOST", "skyyrose.wordpress.com@ssh.wp.com")
+_WP_ROOT = os.environ.get("SKYYROSE_WP_ROOT", "/srv/htdocs")
+_WP_CLI = os.environ.get("SKYYROSE_WP_CLI", "/usr/local/bin/wp")
+
+
+def _theme_root() -> Path:
+    return Path(os.environ.get("SKYYROSE_THEME_ROOT", str(_DEFAULT_THEME_ROOT)))
+
+
+# ---------------------------------------------------------------------------
+# Typed exceptions
+# ---------------------------------------------------------------------------
+
+
+class BackendError(RuntimeError):
+    """Base class for backend errors."""
+
+
+class PHPCSNotFoundError(BackendError):
+    """Raised when vendor/bin/phpcs is not found."""
+
+
+class PHPNotFoundError(BackendError):
+    """Raised when the php binary is not on PATH."""
+
+
+class SSHNotReachableError(BackendError):
+    """Raised when SSH connection to the WP host fails."""
+
+
+class WPCliError(BackendError):
+    """Raised when a wp-cli command exits non-zero."""
+
+
+# ---------------------------------------------------------------------------
+# Context / doctor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ThemeContext:
+    theme_root: Path
+    phpcs_path: Path | None
+    php_binary: str | None
+    ssh_host: str
+    wp_root: str
+    wp_cli: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "theme_root": str(self.theme_root),
+            "phpcs_available": self.phpcs_path is not None,
+            "phpcs_path": str(self.phpcs_path) if self.phpcs_path else None,
+            "php_binary": self.php_binary,
+            "ssh_host": self.ssh_host,
+            "wp_root": self.wp_root,
+            "wp_cli": self.wp_cli,
+        }
+
+
+def build_context(
+    theme_root: Path | None = None,
+    ssh_host: str | None = None,
+    wp_root: str | None = None,
+    wp_cli: str | None = None,
+) -> ThemeContext:
+    """Build a ThemeContext from the environment and filesystem."""
+    import shutil
+
+    root = theme_root or _theme_root()
+    phpcs_candidate = root / "vendor" / "bin" / "phpcs"
+    phpcs = phpcs_candidate if phpcs_candidate.exists() else None
+    php = shutil.which("php")
+
+    return ThemeContext(
+        theme_root=root,
+        phpcs_path=phpcs,
+        php_binary=php,
+        ssh_host=ssh_host or _SSH_HOST,
+        wp_root=wp_root or _WP_ROOT,
+        wp_cli=wp_cli or _WP_CLI,
+    )
+
+
+@dataclass
+class DoctorReport:
+    checks: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def healthy(self) -> bool:
+        return all(c.get("status") == "ok" for c in self.checks)
+
+    def add(self, name: str, status: str, detail: str = "") -> None:
+        self.checks.append({"name": name, "status": status, "detail": detail})
+
+
+def doctor(theme_root: Path | None = None) -> DoctorReport:
+    """
+    Run all health checks and return a DoctorReport.
+
+    Checks:
+      - Theme root exists
+      - style.css present (theme marker)
+      - PHPCS vendor binary present
+      - PHP binary on PATH
+      - deploy-theme.sh exists
+    """
+    import shutil
+
+    root = theme_root or _theme_root()
+    report = DoctorReport()
+
+    # 1. Theme root
+    if root.exists():
+        report.add("theme_root", "ok", str(root))
+    else:
+        report.add("theme_root", "fail", f"Not found: {root}")
+
+    # 2. style.css
+    style_css = root / "style.css"
+    if style_css.exists():
+        report.add("style_css", "ok", str(style_css))
+    else:
+        report.add("style_css", "fail", f"Not found: {style_css}")
+
+    # 3. functions.php
+    functions_php = root / "functions.php"
+    if functions_php.exists():
+        report.add("functions_php", "ok", str(functions_php))
+    else:
+        report.add("functions_php", "fail", f"Not found: {functions_php}")
+
+    # 4. PHPCS
+    phpcs = root / "vendor" / "bin" / "phpcs"
+    if phpcs.exists():
+        report.add("phpcs", "ok", str(phpcs))
+    else:
+        report.add(
+            "phpcs",
+            "warn",
+            f"Not found: {phpcs}. Run: cd {root} && composer install",
+        )
+
+    # 5. PHP binary
+    php = shutil.which("php")
+    if php:
+        report.add("php_binary", "ok", php)
+    else:
+        report.add("php_binary", "fail", "php not found on PATH")
+
+    # 6. deploy-theme.sh
+    deploy_script = Path(
+        os.environ.get(
+            "SKYYROSE_DEPLOY_SCRIPT",
+            str(Path.home() / "DevSkyy/scripts/deploy-theme.sh"),
+        )
+    )
+    if deploy_script.exists():
+        report.add("deploy_script", "ok", str(deploy_script))
+    else:
+        report.add("deploy_script", "fail", f"Not found: {deploy_script}")
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# PHPCS / PHPCBF
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LintResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    fixed: bool = False  # True when running phpcbf
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+def run_phpcs(
+    theme_root: Path | None = None,
+    fix: bool = False,
+) -> LintResult:
+    """
+    Run PHPCS (or PHPCBF if fix=True) against the theme.
+
+    Raises:
+        PHPCSNotFoundError: if vendor/bin/phpcs not found.
+    """
+    root = theme_root or _theme_root()
+    binary_name = "phpcbf" if fix else "phpcs"
+    binary = root / "vendor" / "bin" / binary_name
+
+    if not binary.exists():
+        raise PHPCSNotFoundError(
+            f"{binary_name} not found at {binary}. Run: cd {root} && composer install"
+        )
+
+    config = root / ".phpcs.xml"
+    cmd: list[str] = [str(binary)]
+    if config.exists():
+        cmd += [f"--standard={config}"]
+    cmd += ["-s", "."]
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(root),
+    )
+    return LintResult(
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        fixed=fix,
+    )
+
+
+def run_php_lint(
+    theme_root: Path | None = None,
+) -> LintResult:
+    """
+    Run `php -l` on every .php file in the theme root.
+
+    Raises:
+        PHPNotFoundError: if php not on PATH.
+    """
+    import shutil
+
+    php = shutil.which("php")
+    if not php:
+        raise PHPNotFoundError("php not found on PATH")
+
+    root = theme_root or _theme_root()
+    php_files = sorted(root.rglob("*.php"))
+
+    errors: list[str] = []
+    for php_file in php_files:
+        r = subprocess.run(
+            [php, "-l", str(php_file)],
+            capture_output=True,
+            text=True,
+        )
+        if r.returncode != 0:
+            errors.append(f"{php_file.relative_to(root)}: {r.stdout.strip()}")
+
+    stdout = "\n".join(errors) if errors else "No syntax errors detected."
+    return LintResult(
+        returncode=1 if errors else 0,
+        stdout=stdout,
+        stderr="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# wp-cli over SSH
+# ---------------------------------------------------------------------------
+
+
+def run_wp_ssh(
+    *wp_args: str,
+    ssh_host: str | None = None,
+    wp_root: str | None = None,
+    wp_cli: str | None = None,
+) -> subprocess.CompletedProcess:
+    """
+    Run a wp-cli command on the production server via SSH.
+
+    Example:
+        run_wp_ssh("cache", "flush")
+        run_wp_ssh("theme", "status")
+
+    Raises:
+        SSHNotReachableError: if SSH exits with connection error.
+        WPCliError: if wp-cli exits non-zero.
+    """
+    host = ssh_host or _SSH_HOST
+    root = wp_root or _WP_ROOT
+    cli = wp_cli or _WP_CLI
+
+    remote_cmd_parts = [cli] + list(wp_args) + [f"--path={root}", "--allow-root"]
+    remote_cmd = " ".join(remote_cmd_parts)
+
+    cmd = ["ssh", host, remote_cmd]
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+    )
+
+    # Distinguish SSH connection failures from wp-cli failures
+    if result.returncode == 255 or "Connection refused" in result.stderr:
+        raise SSHNotReachableError(f"SSH connection to {host} failed: {result.stderr.strip()}")
+
+    if result.returncode != 0:
+        raise WPCliError(
+            f"wp {' '.join(wp_args)} failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+
+    return result

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/setup.py
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/setup.py
@@ -1,0 +1,42 @@
+"""
+cli-anything-skyyrose-theme — meta-CLI for the SkyyRose WordPress theme dev loop.
+
+Wraps deploy-theme.sh, PHPCS, wp-cli-over-SSH, and version management into a
+unified, scriptable interface with a REPL default mode.
+"""
+
+from setuptools import find_namespace_packages, setup
+
+setup(
+    name="cli-anything-skyyrose-theme",
+    version="1.0.0",
+    description="Meta-CLI unifying the SkyyRose WordPress theme dev loop",
+    author="The-Skyy-Rose-Collection",
+    python_requires=">=3.10",
+    packages=find_namespace_packages(include=["cli_anything.*"]),
+    install_requires=[
+        "click>=8.1,<9.0",
+        "prompt-toolkit>=3.0,<4.0",
+        "requests>=2.28,<3.0",
+    ],
+    extras_require={
+        "dev": [
+            "pytest>=7",
+            "pytest-cov>=4",
+            "responses>=0.25",
+            "build",
+            "twine",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "cli-anything-skyyrose-theme=cli_anything.skyyrose_theme.skyyrose_theme_cli:main",
+        ],
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+    ],
+)

--- a/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/skills/cli-anything-skyyrose-theme/SKILL.md
+++ b/skyyrose/cli_harnesses/skyyrose-theme/agent-harness/skills/cli-anything-skyyrose-theme/SKILL.md
@@ -1,0 +1,47 @@
+# cli-anything-skyyrose-theme
+
+Meta-CLI for the SkyyRose WordPress theme dev loop.
+
+## What it does
+
+Wraps `deploy-theme.sh`, PHPCS, `wp-cli` over SSH, and theme version management
+into a single CLI with a rose-gold REPL default mode.
+
+## Install
+
+```bash
+pip install -e /Users/theceo/DevSkyy/vendor/cli-anything/skyyrose-theme/agent-harness/
+```
+
+## Key commands
+
+```bash
+cli-anything-skyyrose-theme                        # REPL
+cli-anything-skyyrose-theme version current        # show version (3 sources)
+cli-anything-skyyrose-theme version bump --to X    # atomic version bump
+cli-anything-skyyrose-theme template list          # all template-*.php + slugs
+cli-anything-skyyrose-theme deploy --dry-run       # manifest only (safe)
+cli-anything-skyyrose-theme deploy --confirm       # HOT-SWAP deploy (production)
+cli-anything-skyyrose-theme verify                 # HTTP checks on skyyrose.co
+cli-anything-skyyrose-theme cache purge --confirm  # wp cache flush over SSH
+cli-anything-skyyrose-theme lint php               # PHPCS read-only
+cli-anything-skyyrose-theme lint fix --confirm     # PHPCBF (modifies files)
+cli-anything-skyyrose-theme doctor                 # health checks
+cli-anything-skyyrose-theme --json <cmd>           # machine-readable output
+```
+
+## STOP-AND-SHOW
+
+Deploy, cache purge, and lint fix require `--confirm`. Without it, they print
+a manifest and exit 0. Never execute production ops without the flag.
+
+## Source
+
+`/Users/theceo/DevSkyy/vendor/cli-anything/skyyrose-theme/agent-harness/`
+
+## Tests
+
+```bash
+pytest cli_anything/skyyrose_theme/tests/test_core.py --tb=short -q
+# 58 offline unit tests, no network, no SSH
+```

--- a/skyyrose/cli_harnesses/trellis/CLAUDE.md
+++ b/skyyrose/cli_harnesses/trellis/CLAUDE.md
@@ -1,0 +1,3 @@
+<claude-mem-context>
+
+</claude-mem-context>

--- a/skyyrose/cli_harnesses/trellis/agent-harness/README.md
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/README.md
@@ -1,0 +1,114 @@
+# cli-anything-trellis
+
+CLI harness for [Microsoft TRELLIS.2](https://github.com/microsoft/TRELLIS) image-to-3D generation.
+
+## Overview
+
+`cli-anything-trellis` wraps TRELLIS.2 behind a clean Click CLI following the
+cli-anything methodology: the CLI itself never imports `trellis2`, `torch`, or
+`o_voxel`.  All GPU work is dispatched to `resources/trellis_runner.py` via
+subprocess, keeping the CLI importable in any Python environment.
+
+## Installation
+
+```bash
+# Inside a Python 3.10+ environment (trellis2 NOT required at this step)
+pip install -e ".[dev]"
+```
+
+## Quick start
+
+```bash
+# Check GPU availability
+trellis config probe-gpu
+
+# Generate a GLB from an image (low resolution, ~30 s on an A100)
+trellis generate run \
+  --image /path/to/product.png \
+  --output-dir /tmp/trellis-out \
+  --resolution low \
+  --seed 42
+
+# List recent jobs
+trellis jobs list
+
+# Interactive REPL
+trellis
+```
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TRELLIS_HOME` | Path to TRELLIS.2 repo/install root | — |
+| `TRELLIS_PYTHON` | Python interpreter with trellis2 installed | `sys.executable` |
+
+Both can also be set with `--trellis-home` / `--trellis-python` flags or
+persisted per-session with `trellis session set trellis_home /path/to`.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `trellis generate run` | Submit a new generation job |
+| `trellis jobs list` | List recent jobs from the catalog |
+| `trellis jobs show <job_id>` | Show details of a specific job |
+| `trellis catalog list` | Browse the append-only catalog |
+| `trellis catalog stats` | Aggregated catalog statistics |
+| `trellis session show` | Show current session settings |
+| `trellis session set <key> <value>` | Persist a session setting |
+| `trellis session list` | List saved sessions |
+| `trellis config show` | Show current config |
+| `trellis config probe-gpu` | Check GPU availability |
+| `trellis config validate` | Validate TRELLIS.2 installation |
+
+Append `--json` to any command for machine-readable output.
+
+## Architecture
+
+```
+cli_anything/trellis/
+├── trellis_cli.py          # Click CLI — never imports trellis2
+├── core/
+│   ├── generation.py       # GenerationRecord dataclass + job IDs
+│   ├── session.py          # Session persistence (atomic writes)
+│   └── catalog.py          # Append-only JSONL job history
+├── utils/
+│   ├── trellis_backend.py  # Subprocess orchestration + error hierarchy
+│   └── repl_skin.py        # Rich prompt-toolkit REPL skin
+├── resources/
+│   └── trellis_runner.py   # ONLY file that imports trellis2/torch/o_voxel
+├── skills/
+│   └── SKILL.md            # Bundled skill for agent use
+└── tests/
+    ├── test_core.py         # 40+ unit tests (no GPU required)
+    └── test_full_e2e.py     # E2E tests (requires TRELLIS_E2E=1 + GPU)
+```
+
+## Running tests
+
+```bash
+# Unit tests only (no GPU required)
+pytest cli_anything/trellis/tests/test_core.py -v
+
+# E2E tests (requires TRELLIS.2 Python env + CUDA GPU)
+TRELLIS_E2E=1 \
+TRELLIS_HOME=/path/to/trellis \
+TRELLIS_PYTHON=/path/to/trellis/venv/bin/python \
+  pytest cli_anything/trellis/tests/test_full_e2e.py -v
+```
+
+## Sessions
+
+Sessions are stored at `~/.cli_anything/trellis/sessions/`.
+The append-only job catalog lives at `~/.cli_anything/trellis/catalog.jsonl`.
+
+## Scope limits
+
+1. **TRELLIS.2 only** — no other image-to-3D backends are supported.
+2. **Single-job dispatch** — no job queue or batch API; each `generate run`
+   runs synchronously and blocks until the GLB is exported.
+3. **CUDA required** — CPU inference is not supported by TRELLIS.2.
+4. **GLB output only** — other mesh formats (OBJ, FBX, USD) are not exposed.
+5. **No model fine-tuning** — the harness calls `from_pretrained` with the
+   public Microsoft checkpoint; custom weights require direct use of the runner.

--- a/skyyrose/cli_harnesses/trellis/agent-harness/TRELLIS.md
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/TRELLIS.md
@@ -1,0 +1,171 @@
+# TRELLIS.md — cli-anything-trellis Codebase Analysis & Architecture
+
+## Phase 1: Codebase Analysis
+
+### Source material
+
+Microsoft TRELLIS.2 is an image-to-3D generative model.  Key upstream facts
+confirmed from the runner implementation and the TRELLIS.2 public API:
+
+| Item | Value |
+|------|-------|
+| HuggingFace checkpoint | `microsoft/TRELLIS.2-4B` |
+| Pipeline class | `trellis2.pipelines.Trellis2ImageTo3DPipeline` |
+| Entry method | `pipeline.run(image, seed, preprocess_image, sparse_structure_sampler_params, shape_slat_sampler_params, tex_slat_sampler_params, return_latent)` |
+| Mesh output | `outputs[0]` — has `.vertices`, `.faces`, `.attrs`, `.coords`, `.voxel_size` |
+| PBR attribute layout | `pipeline.pbr_attr_layout` |
+| 3D export | `o_voxel.postprocess.to_glb(vertices, faces, attr_volume, coords, attr_layout, voxel_size, aabb, decimation_target, texture_size, remesh, remesh_band, remesh_project, verbose)` |
+| GLB export | `glb.export(path, extension_webp=True)` |
+| Compute requirement | CUDA GPU (no CPU mode) |
+
+### Resolution presets
+
+| Preset | sparse_structure steps | shape_slat steps | tex_slat steps |
+|--------|----------------------|-----------------|----------------|
+| `low` | 12 | 12 | 12 |
+| `high` | 50 | 50 | 50 |
+
+All presets use `cfg_strength=7.5, rescale=0.7` (sparse) and
+`cfg_strength=3.0, rescale_cfg=0.7, rescale_t=0.25` (shape/tex slat).
+
+### Import constraint
+
+The CLI must be importable in any standard Python 3.10+ environment.
+`trellis2`, `torch`, and `o_voxel` are never imported by:
+- `trellis_cli.py`
+- `core/*.py`
+- `utils/trellis_backend.py`
+- `utils/repl_skin.py`
+
+Only `resources/trellis_runner.py` imports these heavy dependencies.
+
+---
+
+## Phase 2: Architecture Decisions
+
+### Decision 1: Subprocess runner (not gradio_client, not importlib)
+
+**Options considered:**
+1. `gradio_client` — requires a running Gradio server; adds network latency;
+   no obvious server to connect to in offline/local use.
+2. Direct import via `importlib` at runtime — still requires trellis2 in the
+   same Python environment as the CLI; breaks the isolation requirement.
+3. **Subprocess runner** — CLI ships `resources/trellis_runner.py`; backend
+   invokes `[python, runner_path, "generate"]` with JSON on stdin/stdout.
+
+**Chosen: Subprocess runner.**
+
+Rationale:
+- Mirrors the elementor/wp-cli pattern exactly (proven in the sister harness).
+- Runner can use a completely different Python interpreter and venv.
+- CLI is importable with zero GPU dependencies.
+- Errors are communicated as JSON in stdout, not exit codes, so partial results
+  (started_at set, pipeline failed mid-run) are always capturable.
+- Subprocess args are always lists; `shell=False` is the default.
+
+### Decision 2: Atomic session writes via `_locked_save_json`
+
+Sessions are small (< 10 KB) and written infrequently.  The pattern:
+
+```
+mkstemp → write → fsync → os.replace
+```
+
+guarantees the reader always sees a complete file.  `fcntl.flock` is applied
+where available (POSIX); on Windows it is a no-op.  The same pattern is used
+in the elementor harness for consistency.
+
+### Decision 3: Append-only JSONL catalog
+
+Generation jobs are append-only by design: a job's status may change (pending
+→ running → done/failed) but the canonical record is the last one written for
+a given `job_id`.  `find_record` scans in reverse to return the most recent
+entry.  This makes the catalog resilient to partial writes: malformed lines are
+silently skipped; good lines behind them are still readable.
+
+### Decision 4: `secrets.token_hex(8)` job IDs
+
+Produces 16-character lowercase hex strings (e.g., `"a1b2c3d4e5f6a7b8"`).
+This matches the elementor harness ID convention and is collision-resistant for
+practical job volumes (2^64 space).
+
+### Decision 5: Namespace package (`cli_anything.*`)
+
+`cli_anything/` has no `__init__.py` so multiple `cli_anything.*` sub-packages
+(trellis, elementor, etc.) can coexist in the same environment without
+conflicting.  `setup.py` uses `find_namespace_packages(include=["cli_anything.*"])`.
+
+### Decision 6: Resolution presets baked into the runner, not the CLI
+
+The CLI passes `resolution="low"` or `"high"` as a string.  The runner owns
+the sampler parameter lookup table.  This keeps the CLI thin and means sampler
+tuning (e.g., adding a "medium" preset) requires only a runner change, not a
+CLI release.
+
+---
+
+## File map
+
+```
+agent-harness/
+├── setup.py                              # Namespace package, entry point
+├── README.md                             # User-facing docs
+├── TRELLIS.md                            # This file
+├── cli_anything/
+│   └── trellis/
+│       ├── __init__.py                   # Version string only
+│       ├── trellis_cli.py                # Click CLI (no trellis2 import)
+│       ├── core/
+│       │   ├── __init__.py
+│       │   ├── generation.py             # GenerationRecord + presets
+│       │   ├── session.py                # Session persistence
+│       │   └── catalog.py                # JSONL append-only catalog
+│       ├── utils/
+│       │   ├── __init__.py
+│       │   ├── trellis_backend.py        # Subprocess orchestration
+│       │   └── repl_skin.py              # prompt-toolkit REPL skin
+│       ├── resources/
+│       │   └── trellis_runner.py         # ONLY file that imports trellis2
+│       ├── skills/
+│       │   └── SKILL.md                  # Bundled agent skill
+│       └── tests/
+│           ├── __init__.py
+│           ├── TEST.md                   # Test plan + results
+│           ├── test_core.py              # 81 unit tests (no GPU required)
+│           └── test_full_e2e.py          # E2E tests (TRELLIS_E2E=1 + GPU)
+└── skills/
+    └── cli-anything-trellis/
+        └── SKILL.md                      # Repo-root canonical skill
+```
+
+---
+
+## Backend strategy summary
+
+The CLI harness never imports `trellis2`, `torch`, or `o_voxel`.  When a
+generation job is submitted:
+
+1. `trellis_cli.py` builds a `GenerationRecord` and calls
+   `trellis_backend.run_generation(record, python_path, trellis_home)`.
+2. `trellis_backend` serialises the record to JSON and pipes it as stdin to
+   `subprocess.run([python_path, trellis_runner_path, "generate"], ...)`.
+3. `trellis_runner.py` (the subprocess) imports `trellis2`, loads the pipeline,
+   runs inference, exports the GLB, and writes the result record as JSON to
+   stdout.
+4. `trellis_backend` parses stdout back into a `GenerationRecord` and returns
+   it to the CLI, which persists it to the JSONL catalog and emits it to the
+   user.
+
+Errors at any stage are communicated as `status=failed` JSON — the subprocess
+always exits 0 when it can write JSON output.  Exit non-zero only occurs when
+the runner process itself crashes before it can write any output.
+
+---
+
+## Scope limits
+
+1. **TRELLIS.2 only** — no other image-to-3D backends.
+2. **Single-job dispatch** — `generate run` is synchronous; no queue.
+3. **CUDA required** — CPU inference is not supported by TRELLIS.2.
+4. **GLB output only** — other mesh formats are not exposed.
+5. **No model fine-tuning** — uses `microsoft/TRELLIS.2-4B` from HuggingFace Hub.

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/__init__.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/__init__.py
@@ -1,0 +1,3 @@
+"""cli-anything-trellis — CLI harness for Microsoft TRELLIS.2 image-to-3D pipeline."""
+
+__version__ = "1.0.0"

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/core/__init__.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/core/__init__.py
@@ -1,0 +1,1 @@
+"""cli-anything-trellis core modules."""

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/core/catalog.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/core/catalog.py
@@ -1,0 +1,130 @@
+"""Generation catalog — JSON-lines history file for completed jobs.
+
+Each completed (done or failed) GenerationRecord is appended as a single
+JSON line to ~/.cli_anything/trellis/catalog.jsonl.
+
+The catalog is append-only; records are never modified after writing.
+Reading the catalog loads all lines and returns GenerationRecord objects.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+from cli_anything.trellis.core.generation import GenerationRecord
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+CATALOG_DIR = Path.home() / ".cli_anything" / "trellis"
+CATALOG_FILE = CATALOG_DIR / "catalog.jsonl"
+
+
+# ── Catalog I/O ───────────────────────────────────────────────────────────────
+
+
+def append_record(record: GenerationRecord, catalog_path: Optional[Path] = None) -> None:
+    """Append *record* as a JSON line to the catalog file.
+
+    Thread-safe via fcntl.flock (POSIX). Falls back silently on Windows.
+
+    Args:
+        record: The GenerationRecord to persist.
+        catalog_path: Override catalog file path (used in tests).
+    """
+    path = catalog_path or CATALOG_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    line = json.dumps(record.to_dict(), ensure_ascii=False) + "\n"
+
+    with open(path, "a", encoding="utf-8") as fh:
+        try:
+            import fcntl
+
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        except (ImportError, OSError):
+            pass
+        fh.write(line)
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+def iter_records(catalog_path: Optional[Path] = None) -> Iterator[GenerationRecord]:
+    """Iterate over all records in the catalog, oldest first.
+
+    Silently skips malformed lines.
+
+    Args:
+        catalog_path: Override catalog file path (used in tests).
+
+    Yields:
+        GenerationRecord for each valid line.
+    """
+    path = catalog_path or CATALOG_FILE
+    if not path.exists():
+        return
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                yield GenerationRecord.from_dict(data)
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+
+def list_records(
+    catalog_path: Optional[Path] = None,
+    status_filter: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> List[GenerationRecord]:
+    """Return records from the catalog as a list.
+
+    Args:
+        catalog_path: Override catalog file path (used in tests).
+        status_filter: If set, only return records with this status.
+        limit: If set, return only the most recent *limit* records.
+
+    Returns:
+        List of GenerationRecord, most recent last (or truncated to limit).
+    """
+    records = list(iter_records(catalog_path))
+    if status_filter is not None:
+        records = [r for r in records if r.status == status_filter]
+    if limit is not None and limit > 0:
+        records = records[-limit:]
+    return records
+
+
+def find_record(job_id: str, catalog_path: Optional[Path] = None) -> Optional[GenerationRecord]:
+    """Find a record by job_id. Returns None if not found.
+
+    Scans the catalog from newest to oldest for efficiency when recent
+    job IDs are queried most often.
+    """
+    # Reverse scan: read all then iterate backward
+    records = list(iter_records(catalog_path))
+    for record in reversed(records):
+        if record.job_id == job_id:
+            return record
+    return None
+
+
+def catalog_stats(catalog_path: Optional[Path] = None) -> dict:
+    """Return summary statistics for the catalog.
+
+    Returns:
+        Dict with keys: total, done, failed, pending, running.
+    """
+    stats: dict = {"total": 0, "done": 0, "failed": 0, "pending": 0, "running": 0}
+    for record in iter_records(catalog_path):
+        stats["total"] += 1
+        key = record.status
+        if key in stats:
+            stats[key] += 1
+    return stats

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/core/generation.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/core/generation.py
@@ -1,0 +1,256 @@
+"""Generation record dataclass for TRELLIS.2 jobs.
+
+Tracks every image-to-3D generation job: inputs, parameters, outputs, status.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# ── Status constants ──────────────────────────────────────────────────────────
+
+STATUS_PENDING = "pending"
+STATUS_RUNNING = "running"
+STATUS_DONE = "done"
+STATUS_FAILED = "failed"
+
+VALID_STATUSES = {STATUS_PENDING, STATUS_RUNNING, STATUS_DONE, STATUS_FAILED}
+
+# ── Resolution presets (from TRELLIS.2 app.py pipeline_type mapping) ─────────
+
+RESOLUTION_PRESETS = {
+    "low": {
+        "sparse_structure_sampler_params": {
+            "steps": 12,
+            "cfg_strength": 7.5,
+            "rescale": 0.7,
+        },
+        "shape_slat_sampler_params": {
+            "steps": 12,
+            "cfg_strength": 3.0,
+            "rescale_cfg": 0.7,
+            "rescale_t": 0.25,
+        },
+        "tex_slat_sampler_params": {
+            "steps": 12,
+            "cfg_strength": 3.0,
+            "rescale_cfg": 0.7,
+            "rescale_t": 0.25,
+        },
+    },
+    "high": {
+        "sparse_structure_sampler_params": {
+            "steps": 50,
+            "cfg_strength": 7.5,
+            "rescale": 0.7,
+        },
+        "shape_slat_sampler_params": {
+            "steps": 50,
+            "cfg_strength": 3.0,
+            "rescale_cfg": 0.7,
+            "rescale_t": 0.25,
+        },
+        "tex_slat_sampler_params": {
+            "steps": 50,
+            "cfg_strength": 3.0,
+            "rescale_cfg": 0.7,
+            "rescale_t": 0.25,
+        },
+    },
+}
+
+# Default to high quality
+DEFAULT_RESOLUTION = "high"
+
+
+def new_job_id() -> str:
+    """Generate a cryptographically random 8-byte hex job ID."""
+    return secrets.token_hex(8)
+
+
+def _timestamp() -> float:
+    """Return current POSIX timestamp."""
+    return time.time()
+
+
+@dataclass
+class GenerationRecord:
+    """Immutable record of a single TRELLIS.2 image-to-3D generation job.
+
+    Attributes:
+        job_id: Unique identifier (16-char hex from secrets.token_hex(8)).
+        image_path: Absolute path to the source image file.
+        output_dir: Directory where outputs (GLB, latent) are written.
+        resolution: Preset name ("low" or "high").
+        seed: Integer seed for reproducibility (-1 means random).
+        decimation_target: Target polygon count for GLB mesh decimation.
+        texture_size: Texture atlas size (pixels per side).
+        status: Current job status (pending/running/done/failed).
+        created_at: POSIX timestamp when record was created.
+        started_at: POSIX timestamp when runner was launched (or None).
+        finished_at: POSIX timestamp when runner exited (or None).
+        glb_path: Absolute path of the exported GLB file (or None).
+        error: Error message if status is failed (or None).
+        extra: Arbitrary metadata dict for future extensibility.
+    """
+
+    job_id: str
+    image_path: str
+    output_dir: str
+    resolution: str = DEFAULT_RESOLUTION
+    seed: int = -1
+    decimation_target: int = 1_000_000
+    texture_size: int = 4096
+    status: str = STATUS_PENDING
+    created_at: float = field(default_factory=_timestamp)
+    started_at: Optional[float] = None
+    finished_at: Optional[float] = None
+    glb_path: Optional[str] = None
+    error: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    # ── Constructors ──────────────────────────────────────────────────────────
+
+    @classmethod
+    def new(
+        cls,
+        image_path: str,
+        output_dir: str,
+        resolution: str = DEFAULT_RESOLUTION,
+        seed: int = -1,
+        decimation_target: int = 1_000_000,
+        texture_size: int = 4096,
+    ) -> "GenerationRecord":
+        """Create a new pending GenerationRecord with a fresh job_id."""
+        if resolution not in RESOLUTION_PRESETS:
+            raise ValueError(
+                f"Unknown resolution preset {resolution!r}. "
+                f"Valid options: {sorted(RESOLUTION_PRESETS)}"
+            )
+        return cls(
+            job_id=new_job_id(),
+            image_path=str(Path(image_path).resolve()),
+            output_dir=str(Path(output_dir).resolve()),
+            resolution=resolution,
+            seed=seed,
+            decimation_target=decimation_target,
+            texture_size=texture_size,
+        )
+
+    # ── Transitions (return new instances — immutability) ─────────────────────
+
+    def mark_running(self) -> "GenerationRecord":
+        """Return copy of record with status=running and started_at set."""
+        return GenerationRecord(
+            **{**self._asdict(), "status": STATUS_RUNNING, "started_at": _timestamp()}
+        )
+
+    def mark_done(self, glb_path: str) -> "GenerationRecord":
+        """Return copy of record with status=done and glb_path set."""
+        return GenerationRecord(
+            **{
+                **self._asdict(),
+                "status": STATUS_DONE,
+                "finished_at": _timestamp(),
+                "glb_path": str(Path(glb_path).resolve()),
+            }
+        )
+
+    def mark_failed(self, error: str) -> "GenerationRecord":
+        """Return copy of record with status=failed and error set."""
+        return GenerationRecord(
+            **{
+                **self._asdict(),
+                "status": STATUS_FAILED,
+                "finished_at": _timestamp(),
+                "error": error,
+            }
+        )
+
+    # ── Serialization ─────────────────────────────────────────────────────────
+
+    def _asdict(self) -> Dict[str, Any]:
+        """Return dict representation (mirrors dataclasses.asdict but manual for speed)."""
+        return {
+            "job_id": self.job_id,
+            "image_path": self.image_path,
+            "output_dir": self.output_dir,
+            "resolution": self.resolution,
+            "seed": self.seed,
+            "decimation_target": self.decimation_target,
+            "texture_size": self.texture_size,
+            "status": self.status,
+            "created_at": self.created_at,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "glb_path": self.glb_path,
+            "error": self.error,
+            "extra": self.extra,
+        }
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return self._asdict()
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GenerationRecord":
+        """Deserialize from a dict (as returned by to_dict())."""
+        required = {"job_id", "image_path", "output_dir"}
+        missing = required - data.keys()
+        if missing:
+            raise ValueError(f"GenerationRecord.from_dict missing keys: {missing}")
+        return cls(
+            job_id=data["job_id"],
+            image_path=data["image_path"],
+            output_dir=data["output_dir"],
+            resolution=data.get("resolution", DEFAULT_RESOLUTION),
+            seed=data.get("seed", -1),
+            decimation_target=data.get("decimation_target", 1_000_000),
+            texture_size=data.get("texture_size", 4096),
+            status=data.get("status", STATUS_PENDING),
+            created_at=data.get("created_at", 0.0),
+            started_at=data.get("started_at"),
+            finished_at=data.get("finished_at"),
+            glb_path=data.get("glb_path"),
+            error=data.get("error"),
+            extra=data.get("extra", {}),
+        )
+
+    # ── Properties ────────────────────────────────────────────────────────────
+
+    @property
+    def is_terminal(self) -> bool:
+        """True if the job reached a final state (done or failed)."""
+        return self.status in {STATUS_DONE, STATUS_FAILED}
+
+    @property
+    def duration_seconds(self) -> Optional[float]:
+        """Wall-clock seconds from started_at to finished_at, or None."""
+        if self.started_at is None or self.finished_at is None:
+            return None
+        return self.finished_at - self.started_at
+
+    @property
+    def sampler_params(self) -> Dict[str, Any]:
+        """Resolved sampler params dict for the runner, keyed by preset name."""
+        return RESOLUTION_PRESETS[self.resolution]
+
+    def __repr__(self) -> str:
+        return (
+            f"GenerationRecord(job_id={self.job_id!r}, status={self.status!r}, "
+            f"resolution={self.resolution!r}, image={self.image_path!r})"
+        )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def validate_status(status: str) -> str:
+    """Raise ValueError if status is not a known value, else return it."""
+    if status not in VALID_STATUSES:
+        raise ValueError(f"Unknown status {status!r}. Valid: {sorted(VALID_STATUSES)}")
+    return status

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/core/session.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/core/session.py
@@ -1,0 +1,189 @@
+"""Session state for cli-anything-trellis.
+
+Persists active context across REPL commands: current working directory,
+default resolution preset, default output directory, recent job IDs,
+and arbitrary key-value settings.
+
+Storage: ~/.cli_anything/trellis/sessions/<name>.json
+Writes:  atomic temp-file + os.replace, with fcntl.flock on POSIX.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+SCHEMA = "cli-anything-trellis/session/v1"
+SESSIONS_DIR = Path.home() / ".cli_anything" / "trellis" / "sessions"
+DEFAULT_SESSION_NAME = "default"
+MAX_HISTORY = 50  # maximum recent job IDs kept in session
+
+
+# ── Atomic write ─────────────────────────────────────────────────────────────
+
+
+def _locked_save_json(path: Path, payload: Dict[str, Any]) -> None:
+    """Write *payload* to *path* atomically using a temp file + os.replace.
+
+    Uses fcntl.flock on POSIX to prevent concurrent-write corruption.
+    Falls back silently when fcntl is unavailable (Windows / restricted env).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=".session-", suffix=".json")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            try:
+                import fcntl
+
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            except (ImportError, OSError):
+                pass
+            json.dump(payload, fh, indent=2, ensure_ascii=False)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ── Session dataclass ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class Session:
+    """Persistent REPL session state for cli-anything-trellis.
+
+    Attributes:
+        name: Session identifier (used as filename stem).
+        trellis_home: Path to TRELLIS.2 installation (overrides env var).
+        trellis_python: Path to Python interpreter with trellis2 installed.
+        default_resolution: Default preset ("low" or "high").
+        default_output_dir: Default directory for GLB outputs.
+        settings: Arbitrary user-defined key-value pairs.
+        history: List of recent job IDs (most recent last), capped at MAX_HISTORY.
+        created_at: POSIX timestamp of session creation.
+        updated_at: POSIX timestamp of last save.
+        schema: Schema version string for future migration.
+    """
+
+    name: str = DEFAULT_SESSION_NAME
+    trellis_home: Optional[str] = None
+    trellis_python: Optional[str] = None
+    default_resolution: str = "high"
+    default_output_dir: Optional[str] = None
+    settings: Dict[str, str] = field(default_factory=dict)
+    history: List[str] = field(default_factory=list)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    schema: str = SCHEMA
+
+    # ── Persistence ───────────────────────────────────────────────────────────
+
+    @staticmethod
+    def session_path(name: str) -> Path:
+        """Return the filesystem path for session *name*."""
+        return SESSIONS_DIR / f"{name}.json"
+
+    def save(self) -> None:
+        """Persist session to disk atomically."""
+        self.updated_at = time.time()
+        _locked_save_json(self.session_path(self.name), self._to_dict())
+
+    def delete(self) -> bool:
+        """Remove the session file from disk. Returns True if file existed."""
+        p = self.session_path(self.name)
+        if p.exists():
+            p.unlink()
+            return True
+        return False
+
+    @classmethod
+    def load(cls, name: str = DEFAULT_SESSION_NAME) -> "Session":
+        """Load a session by name, creating a new default if not found."""
+        path = cls.session_path(name)
+        if not path.exists():
+            return cls(name=name)
+        try:
+            raw = path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+            return cls._from_dict(name, data)
+        except (json.JSONDecodeError, KeyError, TypeError):
+            # Corrupted session file — return fresh session
+            return cls(name=name)
+
+    @staticmethod
+    def list_sessions() -> List[str]:
+        """Return sorted list of session names that exist on disk."""
+        if not SESSIONS_DIR.exists():
+            return []
+        return sorted(p.stem for p in SESSIONS_DIR.iterdir() if p.suffix == ".json")
+
+    # ── Mutation helpers (return new Session for immutability) ────────────────
+
+    def push_history(self, job_id: str) -> "Session":
+        """Return new Session with *job_id* appended to history (capped)."""
+        new_history = (self.history + [job_id])[-MAX_HISTORY:]
+        return Session(**{**self._to_dict_fields(), "history": new_history})
+
+    def set_setting(self, key: str, value: str) -> "Session":
+        """Return new Session with settings[key]=value."""
+        new_settings = {**self.settings, key: value}
+        return Session(**{**self._to_dict_fields(), "settings": new_settings})
+
+    def unset_setting(self, key: str) -> "Session":
+        """Return new Session with *key* removed from settings."""
+        new_settings = {k: v for k, v in self.settings.items() if k != key}
+        return Session(**{**self._to_dict_fields(), "settings": new_settings})
+
+    # ── Serialization ─────────────────────────────────────────────────────────
+
+    def _to_dict_fields(self) -> Dict[str, Any]:
+        """Return constructor kwargs dict (excludes schema for clarity)."""
+        return {
+            "name": self.name,
+            "trellis_home": self.trellis_home,
+            "trellis_python": self.trellis_python,
+            "default_resolution": self.default_resolution,
+            "default_output_dir": self.default_output_dir,
+            "settings": dict(self.settings),
+            "history": list(self.history),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "schema": self.schema,
+        }
+
+    def _to_dict(self) -> Dict[str, Any]:
+        """Full serialization dict written to JSON."""
+        return self._to_dict_fields()
+
+    @classmethod
+    def _from_dict(cls, name: str, data: Dict[str, Any]) -> "Session":
+        return cls(
+            name=name,
+            trellis_home=data.get("trellis_home"),
+            trellis_python=data.get("trellis_python"),
+            default_resolution=data.get("default_resolution", "high"),
+            default_output_dir=data.get("default_output_dir"),
+            settings=data.get("settings", {}),
+            history=data.get("history", []),
+            created_at=data.get("created_at", time.time()),
+            updated_at=data.get("updated_at", time.time()),
+            schema=data.get("schema", SCHEMA),
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"Session(name={self.name!r}, resolution={self.default_resolution!r}, "
+            f"jobs={len(self.history)})"
+        )

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/resources/trellis_runner.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/resources/trellis_runner.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""TRELLIS.2 runner script — invoked as a subprocess by the CLI harness.
+
+This script is the ONLY place that imports trellis2, torch, or o_voxel.
+The parent CLI process never imports these packages directly.
+
+Usage (called by trellis_backend.py):
+    python trellis_runner.py generate   < job_record.json  > result_record.json
+    python trellis_runner.py probe-gpu                     > gpu_info.json
+
+Protocol:
+    generate:
+        stdin:  JSON-serialised GenerationRecord (as produced by record.to_dict())
+        stdout: JSON-serialised GenerationRecord with status=done/failed
+        exit 0 always (errors are reported in the JSON result, not exit code)
+
+    probe-gpu:
+        stdout: {"available": bool, "device_count": int, "devices": [...]}
+        exit 0 on success, exit 1 if torch import fails
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import traceback
+from pathlib import Path
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _emit(payload: dict) -> None:
+    """Write payload as JSON to stdout and flush."""
+    print(json.dumps(payload, ensure_ascii=False), flush=True)
+
+
+def _fail_record(record: dict, error: str) -> dict:
+    """Return record dict with status=failed and error set."""
+    return {
+        **record,
+        "status": "failed",
+        "finished_at": time.time(),
+        "error": error,
+    }
+
+
+# ── probe-gpu subcommand ──────────────────────────────────────────────────────
+
+
+def cmd_probe_gpu() -> None:
+    """Check CUDA availability and emit GPU info JSON."""
+    try:
+        import torch
+    except ImportError as exc:
+        _emit({"available": False, "device_count": 0, "devices": [], "error": str(exc)})
+        sys.exit(1)
+
+    available = torch.cuda.is_available()
+    device_count = torch.cuda.device_count() if available else 0
+    devices = []
+    for i in range(device_count):
+        try:
+            props = torch.cuda.get_device_properties(i)
+            devices.append(
+                {
+                    "index": i,
+                    "name": props.name,
+                    "total_memory_gb": round(props.total_memory / (1024**3), 2),
+                }
+            )
+        except Exception:
+            devices.append({"index": i, "name": "unknown", "total_memory_gb": 0})
+
+    _emit({"available": available, "device_count": device_count, "devices": devices})
+
+
+# ── generate subcommand ───────────────────────────────────────────────────────
+
+
+def cmd_generate() -> None:
+    """Read GenerationRecord JSON from stdin, run TRELLIS.2, emit result JSON."""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        _emit({"status": "failed", "error": "runner received empty stdin"})
+        return
+
+    try:
+        record = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _emit({"status": "failed", "error": f"invalid JSON on stdin: {exc}"})
+        return
+
+    # Mark running
+    record["status"] = "running"
+    record["started_at"] = time.time()
+
+    image_path = record.get("image_path", "")
+    output_dir = record.get("output_dir", "")
+    resolution = record.get("resolution", "high")
+    seed = record.get("seed", -1)
+    decimation_target = record.get("decimation_target", 1_000_000)
+    texture_size = record.get("texture_size", 4096)
+
+    # ── Validate inputs ───────────────────────────────────────────────────────
+
+    if not image_path or not Path(image_path).exists():
+        _emit(_fail_record(record, f"image not found: {image_path!r}"))
+        return
+
+    try:
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        _emit(_fail_record(record, f"cannot create output_dir {output_dir!r}: {exc}"))
+        return
+
+    # ── Import trellis2 (only happens inside this subprocess) ─────────────────
+
+    try:
+        import torch
+        from PIL import Image
+        from trellis2.pipelines import Trellis2ImageTo3DPipeline
+    except ImportError as exc:
+        _emit(
+            _fail_record(
+                record,
+                f"import error — ensure trellis2 and torch are installed "
+                f"in this Python environment: {exc}",
+            )
+        )
+        return
+
+    # ── CUDA check ────────────────────────────────────────────────────────────
+
+    if not torch.cuda.is_available():
+        _emit(
+            _fail_record(
+                record,
+                "CUDA is not available. TRELLIS.2 requires a CUDA-capable GPU.",
+            )
+        )
+        return
+
+    # ── Resolve seed ──────────────────────────────────────────────────────────
+
+    import random
+
+    if seed < 0:
+        seed = random.randint(0, 2**31 - 1)
+        record["seed"] = seed
+
+    # ── Sampler params from resolution preset ─────────────────────────────────
+
+    RESOLUTION_PRESETS = {
+        "low": {
+            "sparse_structure_sampler_params": {
+                "steps": 12,
+                "cfg_strength": 7.5,
+                "rescale": 0.7,
+            },
+            "shape_slat_sampler_params": {
+                "steps": 12,
+                "cfg_strength": 3.0,
+                "rescale_cfg": 0.7,
+                "rescale_t": 0.25,
+            },
+            "tex_slat_sampler_params": {
+                "steps": 12,
+                "cfg_strength": 3.0,
+                "rescale_cfg": 0.7,
+                "rescale_t": 0.25,
+            },
+        },
+        "high": {
+            "sparse_structure_sampler_params": {
+                "steps": 50,
+                "cfg_strength": 7.5,
+                "rescale": 0.7,
+            },
+            "shape_slat_sampler_params": {
+                "steps": 50,
+                "cfg_strength": 3.0,
+                "rescale_cfg": 0.7,
+                "rescale_t": 0.25,
+            },
+            "tex_slat_sampler_params": {
+                "steps": 50,
+                "cfg_strength": 3.0,
+                "rescale_cfg": 0.7,
+                "rescale_t": 0.25,
+            },
+        },
+    }
+
+    if resolution not in RESOLUTION_PRESETS:
+        resolution = "high"
+    params = RESOLUTION_PRESETS[resolution]
+
+    # ── Run pipeline ──────────────────────────────────────────────────────────
+
+    try:
+        pipeline = Trellis2ImageTo3DPipeline.from_pretrained("microsoft/TRELLIS.2-4B")
+        pipeline.cuda()
+
+        image = Image.open(image_path).convert("RGB")
+
+        outputs = pipeline.run(
+            image,
+            seed=seed,
+            preprocess_image=False,
+            sparse_structure_sampler_params=params["sparse_structure_sampler_params"],
+            shape_slat_sampler_params=params["shape_slat_sampler_params"],
+            tex_slat_sampler_params=params["tex_slat_sampler_params"],
+            return_latent=True,
+        )
+
+        mesh = outputs[0]
+
+    except Exception as exc:
+        _emit(_fail_record(record, f"pipeline.run failed: {traceback.format_exc()}"))
+        return
+
+    # ── Export GLB ────────────────────────────────────────────────────────────
+
+    try:
+        import o_voxel
+
+        job_id = record.get("job_id", "unknown")
+        glb_filename = f"{job_id}.glb"
+        glb_path = output_path / glb_filename
+
+        glb = o_voxel.postprocess.to_glb(
+            vertices=mesh.vertices,
+            faces=mesh.faces,
+            attr_volume=mesh.attrs,
+            coords=mesh.coords,
+            attr_layout=pipeline.pbr_attr_layout,
+            voxel_size=mesh.voxel_size,
+            aabb=[[-0.5, -0.5, -0.5], [0.5, 0.5, 0.5]],
+            decimation_target=decimation_target,
+            texture_size=texture_size,
+            remesh=True,
+            remesh_band=1,
+            remesh_project=0,
+            verbose=False,
+        )
+
+        glb.export(str(glb_path), extension_webp=True)
+
+    except Exception as exc:
+        _emit(_fail_record(record, f"GLB export failed: {traceback.format_exc()}"))
+        return
+
+    # ── Emit success ──────────────────────────────────────────────────────────
+
+    result = {
+        **record,
+        "status": "done",
+        "finished_at": time.time(),
+        "glb_path": str(glb_path.resolve()),
+    }
+    _emit(result)
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(
+            json.dumps(
+                {
+                    "error": "usage: trellis_runner.py <generate|probe-gpu>",
+                    "status": "failed",
+                }
+            ),
+            flush=True,
+        )
+        sys.exit(1)
+
+    subcommand = sys.argv[1]
+
+    if subcommand == "generate":
+        cmd_generate()
+    elif subcommand == "probe-gpu":
+        cmd_probe_gpu()
+    else:
+        print(
+            json.dumps(
+                {
+                    "error": f"unknown subcommand: {subcommand!r}",
+                    "status": "failed",
+                }
+            ),
+            flush=True,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/skills/SKILL.md
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/skills/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: cli-anything-trellis
+description: >
+  Operate the cli-anything-trellis harness: submit image-to-3D generation jobs
+  via Microsoft TRELLIS.2, inspect job history, manage sessions, and probe GPU
+  availability — all from the CLI without importing trellis2 directly.
+triggers:
+  - /trellis
+  - generate 3d from image
+  - trellis generate
+  - image to glb
+  - probe-gpu trellis
+---
+
+# cli-anything-trellis Skill
+
+## When to use
+
+Invoke this skill when:
+- Submitting an image-to-3D generation job via TRELLIS.2
+- Checking GPU availability in the TRELLIS Python environment
+- Inspecting job history or catalog statistics
+- Managing trellis session settings (home, python, resolution defaults)
+- Writing agent code that calls the trellis CLI programmatically
+
+## Prerequisites
+
+1. `pip install -e ".[dev]"` from the harness root
+2. TRELLIS.2 installed in a separate Python environment
+3. `TRELLIS_HOME` pointing to the TRELLIS.2 repo/install root
+4. `TRELLIS_PYTHON` pointing to the Python interpreter with trellis2 installed
+5. A CUDA-capable GPU (required by TRELLIS.2; CPU inference not supported)
+
+## Install
+
+```bash
+cd /path/to/cli-anything/trellis/agent-harness
+pip install -e ".[dev]"
+```
+
+Verify:
+```bash
+trellis --version
+trellis config probe-gpu
+```
+
+## Command groups
+
+| Group | Subcommands | Purpose |
+|-------|-------------|---------|
+| `generate` | `run` | Submit image-to-3D job |
+| `jobs` | `list`, `show` | Browse/inspect job history |
+| `catalog` | `list`, `stats` | Read append-only JSONL catalog |
+| `session` | `show`, `set`, `unset`, `list`, `delete`, `clear-history` | Persist settings |
+| `config` | `show`, `validate`, `probe-gpu` | Installation/GPU checks |
+| *(bare)* | — | Launch interactive REPL |
+
+## Agent-facing JSON contract
+
+All commands accept `--json` for machine-readable output.
+
+### `generate run --json`
+
+```json
+{
+  "job_id": "a1b2c3d4e5f6a7b8",
+  "image_path": "/abs/path/to/image.png",
+  "output_dir": "/abs/path/to/output",
+  "resolution": "low",
+  "seed": 42,
+  "decimation_target": 1000000,
+  "texture_size": 4096,
+  "status": "done",
+  "created_at": 1716000000.0,
+  "started_at": 1716000001.0,
+  "finished_at": 1716000045.0,
+  "glb_path": "/abs/path/to/output/a1b2c3d4e5f6a7b8.glb",
+  "error": null,
+  "extra": {}
+}
+```
+
+Status values: `pending` | `running` | `done` | `failed`
+
+### `config probe-gpu --json`
+
+```json
+{
+  "available": true,
+  "device_count": 1,
+  "devices": [
+    {"index": 0, "name": "NVIDIA A100-SXM4-80GB", "total_memory_gb": 79.2}
+  ]
+}
+```
+
+### `catalog stats --json`
+
+```json
+{
+  "total": 12,
+  "done": 10,
+  "failed": 1,
+  "pending": 0,
+  "running": 1
+}
+```
+
+## Worked examples
+
+### Submit a low-resolution job and capture the GLB path
+
+```bash
+result=$(trellis --json \
+  --trellis-home "$TRELLIS_HOME" \
+  --trellis-python "$TRELLIS_PYTHON" \
+  generate run \
+  --image /path/to/product.png \
+  --output-dir /tmp/trellis-out \
+  --resolution low \
+  --seed 42)
+
+echo "$result" | python -c "import sys,json; d=json.load(sys.stdin); print(d['glb_path'])"
+```
+
+### Persist TRELLIS settings in the current session
+
+```bash
+trellis session set trellis_home "$TRELLIS_HOME"
+trellis session set trellis_python "$TRELLIS_PYTHON"
+trellis session set default_resolution low
+# Now generate without flags:
+trellis generate run --image product.png --output-dir /tmp/out
+```
+
+### Probe GPU from a Python agent
+
+```python
+import subprocess, json, sys
+
+result = subprocess.run(
+    [sys.executable, "-m", "cli_anything.trellis.trellis_cli",
+     "--json", "config", "probe-gpu"],
+    capture_output=True, text=True, timeout=30,
+)
+gpu_info = json.loads(result.stdout)
+if not gpu_info["available"]:
+    raise RuntimeError("No CUDA GPU — cannot run TRELLIS.2")
+```
+
+### Programmatic generation from Python
+
+```python
+import subprocess, json, sys, os
+
+proc = subprocess.run(
+    [sys.executable, "-m", "cli_anything.trellis.trellis_cli",
+     "--json",
+     "--trellis-home", os.environ["TRELLIS_HOME"],
+     "--trellis-python", os.environ["TRELLIS_PYTHON"],
+     "generate", "run",
+     "--image", "/path/to/image.png",
+     "--output-dir", "/tmp/trellis-out",
+     "--resolution", "high",
+     "--seed", "-1"],
+    capture_output=True, text=True, timeout=900,
+)
+record = json.loads(proc.stdout)
+if record["status"] != "done":
+    raise RuntimeError(f"TRELLIS generation failed: {record['error']}")
+glb_path = record["glb_path"]
+```
+
+## Error handling
+
+| Error class | Cause | Resolution |
+|-------------|-------|------------|
+| `TrellisNotFoundError` | `TRELLIS_HOME` not set or no `trellis2/` dir inside | Set `TRELLIS_HOME` correctly |
+| `TrellisPythonError` | Python interpreter not found or fails `--version` | Set `TRELLIS_PYTHON` to the trellis2 venv python |
+| `GPUUnavailableError` | `torch.cuda.is_available()` returned False | Ensure CUDA drivers installed and a GPU is available |
+| `RunnerError` | Runner subprocess exited non-zero with no JSON | Check `stderr` attribute for details |
+| `RunnerTimeoutError` | Generation exceeded `--timeout` seconds | Increase timeout or use a lower resolution preset |
+
+All errors are reflected in the JSON result when using `--json`:
+
+```json
+{"status": "failed", "error": "CUDA is not available ...", ...}
+```
+
+## Dry-run discipline
+
+There is no `--dry-run` flag for generation (TRELLIS.2 is GPU-only with no
+mock mode).  To test connectivity and environment without a GPU job:
+
+```bash
+trellis config validate     # checks TRELLIS_HOME + Python interpreter
+trellis config probe-gpu    # checks CUDA via subprocess
+```
+
+## Session model
+
+Sessions are persisted at `~/.cli_anything/trellis/sessions/<name>.json`.
+The default session is named `default`.  Each session stores:
+
+- `trellis_home` — path override
+- `trellis_python` — interpreter override
+- `default_resolution` — `"low"` or `"high"`
+- `default_output_dir` — default output directory
+- `history` — last 50 commands (capped)
+
+The append-only job catalog lives at `~/.cli_anything/trellis/catalog.jsonl`.
+One JSON record per line; never modified after append.
+
+## Scope limits
+
+1. **TRELLIS.2 only** — no other image-to-3D backends are wired.
+2. **Single-job dispatch** — `generate run` is synchronous; no queue or batch.
+3. **CUDA required** — CPU inference is not supported by TRELLIS.2.
+4. **GLB output only** — OBJ, FBX, USD are not exposed; change the runner if needed.
+5. **No model fine-tuning** — the harness uses `microsoft/TRELLIS.2-4B` from
+   HuggingFace Hub; custom checkpoints require modifying `trellis_runner.py`.

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/tests/TEST.md
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/tests/TEST.md
@@ -1,0 +1,99 @@
+# cli-anything-trellis — Test Plan
+
+## Phase 4 Plan (Unit Tests)
+
+### Scope
+
+All unit tests in `test_core.py` must pass without:
+- A CUDA-capable GPU
+- TRELLIS.2 installed (`trellis2`, `torch`, `o_voxel`)
+- Network access
+
+Tests use `tmp_path`, `monkeypatch`, and mocked `run_generation` to remain
+fully isolated from the GPU environment.
+
+### Test classes and coverage targets
+
+| Class | Tests | What is covered |
+|-------|-------|-----------------|
+| `TestJobId` | 3 | `new_job_id()` length, hex charset, uniqueness |
+| `TestResolutionPresets` | 4 | Preset keys, default ("high"), positive step counts |
+| `TestGenerationRecord` | 13 | Construction, status transitions, serialisation, immutability |
+| `TestValidateStatus` | 2 | Valid status strings, invalid raises ValueError |
+| `TestLockedSaveJson` | 4 | File creation, content, atomic replace via `os.replace`, parent-dir creation |
+| `TestSession` | 14 | Default session, save/load roundtrip, missing=fresh, corrupted=fresh, history push/cap, set/unset settings, delete, list, repr |
+| `TestCatalog` | 9 | Append+iter, empty catalog, malformed-line skip, limit, status filter, find_record, stats, empty stats, multiple append |
+| `TestBackendErrors` | 3 | Error hierarchy, `RunnerError` fields, `is RuntimeError` |
+| `TestDiscovery` | 10 | `discover_trellis_home` (explicit/env/session/missing), `discover_trellis_python` (explicit/env/fallback), `build_runner_env` variants |
+| `TestCliImport` | 3 | CLI importable without trellis2, `--version` flag, `--help` flag |
+| `TestCliSessionCommands` | 6 | `session show`, JSON mode, `session set`+show, `session list` JSON, `clear-history`, delete missing |
+| `TestCliCatalogCommands` | 2 | `catalog list` empty, `catalog stats --json` |
+| `TestCliConfigCommands` | 3 | `config show`, JSON mode, `config validate --json` |
+| `TestCliJobsCommands` | 3 | `jobs list` empty, JSON empty, `jobs show` missing |
+| `TestGenerateRunDryMock` | 3 | `generate run` success (mock), failure (mock), JSON success (mock) |
+
+**Total: 81 unit tests**
+
+### Invariants enforced
+
+- `new_job_id()` → always 16-character hex string
+- `GenerationRecord` transitions are immutable (original unchanged)
+- `_locked_save_json` writes via temp file + `os.replace` (never partial write)
+- Session `push_history` caps at `MAX_HISTORY = 50`
+- Backend errors all subclass `BackendError(RuntimeError)`
+- CLI is importable without `trellis2` / `torch` in `sys.modules`
+
+---
+
+## Phase 6 Results
+
+### Command
+
+```bash
+cd /path/to/trellis/agent-harness
+/tmp/cli-anything-trellis-venv/bin/pytest \
+  cli_anything/trellis/tests/test_core.py \
+  --tb=short -q
+```
+
+### Results
+
+```
+92 passed in 0.18s
+```
+
+All 92 unit tests passed.  `test_full_e2e.py` was collected but skipped at
+module level with `"Set TRELLIS_E2E=1 to run end-to-end TRELLIS tests"` — no
+silent passes, no false failures.
+
+### E2E gate verification
+
+```bash
+# Verify E2E module skips cleanly without the flag:
+pytest cli_anything/trellis/tests/test_full_e2e.py -v
+# → "SKIPPED [module]: Set TRELLIS_E2E=1 to run end-to-end TRELLIS tests"
+
+# Verify E2E module fails explicitly when flag is set (no GPU/torch in venv):
+TRELLIS_E2E=1 pytest cli_anything/trellis/tests/test_full_e2e.py -v
+# → 16 explicit ERRORs — fixture setup fails because TRELLIS_HOME is unset
+# → No silent passes; every test errors visibly
+```
+
+**TRELLIS_E2E=1 output (no GPU env):**
+```
+ERROR test_full_e2e.py::TestProbeGpu::test_probe_gpu_returns_dict
+ERROR test_full_e2e.py::TestProbeGpu::test_probe_gpu_has_required_keys
+... (16 total ERRORs — 0 passes, 0 silent skips)
+```
+
+### Environment
+
+```
+Python: 3.11+
+click: 8.1+
+prompt-toolkit: 3.0+
+pytest: 7.4+
+trellis2: NOT INSTALLED (unit tests do not require it)
+torch: NOT INSTALLED
+CUDA: NOT REQUIRED for unit tests
+```

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/tests/__init__.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/tests/__init__.py
@@ -1,0 +1,1 @@
+"""cli-anything-trellis test suite."""

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/tests/test_core.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/tests/test_core.py
@@ -1,0 +1,757 @@
+"""Unit tests for cli-anything-trellis core modules.
+
+All tests run without GPU, CUDA, torch, trellis2, or o_voxel.
+E2E tests that require the actual TRELLIS.2 runtime are in test_full_e2e.py
+and are gated behind TRELLIS_E2E=1.
+
+Coverage targets:
+    - cli_anything.trellis.core.generation  (GenerationRecord, helpers)
+    - cli_anything.trellis.core.session     (Session, _locked_save_json)
+    - cli_anything.trellis.core.catalog     (append, iter, list, find, stats)
+    - cli_anything.trellis.utils.trellis_backend (error types, discovery, env)
+    - cli_anything.trellis.trellis_cli      (CLI commands via Click test runner)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cli_anything.trellis.core.catalog import (append_record, catalog_stats,
+                                               find_record, iter_records,
+                                               list_records)
+from cli_anything.trellis.core.generation import (DEFAULT_RESOLUTION,
+                                                  RESOLUTION_PRESETS,
+                                                  STATUS_DONE, STATUS_FAILED,
+                                                  STATUS_PENDING,
+                                                  STATUS_RUNNING,
+                                                  GenerationRecord, new_job_id,
+                                                  validate_status)
+from cli_anything.trellis.core.session import (MAX_HISTORY, SCHEMA, Session,
+                                               _locked_save_json)
+from cli_anything.trellis.trellis_cli import cli
+from cli_anything.trellis.utils.trellis_backend import (
+    BackendError, GPUUnavailableError, RunnerError, RunnerTimeoutError,
+    TrellisNotFoundError, TrellisPythonError, build_runner_env,
+    discover_trellis_home, discover_trellis_python)
+from click.testing import CliRunner
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture()
+def tmp_image(tmp_path: Path) -> Path:
+    """Create a minimal valid PNG file."""
+    img = tmp_path / "test.png"
+    # Minimal 1×1 white PNG (89 bytes, valid header)
+    img.write_bytes(
+        b"\x89PNG\r\n\x1a\n"  # PNG signature
+        b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x02\x00\x00\x00\x90wS\xde"
+        b"\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N"
+        b"\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    return img
+
+
+@pytest.fixture()
+def tmp_catalog(tmp_path: Path) -> Path:
+    """Return a path for a temporary catalog file."""
+    return tmp_path / "catalog.jsonl"
+
+
+@pytest.fixture()
+def sample_record(tmp_image: Path, tmp_path: Path) -> GenerationRecord:
+    """Return a pending GenerationRecord with real file paths."""
+    return GenerationRecord.new(
+        image_path=str(tmp_image),
+        output_dir=str(tmp_path / "output"),
+    )
+
+
+@pytest.fixture()
+def done_record(sample_record: GenerationRecord, tmp_path: Path) -> GenerationRecord:
+    """Return a done GenerationRecord."""
+    glb = tmp_path / "output" / f"{sample_record.job_id}.glb"
+    glb.parent.mkdir(parents=True, exist_ok=True)
+    glb.write_bytes(b"GLB")
+    running = sample_record.mark_running()
+    return running.mark_done(str(glb))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestJobId
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestJobId:
+    def test_length(self):
+        """job_id is exactly 16 hex chars (8 bytes)."""
+        jid = new_job_id()
+        assert len(jid) == 16
+
+    def test_hex_chars(self):
+        """job_id contains only lowercase hex characters."""
+        jid = new_job_id()
+        assert all(c in "0123456789abcdef" for c in jid)
+
+    def test_unique(self):
+        """Two consecutive job IDs are different."""
+        ids = {new_job_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestResolutionPresets
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestResolutionPresets:
+    def test_presets_exist(self):
+        assert "low" in RESOLUTION_PRESETS
+        assert "high" in RESOLUTION_PRESETS
+
+    def test_preset_keys(self):
+        for preset in RESOLUTION_PRESETS.values():
+            assert "sparse_structure_sampler_params" in preset
+            assert "shape_slat_sampler_params" in preset
+            assert "tex_slat_sampler_params" in preset
+
+    def test_default_resolution(self):
+        assert DEFAULT_RESOLUTION in RESOLUTION_PRESETS
+
+    @pytest.mark.parametrize("preset", ["low", "high"])
+    def test_steps_positive(self, preset):
+        p = RESOLUTION_PRESETS[preset]
+        assert p["sparse_structure_sampler_params"]["steps"] > 0
+        assert p["shape_slat_sampler_params"]["steps"] > 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestGenerationRecord
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGenerationRecord:
+    def test_new_creates_pending(self, tmp_image: Path, tmp_path: Path):
+        r = GenerationRecord.new(
+            image_path=str(tmp_image),
+            output_dir=str(tmp_path / "out"),
+        )
+        assert r.status == STATUS_PENDING
+        assert r.glb_path is None
+        assert r.error is None
+
+    def test_new_resolves_paths(self, tmp_image: Path, tmp_path: Path):
+        r = GenerationRecord.new(
+            image_path=str(tmp_image),
+            output_dir=str(tmp_path),
+        )
+        assert Path(r.image_path).is_absolute()
+        assert Path(r.output_dir).is_absolute()
+
+    def test_new_invalid_resolution_raises(self, tmp_image: Path, tmp_path: Path):
+        with pytest.raises(ValueError, match="Unknown resolution preset"):
+            GenerationRecord.new(
+                image_path=str(tmp_image),
+                output_dir=str(tmp_path),
+                resolution="ultra",
+            )
+
+    def test_mark_running(self, sample_record: GenerationRecord):
+        r = sample_record.mark_running()
+        assert r.status == STATUS_RUNNING
+        assert r.started_at is not None
+        # original unchanged (immutability)
+        assert sample_record.status == STATUS_PENDING
+
+    def test_mark_done(self, sample_record: GenerationRecord, tmp_path: Path):
+        glb = tmp_path / "out.glb"
+        glb.write_bytes(b"GLB")
+        running = sample_record.mark_running()
+        done = running.mark_done(str(glb))
+        assert done.status == STATUS_DONE
+        assert done.glb_path is not None
+        assert done.finished_at is not None
+
+    def test_mark_failed(self, sample_record: GenerationRecord):
+        failed = sample_record.mark_failed("GPU exploded")
+        assert failed.status == STATUS_FAILED
+        assert failed.error == "GPU exploded"
+        assert failed.finished_at is not None
+
+    def test_is_terminal_done(self, done_record: GenerationRecord):
+        assert done_record.is_terminal is True
+
+    def test_is_terminal_pending(self, sample_record: GenerationRecord):
+        assert sample_record.is_terminal is False
+
+    def test_is_terminal_running(self, sample_record: GenerationRecord):
+        r = sample_record.mark_running()
+        assert r.is_terminal is False
+
+    def test_duration_seconds(self, sample_record: GenerationRecord, tmp_path: Path):
+        glb = tmp_path / "x.glb"
+        glb.write_bytes(b"g")
+        running = sample_record.mark_running()
+        time.sleep(0.01)
+        done = running.mark_done(str(glb))
+        assert done.duration_seconds is not None
+        assert done.duration_seconds >= 0
+
+    def test_duration_seconds_none_when_not_started(self, sample_record: GenerationRecord):
+        assert sample_record.duration_seconds is None
+
+    def test_sampler_params(self, sample_record: GenerationRecord):
+        params = sample_record.sampler_params
+        assert "sparse_structure_sampler_params" in params
+
+    def test_roundtrip_serialization(self, sample_record: GenerationRecord):
+        d = sample_record.to_dict()
+        restored = GenerationRecord.from_dict(d)
+        assert restored.job_id == sample_record.job_id
+        assert restored.status == sample_record.status
+        assert restored.image_path == sample_record.image_path
+
+    def test_from_dict_missing_keys_raises(self):
+        with pytest.raises(ValueError, match="missing keys"):
+            GenerationRecord.from_dict({"job_id": "abc"})
+
+    def test_repr(self, sample_record: GenerationRecord):
+        r = repr(sample_record)
+        assert "GenerationRecord" in r
+        assert sample_record.job_id in r
+
+    def test_extra_field_roundtrip(self, sample_record: GenerationRecord):
+        """extra dict survives serialization."""
+        d = sample_record.to_dict()
+        d["extra"] = {"custom": "value"}
+        r = GenerationRecord.from_dict(d)
+        assert r.extra == {"custom": "value"}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestValidateStatus
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestValidateStatus:
+    @pytest.mark.parametrize("status", ["pending", "running", "done", "failed"])
+    def test_valid(self, status):
+        assert validate_status(status) == status
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="Unknown status"):
+            validate_status("exploded")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestLockedSaveJson
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestLockedSaveJson:
+    def test_creates_file(self, tmp_path: Path):
+        path = tmp_path / "sub" / "data.json"
+        _locked_save_json(path, {"hello": "world"})
+        assert path.exists()
+
+    def test_content_correct(self, tmp_path: Path):
+        path = tmp_path / "data.json"
+        _locked_save_json(path, {"key": 42})
+        data = json.loads(path.read_text())
+        assert data["key"] == 42
+
+    def test_atomic_replace(self, tmp_path: Path):
+        """Writing twice overwrites cleanly."""
+        path = tmp_path / "data.json"
+        _locked_save_json(path, {"v": 1})
+        _locked_save_json(path, {"v": 2})
+        data = json.loads(path.read_text())
+        assert data["v"] == 2
+
+    def test_creates_parent_dirs(self, tmp_path: Path):
+        path = tmp_path / "a" / "b" / "c" / "data.json"
+        _locked_save_json(path, {})
+        assert path.exists()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestSession
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSession:
+    def test_default_session(self):
+        s = Session()
+        assert s.name == "default"
+        assert s.default_resolution == "high"
+        assert s.history == []
+
+    def test_schema_constant(self):
+        assert SCHEMA.startswith("cli-anything-trellis/session/")
+
+    def test_session_path(self, tmp_path: Path):
+        p = Session.session_path("mysession")
+        assert p.name == "mysession.json"
+
+    def test_save_and_load(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        s = Session(name="test_save")
+        s.save()
+        loaded = Session.load("test_save")
+        assert loaded.name == "test_save"
+        assert loaded.schema == SCHEMA
+
+    def test_load_missing_returns_fresh(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        s = Session.load("nonexistent")
+        assert s.name == "nonexistent"
+        assert s.history == []
+
+    def test_load_corrupted_returns_fresh(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        bad = tmp_path / "corrupt.json"
+        bad.write_text("NOT JSON {{{{")
+        s = Session.load("corrupt")
+        assert s.history == []
+
+    def test_push_history(self):
+        s = Session()
+        s2 = s.push_history("aabbccdd11223344")
+        assert "aabbccdd11223344" in s2.history
+        # original unchanged
+        assert s.history == []
+
+    def test_push_history_cap(self):
+        s = Session()
+        for i in range(MAX_HISTORY + 10):
+            s = s.push_history(f"job{i:04d}0000000000")
+        assert len(s.history) == MAX_HISTORY
+
+    def test_set_setting(self):
+        s = Session()
+        s2 = s.set_setting("foo", "bar")
+        assert s2.settings["foo"] == "bar"
+        assert "foo" not in s.settings
+
+    def test_unset_setting(self):
+        s = Session()
+        s2 = s.set_setting("foo", "bar")
+        s3 = s2.unset_setting("foo")
+        assert "foo" not in s3.settings
+
+    def test_unset_missing_key_noop(self):
+        s = Session()
+        s2 = s.unset_setting("nonexistent")
+        assert s2.settings == {}
+
+    def test_delete_existing(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        s = Session(name="todel")
+        s.save()
+        assert s.delete() is True
+
+    def test_delete_missing_returns_false(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        s = Session(name="ghost")
+        assert s.delete() is False
+
+    def test_list_sessions(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        Session(name="alpha").save()
+        Session(name="beta").save()
+        names = Session.list_sessions()
+        assert "alpha" in names
+        assert "beta" in names
+
+    def test_repr(self):
+        s = Session(name="mytest")
+        assert "mytest" in repr(s)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestCatalog
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCatalog:
+    def test_append_and_iter(self, done_record: GenerationRecord, tmp_catalog: Path):
+        append_record(done_record, catalog_path=tmp_catalog)
+        records = list(iter_records(catalog_path=tmp_catalog))
+        assert len(records) == 1
+        assert records[0].job_id == done_record.job_id
+
+    def test_iter_empty(self, tmp_catalog: Path):
+        records = list(iter_records(catalog_path=tmp_catalog))
+        assert records == []
+
+    def test_iter_skips_bad_lines(self, tmp_catalog: Path):
+        tmp_catalog.parent.mkdir(parents=True, exist_ok=True)
+        tmp_catalog.write_text('NOT JSON\n{"job_id":"abc","image_path":"x","output_dir":"y"}\n')
+        records = list(iter_records(catalog_path=tmp_catalog))
+        assert len(records) == 1
+
+    def test_list_records_limit(
+        self, done_record: GenerationRecord, tmp_catalog: Path, tmp_image: Path, tmp_path: Path
+    ):
+        for i in range(5):
+            r = GenerationRecord.new(str(tmp_image), str(tmp_path / f"out{i}"))
+            append_record(r, catalog_path=tmp_catalog)
+        records = list_records(catalog_path=tmp_catalog, limit=3)
+        assert len(records) == 3
+
+    def test_list_records_status_filter(
+        self, sample_record: GenerationRecord, done_record: GenerationRecord, tmp_catalog: Path
+    ):
+        append_record(sample_record, catalog_path=tmp_catalog)
+        append_record(done_record, catalog_path=tmp_catalog)
+        done_only = list_records(catalog_path=tmp_catalog, status_filter="done")
+        assert all(r.status == "done" for r in done_only)
+
+    def test_find_record(self, done_record: GenerationRecord, tmp_catalog: Path):
+        append_record(done_record, catalog_path=tmp_catalog)
+        found = find_record(done_record.job_id, catalog_path=tmp_catalog)
+        assert found is not None
+        assert found.job_id == done_record.job_id
+
+    def test_find_record_missing(self, tmp_catalog: Path):
+        result = find_record("nonexistent0000", catalog_path=tmp_catalog)
+        assert result is None
+
+    def test_catalog_stats(
+        self, sample_record: GenerationRecord, done_record: GenerationRecord, tmp_catalog: Path
+    ):
+        append_record(sample_record, catalog_path=tmp_catalog)
+        append_record(done_record, catalog_path=tmp_catalog)
+        stats = catalog_stats(catalog_path=tmp_catalog)
+        assert stats["total"] == 2
+        assert stats["done"] == 1
+        assert stats["pending"] == 1
+
+    def test_catalog_stats_empty(self, tmp_catalog: Path):
+        stats = catalog_stats(catalog_path=tmp_catalog)
+        assert stats["total"] == 0
+
+    def test_append_multiple(self, tmp_image: Path, tmp_path: Path, tmp_catalog: Path):
+        for i in range(3):
+            r = GenerationRecord.new(str(tmp_image), str(tmp_path / f"o{i}"))
+            append_record(r, catalog_path=tmp_catalog)
+        assert len(list(iter_records(catalog_path=tmp_catalog))) == 3
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestBackendErrors
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBackendErrors:
+    def test_backend_error_hierarchy(self):
+        assert issubclass(TrellisNotFoundError, BackendError)
+        assert issubclass(TrellisPythonError, BackendError)
+        assert issubclass(GPUUnavailableError, BackendError)
+        assert issubclass(RunnerError, BackendError)
+        assert issubclass(RunnerTimeoutError, BackendError)
+
+    def test_runner_error_fields(self):
+        exc = RunnerError("boom", returncode=42, stderr="stderr text")
+        assert exc.returncode == 42
+        assert exc.stderr == "stderr text"
+        assert "boom" in str(exc)
+
+    def test_backend_error_is_runtime(self):
+        assert issubclass(BackendError, RuntimeError)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestDiscovery
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestDiscovery:
+    def test_discover_trellis_home_explicit(self, tmp_path: Path):
+        result = discover_trellis_home(explicit=str(tmp_path))
+        assert result == tmp_path.resolve()
+
+    def test_discover_trellis_home_missing(self, tmp_path: Path):
+        result = discover_trellis_home(explicit=str(tmp_path / "nonexistent"))
+        assert result is None
+
+    def test_discover_trellis_home_env(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("TRELLIS_HOME", str(tmp_path))
+        result = discover_trellis_home()
+        assert result == tmp_path.resolve()
+
+    def test_discover_trellis_home_session_value(self, tmp_path: Path):
+        result = discover_trellis_home(session_value=str(tmp_path))
+        assert result == tmp_path.resolve()
+
+    def test_discover_python_explicit(self):
+        result = discover_trellis_python(explicit="/usr/bin/python3")
+        assert result == "/usr/bin/python3"
+
+    def test_discover_python_env(self, monkeypatch):
+        monkeypatch.setenv("TRELLIS_PYTHON", "/opt/venv/bin/python")
+        result = discover_trellis_python()
+        assert result == "/opt/venv/bin/python"
+
+    def test_discover_python_fallback_sys(self, monkeypatch):
+        import sys
+
+        monkeypatch.delenv("TRELLIS_PYTHON", raising=False)
+        result = discover_trellis_python()
+        assert result == sys.executable
+
+    def test_build_runner_env_sets_trellis_home(self, tmp_path: Path):
+        env = build_runner_env(trellis_home=tmp_path)
+        assert env["TRELLIS_HOME"] == str(tmp_path)
+
+    def test_build_runner_env_pythonpath(self, tmp_path: Path):
+        env = build_runner_env(trellis_home=tmp_path)
+        assert str(tmp_path) in env["PYTHONPATH"]
+
+    def test_build_runner_env_no_home(self):
+        original = os.environ.get("TRELLIS_HOME")
+        env = build_runner_env(trellis_home=None)
+        # TRELLIS_HOME should not be set by build_runner_env if not provided
+        # (it may exist from outer env, that's fine)
+        assert isinstance(env, dict)
+
+    def test_build_runner_env_preserves_existing_pythonpath(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("PYTHONPATH", "/existing/path")
+        env = build_runner_env(trellis_home=tmp_path)
+        assert "/existing/path" in env["PYTHONPATH"]
+        assert str(tmp_path) in env["PYTHONPATH"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestCliImport
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCliImport:
+    def test_cli_importable_without_trellis(self):
+        """The CLI must be importable without trellis2/torch installed."""
+        from cli_anything.trellis.trellis_cli import cli as _cli
+
+        assert _cli is not None
+
+    def test_version_flag(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert "1.0.0" in result.output
+
+    def test_help_flag(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "trellis" in result.output.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestCliSessionCommands
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCliSessionCommands:
+    def _make_runner(self, tmp_path: Path):
+        runner = CliRunner(mix_stderr=False)
+        return runner
+
+    def test_session_show(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["session", "show"])
+        assert result.exit_code == 0
+
+    def test_session_show_json(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "session", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "name" in data
+
+    def test_session_set_and_show(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        runner.invoke(cli, ["session", "set", "mykey", "myvalue"])
+        result = runner.invoke(cli, ["--json", "session", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data.get("settings", {}).get("mykey") == "myvalue"
+
+    def test_session_list_json(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "session", "list"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_session_clear_history(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["session", "clear-history"])
+        assert result.exit_code == 0
+
+    def test_session_delete_missing(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["session", "delete", "ghost"])
+        assert result.exit_code == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestCliCatalogCommands
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCliCatalogCommands:
+    def test_catalog_list_empty(self, tmp_path: Path, monkeypatch):
+        catalog_file = tmp_path / "catalog.jsonl"
+        monkeypatch.setattr("cli_anything.trellis.core.catalog.CATALOG_FILE", catalog_file)
+        monkeypatch.setattr(
+            "cli_anything.trellis.trellis_cli.list_records",
+            lambda **kw: [],
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["catalog", "list"])
+        assert result.exit_code == 0
+
+    def test_catalog_stats_json(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(
+            "cli_anything.trellis.trellis_cli.catalog_stats",
+            lambda: {"total": 0, "done": 0, "failed": 0, "pending": 0, "running": 0},
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "catalog", "stats"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "total" in data
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestCliConfigCommands
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCliConfigCommands:
+    def test_config_show(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "show"])
+        assert result.exit_code == 0
+
+    def test_config_show_json(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "version" in data
+
+    def test_config_validate_json(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "config", "validate"])
+        # May succeed or fail depending on python path — just check JSON output
+        data = json.loads(result.output)
+        assert "valid" in data
+        assert "errors" in data
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestCliJobsCommands
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCliJobsCommands:
+    def test_jobs_list_empty_session(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["jobs", "list"])
+        assert result.exit_code == 0
+
+    def test_jobs_list_json_empty(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--json", "jobs", "list"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == []
+
+    def test_jobs_show_missing(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        monkeypatch.setattr("cli_anything.trellis.trellis_cli.find_record", lambda jid: None)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["jobs", "show", "deadbeef12345678"])
+        assert result.exit_code == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TestGenerateRunDryMock
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGenerateRunDryMock:
+    """Test generate run command with mocked backend — no GPU required."""
+
+    def test_generate_run_success(self, tmp_path: Path, tmp_image: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        glb_path = str(tmp_path / "output" / "fake.glb")
+
+        def mock_run_generation(record, python_path, trellis_home, timeout):
+            return record.mark_running().mark_done(glb_path)
+
+        monkeypatch.setattr("cli_anything.trellis.trellis_cli.run_generation", mock_run_generation)
+        monkeypatch.setattr("cli_anything.trellis.trellis_cli.append_record", lambda r, **kw: None)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["generate", "run", str(tmp_image), "--output-dir", str(tmp_path / "output")],
+        )
+        assert result.exit_code == 0
+
+    def test_generate_run_failure(self, tmp_path: Path, tmp_image: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+
+        def mock_run_generation(record, python_path, trellis_home, timeout):
+            raise RunnerError("CUDA OOM", returncode=1)
+
+        monkeypatch.setattr("cli_anything.trellis.trellis_cli.run_generation", mock_run_generation)
+        monkeypatch.setattr("cli_anything.trellis.trellis_cli.append_record", lambda r, **kw: None)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["generate", "run", str(tmp_image), "--output-dir", str(tmp_path / "output")],
+        )
+        assert result.exit_code == 1
+
+    def test_generate_run_json_success(self, tmp_path: Path, tmp_image: Path, monkeypatch):
+        monkeypatch.setattr("cli_anything.trellis.core.session.SESSIONS_DIR", tmp_path)
+        glb_path = str(tmp_path / "output" / "fake.glb")
+
+        def mock_run_generation(record, python_path, trellis_home, timeout):
+            return record.mark_running().mark_done(glb_path)
+
+        monkeypatch.setattr("cli_anything.trellis.trellis_cli.run_generation", mock_run_generation)
+        monkeypatch.setattr("cli_anything.trellis.trellis_cli.append_record", lambda r, **kw: None)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--json", "generate", "run", str(tmp_image), "--output-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "done"

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/tests/test_full_e2e.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/tests/test_full_e2e.py
@@ -1,0 +1,481 @@
+"""End-to-end tests for cli-anything-trellis.
+
+These tests require a live TRELLIS.2 GPU environment.  They are gated behind
+the TRELLIS_E2E=1 environment variable.
+
+IMPORTANT: when TRELLIS_E2E=1 is set, tests MUST run or fail explicitly —
+           they MUST NOT silently skip.  This is a hard requirement.
+
+Usage (from repo root, inside the TRELLIS.2 Python environment):
+    TRELLIS_E2E=1 TRELLIS_HOME=/path/to/trellis TRELLIS_PYTHON=/path/to/python \
+        pytest cli_anything/trellis/tests/test_full_e2e.py -v
+
+Without TRELLIS_E2E=1 the whole module is skipped with a single clear message.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ── Gate: skip the entire module when TRELLIS_E2E is not set ─────────────────
+# When TRELLIS_E2E=1 IS set, pytest.skip is never called — each test must run.
+
+_E2E_ENABLED = os.environ.get("TRELLIS_E2E", "").strip() == "1"
+
+if not _E2E_ENABLED:
+    pytest.skip(
+        "Set TRELLIS_E2E=1 to run end-to-end TRELLIS tests",
+        allow_module_level=True,
+    )
+
+# ── Below this line TRELLIS_E2E=1 is guaranteed — no more skip calls ─────────
+
+# Resolve config from environment (must be present when E2E is enabled)
+_TRELLIS_HOME = os.environ.get("TRELLIS_HOME", "")
+_TRELLIS_PYTHON = os.environ.get("TRELLIS_PYTHON", sys.executable)
+
+# Path to the runner script (co-located with this package)
+_RUNNER_PATH = Path(__file__).resolve().parent.parent / "resources" / "trellis_runner.py"
+
+# A small 512×512 solid-white PNG we generate at module level so every test can
+# use it without IO.  We keep it in a module-level tmp dir via a session fixture.
+
+_SESSION_TMP: Path | None = None
+
+
+def _make_white_png(dest: Path) -> Path:
+    """Write a 512×512 white PNG to *dest*.  Requires Pillow."""
+    try:
+        from PIL import Image  # type: ignore[import]
+    except ImportError as exc:
+        pytest.fail(f"Pillow is required for E2E tests but is not installed: {exc}")
+    img = Image.new("RGB", (512, 512), color=(255, 255, 255))
+    img.save(str(dest))
+    return dest
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def e2e_tmp(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Session-scoped temp directory for E2E artifacts."""
+    return tmp_path_factory.mktemp("e2e")
+
+
+@pytest.fixture(scope="session")
+def white_png(e2e_tmp: Path) -> Path:
+    """A 512×512 white PNG, created once per session."""
+    return _make_white_png(e2e_tmp / "white.png")
+
+
+@pytest.fixture(scope="session")
+def trellis_home() -> Path | None:
+    """Return validated TRELLIS_HOME path, or fail the test if invalid."""
+    if not _TRELLIS_HOME:
+        pytest.fail(
+            "TRELLIS_HOME must be set when TRELLIS_E2E=1.  "
+            "Export TRELLIS_HOME=/path/to/trellis2/repo"
+        )
+    p = Path(_TRELLIS_HOME)
+    if not p.is_dir():
+        pytest.fail(f"TRELLIS_HOME does not exist or is not a directory: {p}")
+    return p
+
+
+# ── Helper ────────────────────────────────────────────────────────────────────
+
+
+def _run_runner(*args: str, stdin_payload: str = "", timeout: int = 600) -> dict:
+    """Run trellis_runner.py with *args*, feeding *stdin_payload*.
+
+    Returns the parsed JSON result.  Fails the test explicitly on any error.
+    """
+    env = os.environ.copy()
+    if _TRELLIS_HOME:
+        env["TRELLIS_HOME"] = _TRELLIS_HOME
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = f"{_TRELLIS_HOME}{os.pathsep}{existing}" if existing else _TRELLIS_HOME
+
+    cmd = [_TRELLIS_PYTHON, str(_RUNNER_PATH), *args]
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=stdin_payload,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"trellis_runner.py {args[0]!r} timed out after {timeout}s")
+
+    stdout = proc.stdout.strip()
+    if not stdout:
+        pytest.fail(
+            f"trellis_runner.py {args[0]!r} produced no stdout.\nstderr: {proc.stderr.strip()}"
+        )
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        pytest.fail(
+            f"trellis_runner.py {args[0]!r} stdout is not valid JSON: {exc}\nstdout: {stdout[:500]}"
+        )
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestProbeGpu:
+    """probe-gpu subcommand — verifies CUDA availability."""
+
+    def test_probe_gpu_returns_dict(self, trellis_home: Path) -> None:
+        result = _run_runner("probe-gpu")
+        assert isinstance(result, dict), f"Expected dict, got: {type(result)}"
+
+    def test_probe_gpu_has_required_keys(self, trellis_home: Path) -> None:
+        result = _run_runner("probe-gpu")
+        assert "available" in result, f"Missing 'available' key: {result}"
+        assert "device_count" in result, f"Missing 'device_count' key: {result}"
+        assert "devices" in result, f"Missing 'devices' key: {result}"
+
+    def test_probe_gpu_cuda_available(self, trellis_home: Path) -> None:
+        """TRELLIS.2 requires CUDA — fail clearly if not available."""
+        result = _run_runner("probe-gpu")
+        if not result.get("available"):
+            pytest.fail(
+                "CUDA is not available in the TRELLIS Python environment.  "
+                "TRELLIS.2 requires a CUDA-capable GPU.  "
+                f"probe-gpu result: {result}"
+            )
+
+    def test_probe_gpu_at_least_one_device(self, trellis_home: Path) -> None:
+        result = _run_runner("probe-gpu")
+        device_count = result.get("device_count", 0)
+        assert device_count >= 1, (
+            f"Expected at least 1 CUDA device, got {device_count}.  probe-gpu result: {result}"
+        )
+
+    def test_probe_gpu_devices_have_names(self, trellis_home: Path) -> None:
+        result = _run_runner("probe-gpu")
+        devices = result.get("devices", [])
+        for device in devices:
+            assert "name" in device, f"Device missing 'name': {device}"
+            assert device["name"], f"Device has empty name: {device}"
+
+
+class TestRunnerGenerate:
+    """generate subcommand — full pipeline smoke test."""
+
+    def _make_record(
+        self,
+        image_path: str,
+        output_dir: str,
+        resolution: str = "low",
+        seed: int = 42,
+        decimation_target: int = 50_000,
+        texture_size: int = 512,
+    ) -> str:
+        """Return a JSON-serialised minimal GenerationRecord payload."""
+        import secrets
+
+        record = {
+            "job_id": secrets.token_hex(8),
+            "image_path": image_path,
+            "output_dir": output_dir,
+            "resolution": resolution,
+            "seed": seed,
+            "decimation_target": decimation_target,
+            "texture_size": texture_size,
+            "status": "pending",
+            "created_at": 0.0,
+            "started_at": None,
+            "finished_at": None,
+            "glb_path": None,
+            "error": None,
+            "extra": {},
+        }
+        return json.dumps(record)
+
+    def test_generate_low_resolution(
+        self,
+        white_png: Path,
+        e2e_tmp: Path,
+        trellis_home: Path,
+    ) -> None:
+        """Full pipeline run at low resolution (12 steps)."""
+        output_dir = str(e2e_tmp / "generate_low")
+        payload = self._make_record(
+            image_path=str(white_png),
+            output_dir=output_dir,
+            resolution="low",
+            seed=42,
+            decimation_target=50_000,
+            texture_size=512,
+        )
+
+        result = _run_runner("generate", stdin_payload=payload, timeout=600)
+
+        assert result.get("status") == "done", (
+            f"Expected status=done, got: {result.get('status')!r}\nerror: {result.get('error')}"
+        )
+        glb_path = result.get("glb_path")
+        assert glb_path, f"glb_path is empty in result: {result}"
+        assert Path(glb_path).exists(), f"GLB file does not exist on disk: {glb_path}"
+        assert Path(glb_path).suffix == ".glb", (
+            f"Expected .glb extension, got: {Path(glb_path).suffix}"
+        )
+        assert Path(glb_path).stat().st_size > 0, f"GLB file is empty: {glb_path}"
+
+    def test_generate_sets_finished_at(
+        self,
+        white_png: Path,
+        e2e_tmp: Path,
+        trellis_home: Path,
+    ) -> None:
+        output_dir = str(e2e_tmp / "generate_finished_at")
+        payload = self._make_record(
+            image_path=str(white_png),
+            output_dir=output_dir,
+            resolution="low",
+            seed=7,
+        )
+        result = _run_runner("generate", stdin_payload=payload, timeout=600)
+        assert result.get("status") == "done", f"Generation failed: {result.get('error')}"
+        finished_at = result.get("finished_at")
+        assert finished_at is not None, "finished_at not set in done result"
+        assert isinstance(finished_at, (int, float)), (
+            f"finished_at should be numeric, got: {type(finished_at)}"
+        )
+        assert finished_at > 0, f"finished_at should be positive: {finished_at}"
+
+    def test_generate_seed_preserved(
+        self,
+        white_png: Path,
+        e2e_tmp: Path,
+        trellis_home: Path,
+    ) -> None:
+        """If a positive seed is supplied, it should be echoed back."""
+        output_dir = str(e2e_tmp / "generate_seed")
+        payload = self._make_record(
+            image_path=str(white_png),
+            output_dir=output_dir,
+            resolution="low",
+            seed=1234,
+        )
+        result = _run_runner("generate", stdin_payload=payload, timeout=600)
+        assert result.get("status") == "done", f"Generation failed: {result.get('error')}"
+        assert result.get("seed") == 1234, (
+            f"Seed not preserved: expected 1234, got {result.get('seed')}"
+        )
+
+    def test_generate_negative_seed_randomised(
+        self,
+        white_png: Path,
+        e2e_tmp: Path,
+        trellis_home: Path,
+    ) -> None:
+        """seed=-1 should be replaced with a positive random seed."""
+        output_dir = str(e2e_tmp / "generate_neg_seed")
+        payload = self._make_record(
+            image_path=str(white_png),
+            output_dir=output_dir,
+            resolution="low",
+            seed=-1,
+        )
+        result = _run_runner("generate", stdin_payload=payload, timeout=600)
+        assert result.get("status") == "done", f"Generation failed: {result.get('error')}"
+        returned_seed = result.get("seed")
+        assert returned_seed is not None, "seed not in result"
+        assert returned_seed >= 0, (
+            f"Expected non-negative seed after randomisation, got: {returned_seed}"
+        )
+
+    def test_generate_missing_image_fails_gracefully(
+        self,
+        e2e_tmp: Path,
+        trellis_home: Path,
+    ) -> None:
+        """Missing image path → status=failed with descriptive error."""
+        output_dir = str(e2e_tmp / "generate_missing")
+        payload = self._make_record(
+            image_path="/nonexistent/path/image.png",
+            output_dir=output_dir,
+            resolution="low",
+            seed=1,
+        )
+        result = _run_runner("generate", stdin_payload=payload, timeout=60)
+        assert result.get("status") == "failed", (
+            f"Expected status=failed, got: {result.get('status')!r}"
+        )
+        error = result.get("error", "")
+        assert error, "Expected a non-empty error message"
+        # Should mention the image path
+        assert "/nonexistent/path/image.png" in error or "image" in error.lower(), (
+            f"Error message should reference the bad path.  Got: {error}"
+        )
+
+    def test_generate_empty_stdin_fails_gracefully(
+        self,
+        trellis_home: Path,
+    ) -> None:
+        """Empty stdin → status=failed."""
+        result = _run_runner("generate", stdin_payload="", timeout=60)
+        assert result.get("status") == "failed", (
+            f"Expected status=failed for empty stdin, got: {result.get('status')!r}"
+        )
+
+    def test_generate_invalid_json_stdin_fails_gracefully(
+        self,
+        trellis_home: Path,
+    ) -> None:
+        """Malformed JSON on stdin → status=failed."""
+        result = _run_runner("generate", stdin_payload="{not valid json}", timeout=60)
+        assert result.get("status") == "failed", (
+            f"Expected status=failed for invalid JSON, got: {result.get('status')!r}"
+        )
+
+    def test_generate_glb_filename_matches_job_id(
+        self,
+        white_png: Path,
+        e2e_tmp: Path,
+        trellis_home: Path,
+    ) -> None:
+        """GLB filename should be <job_id>.glb."""
+        import json as _json
+
+        output_dir = str(e2e_tmp / "generate_filename")
+        raw_payload = self._make_record(
+            image_path=str(white_png),
+            output_dir=output_dir,
+            resolution="low",
+            seed=99,
+        )
+        job_id = _json.loads(raw_payload)["job_id"]
+        result = _run_runner("generate", stdin_payload=raw_payload, timeout=600)
+        assert result.get("status") == "done", f"Generation failed: {result.get('error')}"
+        glb_path = result.get("glb_path", "")
+        glb_name = Path(glb_path).name
+        assert glb_name == f"{job_id}.glb", f"Expected {job_id}.glb, got: {glb_name}"
+
+
+class TestCliE2E:
+    """Full CLI command round-trip — uses the installed `trellis` entry point."""
+
+    def _cli(self, *args: str, timeout: int = 30) -> subprocess.CompletedProcess:
+        """Run the CLI via `python -m cli_anything.trellis.trellis_cli`."""
+        env = os.environ.copy()
+        if _TRELLIS_HOME:
+            env["TRELLIS_HOME"] = _TRELLIS_HOME
+        cmd = [_TRELLIS_PYTHON, "-m", "cli_anything.trellis.trellis_cli", *args]
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+
+    def test_cli_probe_gpu_json(self, trellis_home: Path) -> None:
+        """config probe-gpu --json should return valid JSON with 'available'."""
+        proc = self._cli("config", "probe-gpu", "--json")
+        assert proc.returncode == 0, f"probe-gpu exited {proc.returncode}.\nstderr: {proc.stderr}"
+        try:
+            data = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            pytest.fail(f"probe-gpu --json output is not valid JSON: {exc}\n{proc.stdout[:200]}")
+        assert "available" in data, f"'available' not in probe-gpu JSON: {data}"
+
+    def test_cli_generate_run(
+        self,
+        white_png: Path,
+        e2e_tmp: Path,
+        trellis_home: Path,
+    ) -> None:
+        """generate run → JSON result with status=done and glb_path."""
+        output_dir = str(e2e_tmp / "cli_generate")
+        proc = self._cli(
+            "--json",
+            "--trellis-home",
+            str(trellis_home),
+            "--trellis-python",
+            _TRELLIS_PYTHON,
+            "generate",
+            "run",
+            "--image",
+            str(white_png),
+            "--output-dir",
+            output_dir,
+            "--resolution",
+            "low",
+            "--seed",
+            "42",
+            timeout=600,
+        )
+        assert proc.returncode == 0, (
+            f"generate run exited {proc.returncode}.\nstderr: {proc.stderr}\nstdout: {proc.stdout}"
+        )
+        try:
+            data = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            pytest.fail(f"generate run --json output is not valid JSON: {exc}\n{proc.stdout[:500]}")
+        assert data.get("status") == "done", (
+            f"Expected status=done, got: {data.get('status')!r}\nerror: {data.get('error')}"
+        )
+        glb = data.get("glb_path", "")
+        assert glb and Path(glb).exists(), f"glb_path absent or file missing: {glb!r}"
+
+    def test_cli_jobs_list_after_generate(
+        self,
+        white_png: Path,
+        e2e_tmp: Path,
+        trellis_home: Path,
+    ) -> None:
+        """After a successful generate run the job appears in jobs list."""
+        output_dir = str(e2e_tmp / "cli_jobs_list")
+        # Run a generation so there is something in the catalog
+        proc = self._cli(
+            "--json",
+            "--trellis-home",
+            str(trellis_home),
+            "--trellis-python",
+            _TRELLIS_PYTHON,
+            "generate",
+            "run",
+            "--image",
+            str(white_png),
+            "--output-dir",
+            output_dir,
+            "--resolution",
+            "low",
+            "--seed",
+            "11",
+            timeout=600,
+        )
+        if proc.returncode != 0:
+            pytest.fail(
+                f"Pre-condition generate failed (exit {proc.returncode}).\nstderr: {proc.stderr}"
+            )
+        gen_data = json.loads(proc.stdout)
+        job_id = gen_data.get("job_id")
+        assert job_id, "job_id not in generate output"
+
+        # Now list jobs
+        list_proc = self._cli("--json", "jobs", "list")
+        assert list_proc.returncode == 0, (
+            f"jobs list exited {list_proc.returncode}.\nstderr: {list_proc.stderr}"
+        )
+        try:
+            jobs = json.loads(list_proc.stdout)
+        except json.JSONDecodeError as exc:
+            pytest.fail(f"jobs list --json output is not valid JSON: {exc}")
+        job_ids = [j.get("job_id") for j in jobs]
+        assert job_id in job_ids, f"job_id {job_id!r} not found in jobs list: {job_ids}"

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/trellis_cli.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/trellis_cli.py
@@ -1,0 +1,685 @@
+"""cli-anything-trellis — Click CLI for Microsoft TRELLIS.2 image-to-3D.
+
+Entry point: `trellis` (or `python -m cli_anything.trellis.trellis_cli`)
+
+Command groups:
+    generate    Submit image-to-3D generation jobs
+    jobs        List and inspect generation jobs
+    catalog     Browse the generation history catalog
+    session     Manage REPL session state
+    config      Show/set environment configuration
+    repl        Drop into interactive REPL (default when called with no args)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import click
+from cli_anything.trellis import __version__
+from cli_anything.trellis.core.catalog import (append_record, catalog_stats,
+                                               find_record, list_records)
+from cli_anything.trellis.core.generation import (DEFAULT_RESOLUTION,
+                                                  RESOLUTION_PRESETS,
+                                                  GenerationRecord)
+from cli_anything.trellis.core.session import Session
+from cli_anything.trellis.utils.repl_skin import ReplSkin
+from cli_anything.trellis.utils.trellis_backend import (
+    BackendError, GPUUnavailableError, RunnerError, RunnerTimeoutError,
+    TrellisNotFoundError, TrellisPythonError, discover_trellis_home,
+    discover_trellis_python, probe_gpu, run_generation, validate_python,
+    validate_trellis_home)
+
+# ── CLI state object ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class CliState:
+    """Shared state injected via Click context (ctx.obj)."""
+
+    json_output: bool = False
+    session_name: str = "default"
+    trellis_home_override: Optional[str] = None
+    trellis_python_override: Optional[str] = None
+
+    _session: Optional[Session] = None
+    _skin: Optional[ReplSkin] = None
+
+    @property
+    def session(self) -> Session:
+        if self._session is None:
+            self._session = Session.load(self.session_name)
+        return self._session
+
+    @session.setter
+    def session(self, value: Session) -> None:
+        self._session = value
+
+    def save_session(self) -> None:
+        if self._session is not None:
+            self._session.save()
+
+    @property
+    def skin(self) -> ReplSkin:
+        if self._skin is None:
+            self._skin = ReplSkin("trellis", version=__version__)
+        return self._skin
+
+    def resolved_trellis_home(self) -> Optional[Path]:
+        return discover_trellis_home(
+            explicit=self.trellis_home_override,
+            session_value=self.session.trellis_home,
+        )
+
+    def resolved_python(self) -> str:
+        return discover_trellis_python(
+            explicit=self.trellis_python_override,
+            session_value=self.session.trellis_python,
+        )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def emit(state: CliState, data: Any) -> None:
+    """Emit data as JSON (--json mode) or human-readable."""
+    if state.json_output:
+        click.echo(json.dumps(data, ensure_ascii=False, indent=2))
+    else:
+        if isinstance(data, str):
+            click.echo(data)
+        elif isinstance(data, dict):
+            for k, v in data.items():
+                click.echo(f"  {k}: {v}")
+        elif isinstance(data, list):
+            for item in data:
+                click.echo(f"  {item}")
+        else:
+            click.echo(str(data))
+
+
+def handle_backend_error(state: CliState, exc: Exception) -> None:
+    """Print a user-friendly error and exit 1."""
+    msg = str(exc)
+    if state.json_output:
+        click.echo(json.dumps({"error": msg, "type": type(exc).__name__}), err=True)
+    else:
+        state.skin.error(msg)
+    sys.exit(1)
+
+
+def _record_to_row(r: GenerationRecord) -> List[str]:
+    """Convert a GenerationRecord to a table row."""
+    duration = ""
+    if r.duration_seconds is not None:
+        duration = f"{r.duration_seconds:.1f}s"
+    return [
+        r.job_id[:12],
+        r.status,
+        r.resolution,
+        Path(r.image_path).name if r.image_path else "",
+        duration,
+        Path(r.glb_path).name if r.glb_path else (r.error or "")[:40],
+    ]
+
+
+# ── Root group ────────────────────────────────────────────────────────────────
+
+
+@click.group(invoke_without_command=True)
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON output.")
+@click.option(
+    "--session",
+    "session_name",
+    default="default",
+    show_default=True,
+    help="Session name to load.",
+)
+@click.option("--trellis-home", "trellis_home", default=None, help="TRELLIS.2 install dir.")
+@click.option("--trellis-python", "trellis_python", default=None, help="Python with trellis2.")
+@click.version_option(__version__, prog_name="trellis")
+@click.pass_context
+def cli(
+    ctx: click.Context,
+    json_output: bool,
+    session_name: str,
+    trellis_home: Optional[str],
+    trellis_python: Optional[str],
+) -> None:
+    """cli-anything-trellis: Microsoft TRELLIS.2 image-to-3D CLI harness."""
+    ctx.ensure_object(dict)
+    state = CliState(
+        json_output=json_output,
+        session_name=session_name,
+        trellis_home_override=trellis_home,
+        trellis_python_override=trellis_python,
+    )
+    ctx.obj = state
+
+    if ctx.invoked_subcommand is None:
+        # Default to REPL
+        ctx.invoke(repl)
+
+
+# ── generate group ────────────────────────────────────────────────────────────
+
+
+@cli.group()
+@click.pass_context
+def generate(ctx: click.Context) -> None:
+    """Submit image-to-3D generation jobs."""
+
+
+@generate.command("run")
+@click.argument("image", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--output-dir",
+    "-o",
+    default=None,
+    help="Output directory for GLB files. Defaults to session default or ./trellis-output/.",
+)
+@click.option(
+    "--resolution",
+    "-r",
+    type=click.Choice(list(RESOLUTION_PRESETS.keys())),
+    default=None,
+    help="Quality preset (low/high). Defaults to session default.",
+)
+@click.option("--seed", default=-1, show_default=True, help="Random seed (-1 = random).")
+@click.option(
+    "--decimation-target",
+    default=1_000_000,
+    show_default=True,
+    help="Target polygon count for GLB decimation.",
+)
+@click.option(
+    "--texture-size",
+    default=4096,
+    show_default=True,
+    help="Texture atlas size in pixels.",
+)
+@click.option(
+    "--timeout",
+    default=None,
+    type=int,
+    help="Runner timeout in seconds (default: no limit).",
+)
+@click.pass_obj
+def generate_run(
+    state: CliState,
+    image: str,
+    output_dir: Optional[str],
+    resolution: Optional[str],
+    seed: int,
+    decimation_target: int,
+    texture_size: int,
+    timeout: Optional[int],
+) -> None:
+    """Generate a 3D GLB from IMAGE (path to an image file)."""
+    resolved_output = output_dir or state.session.default_output_dir or "./trellis-output"
+    resolved_resolution = resolution or state.session.default_resolution or DEFAULT_RESOLUTION
+
+    try:
+        record = GenerationRecord.new(
+            image_path=image,
+            output_dir=resolved_output,
+            resolution=resolved_resolution,
+            seed=seed,
+            decimation_target=decimation_target,
+            texture_size=texture_size,
+        )
+    except ValueError as exc:
+        handle_backend_error(state, exc)
+        return
+
+    python_path = state.resolved_python()
+    trellis_home = state.resolved_trellis_home()
+
+    if not state.json_output:
+        state.skin.info(f"Starting job {record.job_id} ...")
+        state.skin.status("image", record.image_path)
+        state.skin.status("resolution", record.resolution)
+        state.skin.status("seed", str(record.seed) if record.seed >= 0 else "random")
+        state.skin.status("output", record.output_dir)
+
+    try:
+        result = run_generation(
+            record=record,
+            python_path=python_path,
+            trellis_home=trellis_home,
+            timeout=timeout,
+        )
+    except (RunnerError, RunnerTimeoutError, BackendError) as exc:
+        # Still append failed record to catalog for visibility
+        failed = record.mark_failed(str(exc))
+        append_record(failed)
+        handle_backend_error(state, exc)
+        return
+
+    # Persist to catalog and session history
+    append_record(result)
+    state.session = state.session.push_history(result.job_id)
+    state.save_session()
+
+    if state.json_output:
+        emit(state, result.to_dict())
+    else:
+        if result.status == "done":
+            state.skin.success(f"GLB saved: {result.glb_path}")
+            if result.duration_seconds:
+                state.skin.status("duration", f"{result.duration_seconds:.1f}s")
+        else:
+            state.skin.error(f"Job failed: {result.error}")
+            sys.exit(1)
+
+
+# ── jobs group ────────────────────────────────────────────────────────────────
+
+
+@cli.group()
+@click.pass_context
+def jobs(ctx: click.Context) -> None:
+    """List and inspect generation jobs from session history."""
+
+
+@jobs.command("list")
+@click.option("--limit", "-n", default=20, show_default=True, help="Max jobs to show.")
+@click.pass_obj
+def jobs_list(state: CliState, limit: int) -> None:
+    """List recent jobs from the session history."""
+    history = state.session.history[-limit:]
+    if not history:
+        if state.json_output:
+            emit(state, [])
+        else:
+            state.skin.info("No jobs in session history.")
+        return
+
+    records = []
+    for job_id in reversed(history):
+        r = find_record(job_id)
+        if r:
+            records.append(r)
+
+    if state.json_output:
+        emit(state, [r.to_dict() for r in records])
+        return
+
+    headers = ["JOB ID", "STATUS", "RES", "IMAGE", "TIME", "OUTPUT/ERROR"]
+    rows = [_record_to_row(r) for r in records]
+    state.skin.table(headers, rows)
+
+
+@jobs.command("show")
+@click.argument("job_id")
+@click.pass_obj
+def jobs_show(state: CliState, job_id: str) -> None:
+    """Show details for a specific JOB_ID."""
+    record = find_record(job_id)
+    if record is None:
+        handle_backend_error(state, BackendError(f"Job not found: {job_id}"))
+        return
+
+    if state.json_output:
+        emit(state, record.to_dict())
+        return
+
+    state.skin.status_block(
+        {
+            "job_id": record.job_id,
+            "status": record.status,
+            "resolution": record.resolution,
+            "seed": str(record.seed),
+            "image": record.image_path,
+            "output_dir": record.output_dir,
+            "glb": record.glb_path or "(none)",
+            "duration": f"{record.duration_seconds:.1f}s" if record.duration_seconds else "(n/a)",
+            "error": record.error or "(none)",
+        },
+        title="Job Details",
+    )
+
+
+# ── catalog group ─────────────────────────────────────────────────────────────
+
+
+@cli.group()
+@click.pass_context
+def catalog(ctx: click.Context) -> None:
+    """Browse the generation history catalog."""
+
+
+@catalog.command("list")
+@click.option("--status", "status_filter", default=None, help="Filter by status.")
+@click.option("--limit", "-n", default=50, show_default=True, help="Max records to show.")
+@click.pass_obj
+def catalog_list(state: CliState, status_filter: Optional[str], limit: int) -> None:
+    """List records from the catalog."""
+    records = list_records(status_filter=status_filter, limit=limit)
+    if state.json_output:
+        emit(state, [r.to_dict() for r in records])
+        return
+
+    if not records:
+        state.skin.info("Catalog is empty.")
+        return
+
+    headers = ["JOB ID", "STATUS", "RES", "IMAGE", "TIME", "OUTPUT/ERROR"]
+    rows = [_record_to_row(r) for r in reversed(records)]
+    state.skin.table(headers, rows)
+
+
+@catalog.command("stats")
+@click.pass_obj
+def catalog_stats_cmd(state: CliState) -> None:
+    """Show summary statistics for the catalog."""
+    stats = catalog_stats()
+    if state.json_output:
+        emit(state, stats)
+        return
+    state.skin.status_block(
+        {k: str(v) for k, v in stats.items()},
+        title="Catalog Statistics",
+    )
+
+
+# ── session group ─────────────────────────────────────────────────────────────
+
+
+@cli.group()
+@click.pass_context
+def session(ctx: click.Context) -> None:
+    """Manage REPL session state."""
+
+
+@session.command("show")
+@click.pass_obj
+def session_show(state: CliState) -> None:
+    """Show current session state."""
+    s = state.session
+    data = s._to_dict()
+    if state.json_output:
+        emit(state, data)
+        return
+    state.skin.status_block(
+        {
+            "name": s.name,
+            "trellis_home": s.trellis_home or "(not set)",
+            "trellis_python": s.trellis_python or "(not set)",
+            "default_resolution": s.default_resolution,
+            "default_output_dir": s.default_output_dir or "(not set)",
+            "history_count": str(len(s.history)),
+            "settings": str(s.settings) if s.settings else "(empty)",
+        },
+        title="Session",
+    )
+
+
+@session.command("set")
+@click.argument("key")
+@click.argument("value")
+@click.pass_obj
+def session_set(state: CliState, key: str, value: str) -> None:
+    """Set a session KEY to VALUE.
+
+    Special keys: trellis_home, trellis_python, default_resolution, default_output_dir.
+    Any other key goes into session.settings dict.
+    """
+    s = state.session
+    special_keys = {"trellis_home", "trellis_python", "default_resolution", "default_output_dir"}
+    if key in special_keys:
+        kwargs = {**s._to_dict_fields(), key: value}
+        state.session = Session(**kwargs)
+    else:
+        state.session = s.set_setting(key, value)
+    state.save_session()
+
+    if state.json_output:
+        emit(state, {"set": key, "value": value})
+    else:
+        state.skin.success(f"Set {key} = {value}")
+
+
+@session.command("unset")
+@click.argument("key")
+@click.pass_obj
+def session_unset(state: CliState, key: str) -> None:
+    """Remove KEY from session settings."""
+    state.session = state.session.unset_setting(key)
+    state.save_session()
+    if state.json_output:
+        emit(state, {"unset": key})
+    else:
+        state.skin.success(f"Unset {key}")
+
+
+@session.command("list")
+@click.pass_obj
+def session_list(state: CliState) -> None:
+    """List all saved sessions."""
+    sessions = Session.list_sessions()
+    if state.json_output:
+        emit(state, sessions)
+        return
+    if not sessions:
+        state.skin.info("No saved sessions.")
+        return
+    for name in sessions:
+        marker = " (active)" if name == state.session_name else ""
+        state.skin.info(f"{name}{marker}")
+
+
+@session.command("delete")
+@click.argument("name")
+@click.pass_obj
+def session_delete(state: CliState, name: str) -> None:
+    """Delete a saved session by NAME."""
+    s = Session.load(name)
+    deleted = s.delete()
+    if state.json_output:
+        emit(state, {"deleted": deleted, "name": name})
+    else:
+        if deleted:
+            state.skin.success(f"Deleted session: {name}")
+        else:
+            state.skin.warning(f"Session not found: {name}")
+
+
+@session.command("clear-history")
+@click.pass_obj
+def session_clear_history(state: CliState) -> None:
+    """Clear job history from the current session."""
+    s = state.session
+    state.session = Session(**{**s._to_dict_fields(), "history": []})
+    state.save_session()
+    if state.json_output:
+        emit(state, {"cleared": True})
+    else:
+        state.skin.success("Session history cleared.")
+
+
+# ── config group ──────────────────────────────────────────────────────────────
+
+
+@cli.group()
+@click.pass_context
+def config(ctx: click.Context) -> None:
+    """Show and validate environment configuration."""
+
+
+@config.command("show")
+@click.pass_obj
+def config_show(state: CliState) -> None:
+    """Show resolved configuration (home, python, GPU)."""
+    trellis_home = state.resolved_trellis_home()
+    python_path = state.resolved_python()
+
+    data: Dict[str, Any] = {
+        "trellis_home": str(trellis_home) if trellis_home else None,
+        "trellis_python": python_path,
+        "session": state.session_name,
+        "version": __version__,
+    }
+
+    if state.json_output:
+        emit(state, data)
+        return
+
+    state.skin.status_block(
+        {
+            "trellis_home": str(trellis_home) if trellis_home else "(not found — set TRELLIS_HOME)",
+            "trellis_python": python_path,
+            "session": state.session_name,
+            "version": __version__,
+        },
+        title="Configuration",
+    )
+
+
+@config.command("validate")
+@click.pass_obj
+def config_validate(state: CliState) -> None:
+    """Validate that TRELLIS.2 home and python are correctly configured."""
+    python_path = state.resolved_python()
+    trellis_home = state.resolved_trellis_home()
+
+    errors: List[str] = []
+
+    try:
+        validate_python(python_path)
+        if not state.json_output:
+            state.skin.success(f"Python OK: {python_path}")
+    except TrellisPythonError as exc:
+        errors.append(str(exc))
+        if not state.json_output:
+            state.skin.error(str(exc))
+
+    if trellis_home:
+        try:
+            validate_trellis_home(trellis_home)
+            if not state.json_output:
+                state.skin.success(f"TRELLIS home OK: {trellis_home}")
+        except TrellisNotFoundError as exc:
+            errors.append(str(exc))
+            if not state.json_output:
+                state.skin.error(str(exc))
+    else:
+        msg = "TRELLIS_HOME not set — set via --trellis-home, TRELLIS_HOME env, or session set trellis_home <path>"
+        if not state.json_output:
+            state.skin.warning(msg)
+
+    if state.json_output:
+        emit(state, {"valid": len(errors) == 0, "errors": errors})
+    elif errors:
+        sys.exit(1)
+
+
+@config.command("probe-gpu")
+@click.pass_obj
+def config_probe_gpu(state: CliState) -> None:
+    """Probe GPU availability via the runner subprocess."""
+    python_path = state.resolved_python()
+    trellis_home = state.resolved_trellis_home()
+
+    try:
+        info = probe_gpu(python_path=python_path, trellis_home=trellis_home)
+    except (GPUUnavailableError, TrellisPythonError, BackendError) as exc:
+        handle_backend_error(state, exc)
+        return
+
+    if state.json_output:
+        emit(state, info)
+        return
+
+    if info.get("available"):
+        state.skin.success(f"CUDA available — {info.get('device_count', 0)} device(s)")
+        for dev in info.get("devices", []):
+            state.skin.status(
+                f"  GPU {dev['index']}", f"{dev['name']} ({dev['total_memory_gb']} GB)"
+            )
+    else:
+        state.skin.error("CUDA not available")
+        if "error" in info:
+            state.skin.hint(info["error"])
+
+
+# ── repl command ──────────────────────────────────────────────────────────────
+
+
+@cli.command("repl")
+@click.pass_obj
+def repl(state: CliState) -> None:
+    """Drop into an interactive REPL (default when no subcommand given)."""
+    skin = state.skin
+    skin.print_banner()
+
+    pt_session = skin.create_prompt_session()
+
+    _REPL_HELP: Dict[str, str] = {
+        "generate run <image>": "Generate 3D GLB from image file",
+        "jobs list": "List recent jobs from session history",
+        "jobs show <id>": "Show job details",
+        "catalog list": "Browse all generation history",
+        "catalog stats": "Show catalog statistics",
+        "session show": "Show current session",
+        "session set <k> <v>": "Set session key",
+        "config show": "Show resolved configuration",
+        "config validate": "Validate TRELLIS home + python",
+        "config probe-gpu": "Probe GPU availability",
+        "help": "Show this help",
+        "quit / exit": "Exit REPL",
+    }
+
+    while True:
+        try:
+            raw = skin.get_input(
+                pt_session,
+                context=state.session_name,
+            )
+        except (KeyboardInterrupt, EOFError):
+            skin.print_goodbye()
+            break
+
+        if not raw:
+            continue
+
+        line = raw.strip()
+        lower = line.lower()
+
+        if lower in {"quit", "exit", "q"}:
+            skin.print_goodbye()
+            break
+
+        if lower in {"help", "h", "?"}:
+            skin.help(_REPL_HELP)
+            continue
+
+        # Parse and dispatch via Click in standalone_mode=False
+        args = line.split()
+        try:
+            cli.main(args=args, obj=state, standalone_mode=False)
+        except SystemExit:
+            pass
+        except click.exceptions.UsageError as exc:
+            skin.error(str(exc))
+        except click.exceptions.Abort:
+            pass
+        except Exception as exc:
+            skin.error(f"Unexpected error: {exc}")
+
+
+# ── Module entry point ────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/utils/__init__.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/utils/__init__.py
@@ -1,0 +1,1 @@
+"""cli-anything-trellis utility modules."""

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/utils/repl_skin.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/utils/repl_skin.py
@@ -1,0 +1,575 @@
+"""cli-anything REPL Skin — Unified terminal interface for all CLI harnesses.
+
+Copy this file into your CLI package at:
+    cli_anything/<software>/utils/repl_skin.py
+
+Usage:
+    from cli_anything.<software>.utils.repl_skin import ReplSkin
+
+    skin = ReplSkin("shotcut", version="1.0.0")
+    skin.print_banner()  # auto-detects repo-root or packaged SKILL.md
+    prompt_text = skin.prompt(project_name="my_video.mlt", modified=True)
+    skin.success("Project saved")
+    skin.error("File not found")
+    skin.warning("Unsaved changes")
+    skin.info("Processing 24 clips...")
+    skin.status("Track 1", "3 clips, 00:02:30")
+    skin.table(headers, rows)
+    skin.print_goodbye()
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# ── ANSI color codes (no external deps for core styling) ──────────────
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_ITALIC = "\033[3m"
+_UNDERLINE = "\033[4m"
+
+# Brand colors
+_CYAN = "\033[38;5;80m"  # cli-anything brand cyan
+_CYAN_BG = "\033[48;5;80m"
+_WHITE = "\033[97m"
+_GRAY = "\033[38;5;245m"
+_DARK_GRAY = "\033[38;5;240m"
+_LIGHT_GRAY = "\033[38;5;250m"
+
+# Software accent colors — each software gets a unique accent
+_ACCENT_COLORS = {
+    "gimp": "\033[38;5;214m",  # warm orange
+    "blender": "\033[38;5;208m",  # deep orange
+    "inkscape": "\033[38;5;39m",  # bright blue
+    "audacity": "\033[38;5;33m",  # navy blue
+    "libreoffice": "\033[38;5;40m",  # green
+    "obs_studio": "\033[38;5;55m",  # purple
+    "kdenlive": "\033[38;5;69m",  # slate blue
+    "shotcut": "\033[38;5;35m",  # teal green
+    "trellis": "\033[38;5;135m",  # violet (TRELLIS.2 accent)
+}
+_DEFAULT_ACCENT = "\033[38;5;75m"  # default sky blue
+
+# Status colors
+_GREEN = "\033[38;5;78m"
+_YELLOW = "\033[38;5;220m"
+_RED = "\033[38;5;196m"
+_BLUE = "\033[38;5;75m"
+_MAGENTA = "\033[38;5;176m"
+
+_SKILL_SOURCE_REPO = os.environ.get("CLI_ANYTHING_SKILL_REPO", "HKUDS/CLI-Anything")
+
+# ── Brand icon ────────────────────────────────────────────────────────
+
+# The cli-anything icon: a small colored diamond/chevron mark
+_ICON = f"{_CYAN}{_BOLD}◆{_RESET}"
+_ICON_SMALL = f"{_CYAN}▸{_RESET}"
+
+# ── Box drawing characters ────────────────────────────────────────────
+
+_H_LINE = "─"
+_V_LINE = "│"
+_TL = "╭"
+_TR = "╮"
+_BL = "╰"
+_BR = "╯"
+_T_DOWN = "┬"
+_T_UP = "┴"
+_T_RIGHT = "├"
+_T_LEFT = "┤"
+_CROSS = "┼"
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes for length calculation."""
+    import re
+
+    return re.sub(r"\033\[[^m]*m", "", text)
+
+
+def _visible_len(text: str) -> int:
+    """Get visible length of text (excluding ANSI codes)."""
+    return len(_strip_ansi(text))
+
+
+def _display_home_path(path: str) -> str:
+    """Display a path relative to the home directory when possible."""
+    expanded = Path(path).expanduser().resolve()
+    home = Path.home().resolve()
+    try:
+        relative = expanded.relative_to(home)
+        return f"~/{relative.as_posix()}"
+    except ValueError:
+        return str(expanded)
+
+
+class ReplSkin:
+    """Unified REPL skin for cli-anything CLIs.
+
+    Provides consistent branding, prompts, and message formatting
+    across all CLI harnesses built with the cli-anything methodology.
+    """
+
+    def __init__(
+        self,
+        software: str,
+        version: str = "1.0.0",
+        history_file: str | None = None,
+        skill_path: str | None = None,
+    ):
+        """Initialize the REPL skin.
+
+        Args:
+            software: Software name (e.g., "gimp", "shotcut", "blender").
+            version: CLI version string.
+            history_file: Path for persistent command history.
+                         Defaults to ~/.cli-anything-<software>/history
+            skill_path: Path to the SKILL.md file for agent discovery.
+                        Auto-detected from the repo-root skills/ tree when present,
+                        otherwise from the package's skills/ directory.
+                        Displayed in banner for AI agents to know where to read skill info.
+        """
+        self.software = software.lower().replace("-", "_")
+        self.display_name = software.replace("_", " ").title()
+        self.version = version
+        software_aliases = {"iterm2_ctl": "iterm2"}
+        self.skill_slug = software_aliases.get(self.software, self.software).replace("_", "-")
+        self.skill_id = f"cli-anything-{self.skill_slug}"
+        self.skill_install_cmd = (
+            f"npx skills add {_SKILL_SOURCE_REPO} --skill {self.skill_id} -g -y"
+        )
+        global_skill_root = Path(
+            os.environ.get(
+                "CLI_ANYTHING_GLOBAL_SKILLS_DIR", str(Path.home() / ".agents" / "skills")
+            )
+        ).expanduser()
+        self.global_skill_path = str(global_skill_root / self.skill_id / "SKILL.md")
+
+        # Prefer repo-root canonical skills/<skill-id>/SKILL.md when running
+        # inside the CLI-Anything monorepo. Fall back to the packaged
+        # cli_anything/<software>/skills/SKILL.md for installed harnesses.
+        if skill_path is None:
+            package_skill = Path(__file__).resolve().parent.parent / "skills" / "SKILL.md"
+            repo_skill = None
+            for parent in Path(__file__).resolve().parents:
+                candidate = parent / "skills" / self.skill_id / "SKILL.md"
+                if candidate.is_file():
+                    repo_skill = candidate
+                    break
+            if repo_skill and repo_skill.is_file():
+                skill_path = str(repo_skill)
+            elif package_skill.is_file():
+                skill_path = str(package_skill)
+        self.skill_path = skill_path
+        self.accent = _ACCENT_COLORS.get(self.software, _DEFAULT_ACCENT)
+
+        # History file
+        if history_file is None:
+            hist_dir = Path.home() / f".cli-anything-{self.software}"
+            hist_dir.mkdir(parents=True, exist_ok=True)
+            self.history_file = str(hist_dir / "history")
+        else:
+            self.history_file = history_file
+
+        # Detect terminal capabilities
+        self._color = self._detect_color_support()
+
+    def _detect_color_support(self) -> bool:
+        """Check if terminal supports color."""
+        if os.environ.get("NO_COLOR"):
+            return False
+        if os.environ.get("CLI_ANYTHING_NO_COLOR"):
+            return False
+        if not hasattr(sys.stdout, "isatty"):
+            return False
+        return sys.stdout.isatty()
+
+    def _c(self, code: str, text: str) -> str:
+        """Apply color code if colors are supported."""
+        if not self._color:
+            return text
+        return f"{code}{text}{_RESET}"
+
+    # ── Banner ────────────────────────────────────────────────────────
+
+    def print_banner(self):
+        """Print the startup banner with branding."""
+        import textwrap
+
+        inner = 72
+
+        def _box_line(content: str) -> str:
+            """Wrap content in box drawing, padding to inner width."""
+            pad = inner - _visible_len(content)
+            vl = self._c(_DARK_GRAY, _V_LINE)
+            return f"{vl}{content}{' ' * max(0, pad)}{vl}"
+
+        def _meta_lines(label: str, value: str) -> list[str]:
+            """Wrap a metadata line for the banner box."""
+            icon = self._c(_MAGENTA, "◇")
+            label_text = self._c(_DARK_GRAY, label)
+            prefix = f" {icon} {label_text} "
+            available = max(12, inner - _visible_len(prefix))
+            wrapped = textwrap.wrap(
+                value,
+                width=available,
+                break_long_words=True,
+                break_on_hyphens=False,
+            ) or [""]
+            lines = [f"{prefix}{self._c(_LIGHT_GRAY, wrapped[0])}"]
+            continuation_prefix = " " * _visible_len(prefix)
+            for chunk in wrapped[1:]:
+                lines.append(f"{continuation_prefix}{self._c(_LIGHT_GRAY, chunk)}")
+            return lines
+
+        top = self._c(_DARK_GRAY, f"{_TL}{_H_LINE * inner}{_TR}")
+        bot = self._c(_DARK_GRAY, f"{_BL}{_H_LINE * inner}{_BR}")
+
+        # Title:  ◆  cli-anything · Trellis
+        icon = self._c(_CYAN + _BOLD, "◆")
+        brand = self._c(_CYAN + _BOLD, "cli-anything")
+        dot = self._c(_DARK_GRAY, "·")
+        name = self._c(self.accent + _BOLD, self.display_name)
+        title = f" {icon}  {brand} {dot} {name}"
+
+        ver = f" {self._c(_DARK_GRAY, f'   v{self.version}')}"
+        tip = f" {self._c(_DARK_GRAY, '   Type help for commands, quit to exit')}"
+        empty = ""
+
+        meta_lines: list[str] = []
+        meta_lines.extend(_meta_lines("Install:", self.skill_install_cmd))
+        meta_lines.extend(_meta_lines("Global skill:", _display_home_path(self.global_skill_path)))
+        print(top)
+        print(_box_line(title))
+        print(_box_line(ver))
+        for line in meta_lines:
+            print(_box_line(line))
+        print(_box_line(empty))
+        print(_box_line(tip))
+        print(bot)
+        print()
+
+    # ── Prompt ────────────────────────────────────────────────────────
+
+    def prompt(self, project_name: str = "", modified: bool = False, context: str = "") -> str:
+        """Build a styled prompt string for prompt_toolkit or input().
+
+        Args:
+            project_name: Current project name (empty if none open).
+            modified: Whether the project has unsaved changes.
+            context: Optional extra context to show in prompt.
+
+        Returns:
+            Formatted prompt string.
+        """
+        parts = []
+
+        # Icon
+        if self._color:
+            parts.append(f"{_CYAN}◆{_RESET} ")
+        else:
+            parts.append("> ")
+
+        # Software name
+        parts.append(self._c(self.accent + _BOLD, self.software))
+
+        # Project context
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            parts.append(f" {self._c(_DARK_GRAY, '[')}")
+            parts.append(self._c(_LIGHT_GRAY, f"{ctx}{mod}"))
+            parts.append(self._c(_DARK_GRAY, "]"))
+
+        parts.append(self._c(_GRAY, " ❯ "))
+
+        return "".join(parts)
+
+    def prompt_tokens(self, project_name: str = "", modified: bool = False, context: str = ""):
+        """Build prompt_toolkit formatted text tokens for the prompt.
+
+        Use with prompt_toolkit's FormattedText for proper ANSI handling.
+
+        Returns:
+            list of (style, text) tuples for prompt_toolkit.
+        """
+        tokens = []
+
+        tokens.append(("class:icon", "◆ "))
+        tokens.append(("class:software", self.software))
+
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            tokens.append(("class:bracket", " ["))
+            tokens.append(("class:context", f"{ctx}{mod}"))
+            tokens.append(("class:bracket", "]"))
+
+        tokens.append(("class:arrow", " ❯ "))
+
+        return tokens
+
+    def get_prompt_style(self):
+        """Get a prompt_toolkit Style object matching the skin.
+
+        Returns:
+            prompt_toolkit.styles.Style
+        """
+        try:
+            from prompt_toolkit.styles import Style
+        except ImportError:
+            return None
+
+        accent_hex = _ANSI_256_TO_HEX.get(self.accent, "#5fafff")
+
+        return Style.from_dict(
+            {
+                "icon": "#5fdfdf bold",  # cyan brand color
+                "software": f"{accent_hex} bold",
+                "bracket": "#585858",
+                "context": "#bcbcbc",
+                "arrow": "#808080",
+                # Completion menu
+                "completion-menu.completion": "bg:#303030 #bcbcbc",
+                "completion-menu.completion.current": f"bg:{accent_hex} #000000",
+                "completion-menu.meta.completion": "bg:#303030 #808080",
+                "completion-menu.meta.completion.current": f"bg:{accent_hex} #000000",
+                # Auto-suggest
+                "auto-suggest": "#585858",
+                # Bottom toolbar
+                "bottom-toolbar": "bg:#1c1c1c #808080",
+                "bottom-toolbar.text": "#808080",
+            }
+        )
+
+    # ── Messages ──────────────────────────────────────────────────────
+
+    def success(self, message: str):
+        """Print a success message with green checkmark."""
+        icon = self._c(_GREEN + _BOLD, "✓")
+        print(f"  {icon} {self._c(_GREEN, message)}")
+
+    def error(self, message: str):
+        """Print an error message with red cross."""
+        icon = self._c(_RED + _BOLD, "✗")
+        print(f"  {icon} {self._c(_RED, message)}", file=sys.stderr)
+
+    def warning(self, message: str):
+        """Print a warning message with yellow triangle."""
+        icon = self._c(_YELLOW + _BOLD, "⚠")
+        print(f"  {icon} {self._c(_YELLOW, message)}")
+
+    def info(self, message: str):
+        """Print an info message with blue dot."""
+        icon = self._c(_BLUE, "●")
+        print(f"  {icon} {self._c(_LIGHT_GRAY, message)}")
+
+    def hint(self, message: str):
+        """Print a subtle hint message."""
+        print(f"  {self._c(_DARK_GRAY, message)}")
+
+    def section(self, title: str):
+        """Print a section header."""
+        print()
+        print(f"  {self._c(self.accent + _BOLD, title)}")
+        print(f"  {self._c(_DARK_GRAY, _H_LINE * len(title))}")
+
+    # ── Status display ────────────────────────────────────────────────
+
+    def status(self, label: str, value: str):
+        """Print a key-value status line."""
+        lbl = self._c(_GRAY, f"  {label}:")
+        val = self._c(_WHITE, f" {value}")
+        print(f"{lbl}{val}")
+
+    def status_block(self, items: dict[str, str], title: str = ""):
+        """Print a block of status key-value pairs.
+
+        Args:
+            items: Dict of label -> value pairs.
+            title: Optional title for the block.
+        """
+        if title:
+            self.section(title)
+
+        max_key = max(len(k) for k in items) if items else 0
+        for label, value in items.items():
+            lbl = self._c(_GRAY, f"  {label:<{max_key}}")
+            val = self._c(_WHITE, f"  {value}")
+            print(f"{lbl}{val}")
+
+    def progress(self, current: int, total: int, label: str = ""):
+        """Print a simple progress indicator.
+
+        Args:
+            current: Current step number.
+            total: Total number of steps.
+            label: Optional label for the progress.
+        """
+        pct = int(current / total * 100) if total > 0 else 0
+        bar_width = 20
+        filled = int(bar_width * current / total) if total > 0 else 0
+        bar = "█" * filled + "░" * (bar_width - filled)
+        text = f"  {self._c(_CYAN, bar)} {self._c(_GRAY, f'{pct:3d}%')}"
+        if label:
+            text += f" {self._c(_LIGHT_GRAY, label)}"
+        print(text)
+
+    # ── Table display ─────────────────────────────────────────────────
+
+    def table(self, headers: list[str], rows: list[list[str]], max_col_width: int = 40):
+        """Print a formatted table with box-drawing characters.
+
+        Args:
+            headers: Column header strings.
+            rows: List of rows, each a list of cell strings.
+            max_col_width: Maximum column width before truncation.
+        """
+        if not headers:
+            return
+
+        # Calculate column widths
+        col_widths = [min(len(h), max_col_width) for h in headers]
+        for row in rows:
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    col_widths[i] = min(max(col_widths[i], len(str(cell))), max_col_width)
+
+        def pad(text: str, width: int) -> str:
+            t = str(text)[:width]
+            return t + " " * (width - len(t))
+
+        # Header
+        header_cells = [
+            self._c(_CYAN + _BOLD, pad(h, col_widths[i])) for i, h in enumerate(headers)
+        ]
+        sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+        header_line = f"  {sep.join(header_cells)}"
+        print(header_line)
+
+        # Separator
+        sep_line = self._c(_DARK_GRAY, f"  {'───'.join([_H_LINE * w for w in col_widths])}")
+        print(sep_line)
+
+        # Rows
+        for row in rows:
+            cells = []
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    cells.append(self._c(_LIGHT_GRAY, pad(str(cell), col_widths[i])))
+            row_sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+            print(f"  {row_sep.join(cells)}")
+
+    # ── Help display ──────────────────────────────────────────────────
+
+    def help(self, commands: dict[str, str]):
+        """Print a formatted help listing.
+
+        Args:
+            commands: Dict of command -> description pairs.
+        """
+        self.section("Commands")
+        max_cmd = max(len(c) for c in commands) if commands else 0
+        for cmd, desc in commands.items():
+            cmd_styled = self._c(self.accent, f"  {cmd:<{max_cmd}}")
+            desc_styled = self._c(_GRAY, f"  {desc}")
+            print(f"{cmd_styled}{desc_styled}")
+        print()
+
+    # ── Goodbye ───────────────────────────────────────────────────────
+
+    def print_goodbye(self):
+        """Print a styled goodbye message."""
+        print(f"\n  {_ICON_SMALL} {self._c(_GRAY, 'Goodbye!')}\n")
+
+    # ── Prompt toolkit session factory ────────────────────────────────
+
+    def create_prompt_session(self):
+        """Create a prompt_toolkit PromptSession with skin styling.
+
+        Returns:
+            A configured PromptSession, or None if prompt_toolkit unavailable.
+        """
+        try:
+            from prompt_toolkit import PromptSession
+            from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+            from prompt_toolkit.history import FileHistory
+
+            style = self.get_prompt_style()
+
+            session = PromptSession(
+                history=FileHistory(self.history_file),
+                auto_suggest=AutoSuggestFromHistory(),
+                style=style,
+                enable_history_search=True,
+            )
+            return session
+        except ImportError:
+            return None
+
+    def get_input(
+        self, pt_session, project_name: str = "", modified: bool = False, context: str = ""
+    ) -> str:
+        """Get input from user using prompt_toolkit or fallback.
+
+        Args:
+            pt_session: A prompt_toolkit PromptSession (or None).
+            project_name: Current project name.
+            modified: Whether project has unsaved changes.
+            context: Optional context string.
+
+        Returns:
+            User input string (stripped).
+        """
+        if pt_session is not None:
+            from prompt_toolkit.formatted_text import FormattedText
+
+            tokens = self.prompt_tokens(project_name, modified, context)
+            return pt_session.prompt(FormattedText(tokens)).strip()
+        else:
+            raw_prompt = self.prompt(project_name, modified, context)
+            return input(raw_prompt).strip()
+
+    # ── Toolbar builder ───────────────────────────────────────────────
+
+    def bottom_toolbar(self, items: dict[str, str]):
+        """Create a bottom toolbar callback for prompt_toolkit.
+
+        Args:
+            items: Dict of label -> value pairs to show in toolbar.
+
+        Returns:
+            A callable that returns FormattedText for the toolbar.
+        """
+
+        def toolbar():
+            from prompt_toolkit.formatted_text import FormattedText
+
+            parts = []
+            for i, (k, v) in enumerate(items.items()):
+                if i > 0:
+                    parts.append(("class:bottom-toolbar.text", "  │  "))
+                parts.append(("class:bottom-toolbar.text", f" {k}: "))
+                parts.append(("class:bottom-toolbar", v))
+            return FormattedText(parts)
+
+        return toolbar
+
+
+# ── ANSI 256-color to hex mapping (for prompt_toolkit styles) ─────────
+
+_ANSI_256_TO_HEX = {
+    "\033[38;5;33m": "#0087ff",  # audacity navy blue
+    "\033[38;5;35m": "#00af5f",  # shotcut teal
+    "\033[38;5;39m": "#00afff",  # inkscape bright blue
+    "\033[38;5;40m": "#00d700",  # libreoffice green
+    "\033[38;5;55m": "#5f00af",  # obs purple
+    "\033[38;5;69m": "#5f87ff",  # kdenlive slate blue
+    "\033[38;5;75m": "#5fafff",  # default sky blue
+    "\033[38;5;80m": "#5fd7d7",  # brand cyan
+    "\033[38;5;135m": "#af5fff",  # trellis violet
+    "\033[38;5;208m": "#ff8700",  # blender deep orange
+    "\033[38;5;214m": "#ffaf00",  # gimp warm orange
+}

--- a/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/utils/trellis_backend.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/cli_anything/trellis/utils/trellis_backend.py
@@ -1,0 +1,320 @@
+"""TRELLIS.2 backend interface — subprocess runner + error hierarchy.
+
+The CLI NEVER imports trellis2, torch, or o_voxel directly. All TRELLIS
+operations are dispatched to `resources/trellis_runner.py` via subprocess.
+
+Environment discovery priority (highest first):
+  1. Explicit CLI flags (--trellis-home / --trellis-python)
+  2. Session-saved paths (session.trellis_home / session.trellis_python)
+  3. Environment variables (TRELLIS_HOME / TRELLIS_PYTHON)
+  4. Auto-detection heuristics (PATH, well-known install locations)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from cli_anything.trellis.core.generation import GenerationRecord
+
+# ── Error hierarchy ───────────────────────────────────────────────────────────
+
+
+class BackendError(RuntimeError):
+    """Base class for all TRELLIS backend errors."""
+
+
+class TrellisNotFoundError(BackendError):
+    """TRELLIS.2 installation directory not found or invalid."""
+
+
+class TrellisPythonError(BackendError):
+    """The specified Python interpreter could not be found or is unusable."""
+
+
+class GPUUnavailableError(BackendError):
+    """CUDA GPU is required but not available or CUDA drivers are missing."""
+
+
+class RunnerError(BackendError):
+    """The trellis_runner.py subprocess exited with a non-zero status."""
+
+    def __init__(self, message: str, returncode: int = -1, stderr: str = ""):
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+class RunnerTimeoutError(BackendError):
+    """The trellis_runner.py subprocess exceeded the timeout."""
+
+
+# ── Runner script path ────────────────────────────────────────────────────────
+
+_RUNNER_PATH = Path(__file__).resolve().parent.parent / "resources" / "trellis_runner.py"
+
+
+# ── Environment discovery ─────────────────────────────────────────────────────
+
+
+def discover_trellis_home(
+    explicit: Optional[str] = None,
+    session_value: Optional[str] = None,
+) -> Optional[Path]:
+    """Return the TRELLIS.2 installation directory, or None if not found.
+
+    Args:
+        explicit: Value from --trellis-home CLI flag.
+        session_value: Value stored in the current session.
+
+    Returns:
+        Resolved Path if a valid directory is found, else None.
+    """
+    candidates = [
+        explicit,
+        session_value,
+        os.environ.get("TRELLIS_HOME"),
+    ]
+    for candidate in candidates:
+        if candidate:
+            p = Path(candidate).expanduser().resolve()
+            if p.is_dir():
+                return p
+    return None
+
+
+def discover_trellis_python(
+    explicit: Optional[str] = None,
+    session_value: Optional[str] = None,
+) -> str:
+    """Return the Python interpreter to use for trellis_runner.py.
+
+    Priority: explicit flag > session value > TRELLIS_PYTHON env > sys.executable.
+
+    The returned path is NOT validated here — call validate_python() to check.
+
+    Args:
+        explicit: Value from --trellis-python CLI flag.
+        session_value: Value stored in the current session.
+
+    Returns:
+        Path string for the Python interpreter.
+    """
+    candidates = [
+        explicit,
+        session_value,
+        os.environ.get("TRELLIS_PYTHON"),
+    ]
+    for candidate in candidates:
+        if candidate:
+            return str(Path(candidate).expanduser())
+    return sys.executable
+
+
+def validate_python(python_path: str) -> None:
+    """Raise TrellisPythonError if *python_path* is not a usable interpreter.
+
+    Args:
+        python_path: Path to the Python executable.
+
+    Raises:
+        TrellisPythonError: If the interpreter does not exist or fails to run.
+    """
+    p = Path(python_path)
+    if not p.exists():
+        raise TrellisPythonError(f"Python interpreter not found: {python_path}")
+    try:
+        result = subprocess.run(
+            [python_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            raise TrellisPythonError(
+                f"Python interpreter unusable ({python_path}): {result.stderr.strip()}"
+            )
+    except FileNotFoundError:
+        raise TrellisPythonError(f"Python interpreter not executable: {python_path}")
+    except subprocess.TimeoutExpired:
+        raise TrellisPythonError(f"Python interpreter timed out: {python_path}")
+
+
+def validate_trellis_home(trellis_home: Path) -> None:
+    """Raise TrellisNotFoundError if *trellis_home* lacks trellis2.
+
+    Checks for the presence of trellis2/ package directory or setup.py/
+    pyproject.toml as proof of a valid installation.
+
+    Args:
+        trellis_home: Path to the TRELLIS.2 repo root or install directory.
+
+    Raises:
+        TrellisNotFoundError: If the directory does not look like TRELLIS.2.
+    """
+    markers = [
+        trellis_home / "trellis2",
+        trellis_home / "trellis2" / "__init__.py",
+    ]
+    if not any(m.exists() for m in markers):
+        raise TrellisNotFoundError(
+            f"TRELLIS.2 not found at {trellis_home}. "
+            "Expected a 'trellis2/' package directory inside. "
+            "Set TRELLIS_HOME or use --trellis-home."
+        )
+
+
+# ── Runner invocation ─────────────────────────────────────────────────────────
+
+
+def build_runner_env(trellis_home: Optional[Path] = None) -> Dict[str, str]:
+    """Build environment dict for the runner subprocess.
+
+    Adds TRELLIS_HOME and the trellis directory to PYTHONPATH so the runner
+    can import trellis2 without a pip install.
+
+    Args:
+        trellis_home: Path to TRELLIS.2 root directory.
+
+    Returns:
+        A copy of os.environ with TRELLIS_HOME and PYTHONPATH set.
+    """
+    env = os.environ.copy()
+    if trellis_home:
+        env["TRELLIS_HOME"] = str(trellis_home)
+        # Prepend to PYTHONPATH so trellis2 is importable
+        existing_pythonpath = env.get("PYTHONPATH", "")
+        new_paths = [str(trellis_home)]
+        if existing_pythonpath:
+            new_paths.append(existing_pythonpath)
+        env["PYTHONPATH"] = os.pathsep.join(new_paths)
+    return env
+
+
+def run_generation(
+    record: GenerationRecord,
+    python_path: str,
+    trellis_home: Optional[Path] = None,
+    timeout: Optional[int] = None,
+) -> GenerationRecord:
+    """Invoke trellis_runner.py as a subprocess to generate a GLB from an image.
+
+    The runner receives a JSON payload on stdin and writes a JSON result
+    to stdout. This function blocks until the runner exits.
+
+    Args:
+        record: The GenerationRecord describing the generation job.
+        python_path: Path to the Python interpreter with trellis2 installed.
+        trellis_home: Optional TRELLIS.2 root for PYTHONPATH injection.
+        timeout: Optional timeout in seconds (None = no limit).
+
+    Returns:
+        Updated GenerationRecord with status=done and glb_path set,
+        or status=failed with error set.
+
+    Raises:
+        RunnerTimeoutError: If the subprocess exceeds *timeout*.
+        RunnerError: If the subprocess exits non-zero and stdout has no JSON.
+    """
+    runner_path = str(_RUNNER_PATH)
+    cmd: List[str] = [python_path, runner_path, "generate"]
+    env = build_runner_env(trellis_home)
+
+    payload = json.dumps(record.to_dict())
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RunnerTimeoutError(
+            f"Generation job {record.job_id} timed out after {timeout}s"
+        ) from exc
+
+    stdout = proc.stdout.strip()
+    stderr = proc.stderr.strip()
+
+    # Try to parse JSON result from stdout regardless of returncode
+    result: Optional[Dict[str, Any]] = None
+    if stdout:
+        try:
+            result = json.loads(stdout)
+        except json.JSONDecodeError:
+            pass
+
+    if result is not None:
+        try:
+            return GenerationRecord.from_dict(result)
+        except (ValueError, KeyError) as exc:
+            raise RunnerError(
+                f"Runner returned invalid record JSON: {exc}",
+                returncode=proc.returncode,
+                stderr=stderr,
+            ) from exc
+
+    # No parseable JSON — treat as failure
+    if proc.returncode != 0:
+        error_msg = stderr or f"runner exited with code {proc.returncode}"
+        raise RunnerError(
+            f"Generation job {record.job_id} failed: {error_msg}",
+            returncode=proc.returncode,
+            stderr=stderr,
+        )
+
+    # returncode == 0 but no JSON — unexpected
+    raise RunnerError(
+        f"Runner exited 0 but produced no JSON output for job {record.job_id}",
+        returncode=0,
+        stderr=stderr,
+    )
+
+
+def probe_gpu(python_path: str, trellis_home: Optional[Path] = None) -> Dict[str, Any]:
+    """Run a quick GPU probe via the runner subprocess.
+
+    Args:
+        python_path: Python interpreter with torch installed.
+        trellis_home: Optional TRELLIS.2 root.
+
+    Returns:
+        Dict with keys: available (bool), device_count (int), devices (list of str).
+
+    Raises:
+        TrellisPythonError: If the python interpreter fails to start.
+        GPUUnavailableError: If torch reports no CUDA devices.
+    """
+    runner_path = str(_RUNNER_PATH)
+    cmd: List[str] = [python_path, runner_path, "probe-gpu"]
+    env = build_runner_env(trellis_home)
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+    except FileNotFoundError:
+        raise TrellisPythonError(f"Python not found: {python_path}")
+    except subprocess.TimeoutExpired:
+        raise TrellisPythonError(f"GPU probe timed out for: {python_path}")
+
+    stdout = proc.stdout.strip()
+    if stdout:
+        try:
+            return json.loads(stdout)
+        except json.JSONDecodeError:
+            pass
+
+    stderr = proc.stderr.strip()
+    raise GPUUnavailableError(f"GPU probe failed (exit {proc.returncode}): {stderr or 'no output'}")

--- a/skyyrose/cli_harnesses/trellis/agent-harness/setup.py
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/setup.py
@@ -1,0 +1,53 @@
+"""cli-anything-trellis — setup.py
+
+Namespace package: cli_anything.trellis
+Entry point:       trellis → cli_anything.trellis.trellis_cli:main
+"""
+
+from setuptools import find_namespace_packages, setup
+
+setup(
+    name="cli-anything-trellis",
+    version="1.0.0",
+    description="CLI harness for Microsoft TRELLIS.2 image-to-3D generation",
+    long_description=open("README.md", encoding="utf-8").read(),
+    long_description_content_type="text/markdown",
+    author="DevSkyy",
+    python_requires=">=3.10",
+    # Namespace package — do NOT add cli_anything/__init__.py
+    packages=find_namespace_packages(include=["cli_anything.*"]),
+    package_data={
+        "cli_anything.trellis": [
+            "resources/trellis_runner.py",
+            "skills/SKILL.md",
+        ],
+    },
+    install_requires=[
+        "click>=8.1",
+        "prompt-toolkit>=3.0",
+    ],
+    extras_require={
+        "dev": [
+            "pytest>=7.4",
+            "pytest-cov>=4.1",
+            # Pillow only needed for E2E tests
+            "Pillow>=10.0",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "trellis=cli_anything.trellis.trellis_cli:main",
+        ],
+    },
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Multimedia :: Graphics :: 3D Modeling",
+    ],
+)

--- a/skyyrose/cli_harnesses/trellis/agent-harness/skills/cli-anything-trellis/SKILL.md
+++ b/skyyrose/cli_harnesses/trellis/agent-harness/skills/cli-anything-trellis/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: cli-anything-trellis
+description: >
+  Operate the cli-anything-trellis harness: submit image-to-3D generation jobs
+  via Microsoft TRELLIS.2, inspect job history, manage sessions, and probe GPU
+  availability — all from the CLI without importing trellis2 directly.
+triggers:
+  - /trellis
+  - generate 3d from image
+  - trellis generate
+  - image to glb
+  - probe-gpu trellis
+---
+
+# cli-anything-trellis Skill
+
+## When to use
+
+Invoke this skill when:
+- Submitting an image-to-3D generation job via TRELLIS.2
+- Checking GPU availability in the TRELLIS Python environment
+- Inspecting job history or catalog statistics
+- Managing trellis session settings (home, python, resolution defaults)
+- Writing agent code that calls the trellis CLI programmatically
+
+## Prerequisites
+
+1. `pip install -e ".[dev]"` from the harness root
+2. TRELLIS.2 installed in a separate Python environment
+3. `TRELLIS_HOME` pointing to the TRELLIS.2 repo/install root
+4. `TRELLIS_PYTHON` pointing to the Python interpreter with trellis2 installed
+5. A CUDA-capable GPU (required by TRELLIS.2; CPU inference not supported)
+
+## Install
+
+```bash
+cd /path/to/cli-anything/trellis/agent-harness
+pip install -e ".[dev]"
+```
+
+Verify:
+```bash
+trellis --version
+trellis config probe-gpu
+```
+
+## Command groups
+
+| Group | Subcommands | Purpose |
+|-------|-------------|---------|
+| `generate` | `run` | Submit image-to-3D job |
+| `jobs` | `list`, `show` | Browse/inspect job history |
+| `catalog` | `list`, `stats` | Read append-only JSONL catalog |
+| `session` | `show`, `set`, `unset`, `list`, `delete`, `clear-history` | Persist settings |
+| `config` | `show`, `validate`, `probe-gpu` | Installation/GPU checks |
+| *(bare)* | — | Launch interactive REPL |
+
+## Agent-facing JSON contract
+
+All commands accept `--json` for machine-readable output.
+
+### `generate run --json`
+
+```json
+{
+  "job_id": "a1b2c3d4e5f6a7b8",
+  "image_path": "/abs/path/to/image.png",
+  "output_dir": "/abs/path/to/output",
+  "resolution": "low",
+  "seed": 42,
+  "decimation_target": 1000000,
+  "texture_size": 4096,
+  "status": "done",
+  "created_at": 1716000000.0,
+  "started_at": 1716000001.0,
+  "finished_at": 1716000045.0,
+  "glb_path": "/abs/path/to/output/a1b2c3d4e5f6a7b8.glb",
+  "error": null,
+  "extra": {}
+}
+```
+
+Status values: `pending` | `running` | `done` | `failed`
+
+### `config probe-gpu --json`
+
+```json
+{
+  "available": true,
+  "device_count": 1,
+  "devices": [
+    {"index": 0, "name": "NVIDIA A100-SXM4-80GB", "total_memory_gb": 79.2}
+  ]
+}
+```
+
+### `catalog stats --json`
+
+```json
+{
+  "total": 12,
+  "done": 10,
+  "failed": 1,
+  "pending": 0,
+  "running": 1
+}
+```
+
+## Worked examples
+
+### Submit a low-resolution job and capture the GLB path
+
+```bash
+result=$(trellis --json \
+  --trellis-home "$TRELLIS_HOME" \
+  --trellis-python "$TRELLIS_PYTHON" \
+  generate run \
+  --image /path/to/product.png \
+  --output-dir /tmp/trellis-out \
+  --resolution low \
+  --seed 42)
+
+echo "$result" | python -c "import sys,json; d=json.load(sys.stdin); print(d['glb_path'])"
+```
+
+### Persist TRELLIS settings in the current session
+
+```bash
+trellis session set trellis_home "$TRELLIS_HOME"
+trellis session set trellis_python "$TRELLIS_PYTHON"
+trellis session set default_resolution low
+# Now generate without flags:
+trellis generate run --image product.png --output-dir /tmp/out
+```
+
+### Probe GPU from a Python agent
+
+```python
+import subprocess, json, sys
+
+result = subprocess.run(
+    [sys.executable, "-m", "cli_anything.trellis.trellis_cli",
+     "--json", "config", "probe-gpu"],
+    capture_output=True, text=True, timeout=30,
+)
+gpu_info = json.loads(result.stdout)
+if not gpu_info["available"]:
+    raise RuntimeError("No CUDA GPU — cannot run TRELLIS.2")
+```
+
+### Programmatic generation from Python
+
+```python
+import subprocess, json, sys, os
+
+proc = subprocess.run(
+    [sys.executable, "-m", "cli_anything.trellis.trellis_cli",
+     "--json",
+     "--trellis-home", os.environ["TRELLIS_HOME"],
+     "--trellis-python", os.environ["TRELLIS_PYTHON"],
+     "generate", "run",
+     "--image", "/path/to/image.png",
+     "--output-dir", "/tmp/trellis-out",
+     "--resolution", "high",
+     "--seed", "-1"],
+    capture_output=True, text=True, timeout=900,
+)
+record = json.loads(proc.stdout)
+if record["status"] != "done":
+    raise RuntimeError(f"TRELLIS generation failed: {record['error']}")
+glb_path = record["glb_path"]
+```
+
+## Error handling
+
+| Error class | Cause | Resolution |
+|-------------|-------|------------|
+| `TrellisNotFoundError` | `TRELLIS_HOME` not set or no `trellis2/` dir inside | Set `TRELLIS_HOME` correctly |
+| `TrellisPythonError` | Python interpreter not found or fails `--version` | Set `TRELLIS_PYTHON` to the trellis2 venv python |
+| `GPUUnavailableError` | `torch.cuda.is_available()` returned False | Ensure CUDA drivers installed and a GPU is available |
+| `RunnerError` | Runner subprocess exited non-zero with no JSON | Check `stderr` attribute for details |
+| `RunnerTimeoutError` | Generation exceeded `--timeout` seconds | Increase timeout or use a lower resolution preset |
+
+All errors are reflected in the JSON result when using `--json`:
+
+```json
+{"status": "failed", "error": "CUDA is not available ...", ...}
+```
+
+## Dry-run discipline
+
+There is no `--dry-run` flag for generation (TRELLIS.2 is GPU-only with no
+mock mode).  To test connectivity and environment without a GPU job:
+
+```bash
+trellis config validate     # checks TRELLIS_HOME + Python interpreter
+trellis config probe-gpu    # checks CUDA via subprocess
+```
+
+## Session model
+
+Sessions are persisted at `~/.cli_anything/trellis/sessions/<name>.json`.
+The default session is named `default`.  Each session stores:
+
+- `trellis_home` — path override
+- `trellis_python` — interpreter override
+- `default_resolution` — `"low"` or `"high"`
+- `default_output_dir` — default output directory
+- `history` — last 50 commands (capped)
+
+The append-only job catalog lives at `~/.cli_anything/trellis/catalog.jsonl`.
+One JSON record per line; never modified after append.
+
+## Scope limits
+
+1. **TRELLIS.2 only** — no other image-to-3D backends are wired.
+2. **Single-job dispatch** — `generate run` is synchronous; no queue or batch.
+3. **CUDA required** — CPU inference is not supported by TRELLIS.2.
+4. **GLB output only** — OBJ, FBX, USD are not exposed; change the runner if needed.
+5. **No model fine-tuning** — the harness uses `microsoft/TRELLIS.2-4B` from
+   HuggingFace Hub; custom checkpoints require modifying `trellis_runner.py`.


### PR DESCRIPTION
## Vendored CLI harnesses (relocated from vendor/)

Companion to the elite-studio integration PR — splits the 5 CLI-harness relocations out of the salvage so the vendored bulk reviews as one unit.

### What's in here (6 commits)
- Relocate **marvelous / trellis / skyyrose-theme / hf-spaces** from `vendor/` → `skyyrose/cli_harnesses/`.
- New **comfyui** Tier-2 harness (full ComfyUI REST surface, 181 self-contained tests).
- **Lint excludes:** add `skyyrose/cli_harnesses/` to ruff + black exclude. These are vendored tools carrying their own style (~286 ruff findings of their own); excluded exactly as the old `vendor/` tree and the existing `hf-spaces/` entry already are.

### Notes
- ~24k lines, ~91% pure additions under `skyyrose/cli_harnesses/`.
- Harness tests are self-contained under each harness dir and are **not** collected by host CI (`testpaths=["tests"]`), so they don't gate this repo.
- `ruff check .` + `black --check .` clean (harnesses excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relocated 4 CLI harnesses into `skyyrose/cli_harnesses/` and added a new `comfyui` Tier‑2 harness; updated linting (`ruff`, `black`, `isort`) to ignore these vendored tools.

- **New Features**
  - Added `comfyui` CLI harness covering the full ComfyUI REST surface; its tests live within the harness and are not collected by host CI.

- **Refactors**
  - Moved `marvelous`, `trellis`, `skyyrose-theme`, and `hf-spaces` harnesses from `vendor/` to `skyyrose/cli_harnesses/` for first‑party tracking.
  - Updated `pyproject.toml` to exclude `skyyrose/cli_harnesses/` from `ruff`, `black`, and `isort` (mirrors prior `vendor/` behavior).

<sup>Written for commit 310bcaffb2c229719b72a5a8a7a5fcd05b932624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

