### PR TITLE
fix(ci): lazy-import heavy SDK chain in elite_studio conftest (restore Catalog Consistency job)

### DIFF
--- a/.github/workflows/catalog-validate.yml
+++ b/.github/workflows/catalog-validate.yml
@@ -37,10 +37,13 @@ jobs:
       - name: Install minimal dependencies
         run: |
           python -m pip install --upgrade pip
-          # Validator uses stdlib only — no extra deps needed
-          # Install project for test_catalog_consistency.py imports
-          pip install -e ".[dev]" --quiet 2>/dev/null || \
-            pip install pytest --quiet
+          # The validator step is stdlib-only. The pytest step collects
+          # test_catalog_consistency.py + the (lazy-import) shared conftest, which
+          # need only pytest + pytest-asyncio (asyncio_mode is declared in
+          # pyproject; without pytest-asyncio pytest errors "Unknown config option").
+          # No project/base install — `.[dev]` pulls the heavy provider stack, was
+          # timing out, and silently fell back to a pytest-only env that failed.
+          pip install pytest pytest-asyncio --quiet
 
       - name: Run catalog consistency validator
         run: |

--- a/.github/workflows/catalog-validate.yml
+++ b/.github/workflows/catalog-validate.yml
@@ -10,6 +10,7 @@ on:
       - "scripts/validate_catalog_consistency.py"
       - "scripts/sync_catalog_downstream.py"
       - "skyyrose/elite_studio/tests/test_catalog_consistency.py"
+      - "skyyrose/elite_studio/tests/conftest.py"
   push:
     branches: [main]
     paths:

--- a/skyyrose/elite_studio/tests/conftest.py
+++ b/skyyrose/elite_studio/tests/conftest.py
@@ -5,8 +5,12 @@ from pathlib import Path
 
 import pytest
 
-from llm.model_ids import CLAUDE_SONNET_MODEL
-from skyyrose.elite_studio.coordinator import Coordinator, NullLogger
+# NOTE: llm.model_ids and skyyrose.elite_studio.coordinator are imported lazily
+# inside the fixtures/factories that need them (see make_quality_verification +
+# silent_coordinator). Importing them at module top pulls the heavy provider SDK
+# chain (httpx/openai/transformers) at collection time, which breaks minimal-env
+# jobs (e.g. Catalog Consistency Validation) that only collect the stdlib-only
+# catalog tests sharing this conftest. elite_studio.models is light, kept here.
 from skyyrose.elite_studio.models import (
     GenerationResult,
     ProductData,
@@ -81,6 +85,8 @@ def make_quality_verification(
     **kwargs,
 ) -> QualityVerification:
     """Create a test QualityVerification."""
+    from llm.model_ids import CLAUDE_SONNET_MODEL
+
     return QualityVerification(
         success=success,
         provider="anthropic",
@@ -119,6 +125,8 @@ def make_production_result(
 def silent_coordinator():
     """Coordinator with silent logger for clean test output."""
     from unittest.mock import MagicMock
+
+    from skyyrose.elite_studio.coordinator import Coordinator, NullLogger
 
     return Coordinator(
         vision=MagicMock(),


### PR DESCRIPTION
## Problem
The **Catalog Consistency Validation** job has been red on main (through #602, the Dependabot merges, #600/#608). It collects the stdlib-only \`test_catalog_consistency.py\`, but shares \`skyyrose/elite_studio/tests/conftest.py\`, whose **module-top** imports pull the full provider SDK chain at collection time:
- \`from llm.model_ids import CLAUDE_SONNET_MODEL\` → runs \`llm/__init__\` → eager-imports all 6 providers (httpx/openai/transformers)
- \`from skyyrose.elite_studio.coordinator import Coordinator, NullLogger\` → openai/httpx/transformers

In the job's minimal env those aren't installed → ImportError → whole job fails (earlier surfaced as "httpx missing").

## Fix
- Move both heavy imports **lazy** — into \`make_quality_verification\` and the \`silent_coordinator\` fixture (matching the file's existing function-local \`MagicMock\` import). \`elite_studio.models\` is light, stays top-level (def-time annotations).
- Add \`conftest.py\` to the job's \`pull_request\` path filter so it re-runs when the conftest changes (and validates this PR).

## Verification (local)
- conftest import pulls **zero** provider SDKs (was httpx/openai/transformers)
- \`test_catalog_consistency.py\` **18/18 pass**
- ruff clean; lazy fixtures still resolve for the heavy tests

## Out of scope (pre-existing on main, NOT run by this job)
\`test_config::test_overrides_dir_exists\` + 3 \`test_logo_registry\` data-drift failures — separate issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Catalog Consistency job by lazy-loading heavy SDK imports in `skyyrose/elite_studio/tests/conftest.py` and installing only `pytest` + `pytest-asyncio` in the CI job. Test collection no longer requires `httpx`, `openai`, or `transformers`, and the job re-runs when the conftest changes.

- **Bug Fixes**
  - Moved `llm.model_ids.CLAUDE_SONNET_MODEL` and `skyyrose.elite_studio.coordinator` imports into `make_quality_verification` and `silent_coordinator`.
  - Kept `elite_studio.models` as a top-level import; fixtures still resolve in full envs.
  - Included `skyyrose/elite_studio/tests/conftest.py` in the `pull_request` path filter in `catalog-validate.yml`.

- **Dependencies**
  - CI installs only `pytest` and `pytest-asyncio` for the minimal job, removing the `.[dev]` install that pulled provider stacks and failed on `asyncio_mode`.

<sup>Written for commit 50366ce170e7058f0c9de972ee7298c884c35604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

