### PR TITLE
fix(tests): hermetic Stage H IC-Light relight cache (fixes KeyError: 'prompt')

### DIFF
--- a/tests/elite_studio/test_stage_h_iclight.py
+++ b/tests/elite_studio/test_stage_h_iclight.py
@@ -15,6 +15,28 @@ from skyyrose.elite_studio.agents.compositor.stage_h_iclight import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_iclight_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect Stage H's relight cache to a per-test tmp dir so the suite is
+    hermetic.
+
+    ``relight_composite`` returns early on a cache hit (before calling
+    ``_invoke_iclight_v2``). Without isolation it reads the *real* cache dir, where
+    a stale ``{cache_key}.png`` from a past run makes the relight tests hit that
+    early return — so the FAL-invocation mock never runs and ``captured`` is empty
+    (KeyError: 'prompt'). ``stage_h_iclight`` binds ``_cache_dir`` locally
+    (``from .infra import _cache_dir``), so we patch it on THIS module, not on
+    ``.infra``. autouse → every relight test is isolated and this can't regress.
+    """
+
+    def _fake_cache_dir(name: str) -> Path:
+        d = tmp_path / "iclight-cache" / name
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    monkeypatch.setattr(stage_h_iclight, "_cache_dir", _fake_cache_dir)
+
+
 @pytest.fixture
 def composite_image(tmp_path: Path) -> Path:
     """64x64 RGB composite stand-in (would be Stage D output)."""


### PR DESCRIPTION
## Problem
`tests/elite_studio/test_stage_h_iclight.py::test_relight_calls_fal_with_correct_endpoint_and_denoise` has failed on `main` since ~Jun 12 with `KeyError: 'prompt'` — the Stop-hook / `pytest tests/ -x` gate blocker.

## Root cause
`relight_composite` returns early on a **cache hit** (`stage_h_iclight.py:98`) before calling `_invoke_iclight_v2`. The relight tests read the **real** cache dir, where a stale `{cache_key}.png` from a past run forces that early return — so the FAL-invocation mock never runs and `captured` stays empty. A prior fix attempt patched `.infra._cache_dir`, which didn't work because `stage_h_iclight` binds it locally (`from .infra import _cache_dir`).

## Fix (hardened, test-only)
An **autouse** fixture redirects the cache to a per-test `tmp_path`, patching `_cache_dir` on the `stage_h_iclight` module (the correct binding). autouse → every relight test is hermetic and this can't regress. **No production code changed.**

## Verify
- [x] `pytest tests/elite_studio/test_stage_h_iclight.py` → 13 passed
- [x] full `pytest tests/ -x` → green (RC=0; only XFAIL/XPASS markers)
- [x] pre-commit gate green (ruff/black/isort/mypy 1381 files/fast tests/freshness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Stage H IC-Light relight tests hermetic by isolating the relight cache per test, fixing the KeyError: 'prompt' caused by stale cache hits that bypassed `_invoke_iclight_v2`.

- **Bug Fixes**
  - Added autouse fixture `_isolate_iclight_cache` to patch `stage_h_iclight._cache_dir` to a per-test `tmp_path`.
  - Stops reading the shared cache, so the FAL call mock runs and assertions pass. No production code changed.

<sup>Written for commit 07a1cddaecea48102081841ac64121319a63ff1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for cache-related tests to prevent interference between test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->