### PR TITLE
JSON scene schema + FLUX LoRA infra (verified end-to-end)

### DIFF
--- a/scripts/flux_lora/__init__.py
+++ b/scripts/flux_lora/__init__.py
@@ -1,0 +1,35 @@
+"""
+scripts.flux_lora — FLUX LoRA training + inference package for SkyyRose brand.
+
+Error hierarchy:
+  FluxLoraError                 base
+    DatasetError                dataset validation / loading failures
+    RequiresConfirmationError   STOP-AND-SHOW gate: call raised when confirmed=False
+    UserAbortError              user typed 'n' at confirmation prompt
+    TrainingError               Replicate API / training job failures
+"""
+
+
+class FluxLoraError(Exception):
+    """Base error for all flux_lora failures."""
+
+
+class DatasetError(FluxLoraError):
+    """Dataset validation or loading failure."""
+
+
+class RequiresConfirmationError(FluxLoraError):
+    """
+    Raised when a paid Replicate call is attempted without confirmed=True.
+
+    Callers must print a STOP-AND-SHOW manifest and receive explicit 'y'
+    from the user before re-calling with confirmed=True.
+    """
+
+
+class UserAbortError(FluxLoraError):
+    """Raised when the user declines the STOP-AND-SHOW confirmation."""
+
+
+class TrainingError(FluxLoraError):
+    """Replicate API error or training job failure."""

--- a/scripts/flux_lora/__init__.py
+++ b/scripts/flux_lora/__init__.py
@@ -6,7 +6,8 @@ Error hierarchy:
     DatasetError                dataset validation / loading failures
     RequiresConfirmationError   STOP-AND-SHOW gate: call raised when confirmed=False
     UserAbortError              user typed 'n' at confirmation prompt
-    TrainingError               Replicate API / training job failures
+    TrainingError               Replicate training API / training job failures
+    InferenceError              Replicate prediction API / inference failures
 """
 
 
@@ -32,4 +33,8 @@ class UserAbortError(FluxLoraError):
 
 
 class TrainingError(FluxLoraError):
-    """Replicate API error or training job failure."""
+    """Replicate training API error or training job failure."""
+
+
+class InferenceError(FluxLoraError):
+    """Replicate prediction API error or inference job failure."""

--- a/scripts/flux_lora/cli.py
+++ b/scripts/flux_lora/cli.py
@@ -33,7 +33,6 @@ from scripts.flux_lora.config import (
     DEFAULT_BATCH_SIZE,
     DEFAULT_LEARNING_RATE,
     DEFAULT_LORA_RANK,
-    DEFAULT_LR_SCHEDULER,
     DEFAULT_OPTIMIZER,
     DEFAULT_RESOLUTION,
     DEFAULT_STEPS,
@@ -41,7 +40,7 @@ from scripts.flux_lora.config import (
     api_key_present,
 )
 from scripts.flux_lora.dataset import dataset_summary, pack_zip, validate_dataset
-from scripts.flux_lora.inference import generate, load_latest_lora
+from scripts.flux_lora.inference import DEFAULT_NUM_OUTPUTS, generate, load_latest_lora
 from scripts.flux_lora.status import format_status, get_status, list_runs
 from scripts.flux_lora.trainer import (
     build_manifest,
@@ -131,9 +130,8 @@ def cmd_train(args: argparse.Namespace) -> None:
             optimizer=args.optimizer,
             batch_size=args.batch_size,
             resolution=args.resolution,
-            lr_scheduler=args.lr_scheduler,
             learning_rate=args.learning_rate,
-            destination_model=args.destination_model or None,
+            destination_model=args.destination_model,
         )
     except ValueError as exc:
         print(f"Manifest error: {exc}", file=sys.stderr)
@@ -292,9 +290,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_train.add_argument("--optimizer", default=DEFAULT_OPTIMIZER)
     p_train.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
     p_train.add_argument("--resolution", default=DEFAULT_RESOLUTION)
-    p_train.add_argument("--lr-scheduler", default=DEFAULT_LR_SCHEDULER)
     p_train.add_argument("--learning-rate", type=float, default=DEFAULT_LEARNING_RATE)
-    p_train.add_argument("--destination-model", default=None)
+    p_train.add_argument(
+        "--destination-model",
+        required=True,
+        help="REQUIRED. Replicate model slug to push the LoRA to, e.g. 'skyyrose/skyyrose-lora'.",
+    )
     p_train.add_argument(
         "--input-images-url",
         default=None,
@@ -306,7 +307,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_gen = sub.add_parser("generate", help="Run FLUX inference with a trained LoRA.")
     p_gen.add_argument("prompt", help="Text prompt (include trigger word).")
     p_gen.add_argument("--lora-url", default=None, help="Override LoRA URL.")
-    p_gen.add_argument("--num-outputs", type=int, default=DEFAULT_NUM_OUTPUTS if False else 1)
+    p_gen.add_argument("--num-outputs", type=int, default=DEFAULT_NUM_OUTPUTS)
     p_gen.set_defaults(func=cmd_generate)
 
     # status

--- a/scripts/flux_lora/cli.py
+++ b/scripts/flux_lora/cli.py
@@ -2,11 +2,13 @@
 scripts.flux_lora.cli — Command-line interface for FLUX LoRA operations.
 
 Commands:
-  train          Pack dataset, show manifest, gate on 'y', submit training.
-  generate       Run inference with latest (or specified) LoRA.
-  status         Fetch live status of a training run by ID.
-  list           List all saved training run records.
-  dataset-info   Validate dataset and print summary.
+  train            Pack dataset, show manifest, gate on 'y', submit training.
+  generate         Run inference with latest (or specified) LoRA.
+  status           Fetch live status of a training run by ID.
+  list             List all saved training run records.
+  dataset-info     Validate dataset and print summary.
+  build-dataset    Assemble a training dataset dir from a JSON source list.
+  upload-dataset   Upload a dataset zip to HuggingFace Hub.
 
 Usage:
   python -m scripts.flux_lora.cli train [--dataset-dir PATH] [--steps N] ...
@@ -14,11 +16,14 @@ Usage:
   python -m scripts.flux_lora.cli status TRAINING_ID
   python -m scripts.flux_lora.cli list
   python -m scripts.flux_lora.cli dataset-info [--dataset-dir PATH]
+  python -m scripts.flux_lora.cli build-dataset --from SOURCES.json --dest DIR [--overwrite]
+  python -m scripts.flux_lora.cli upload-dataset --zip PATH --repo REPO_ID [--private]
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -246,6 +251,94 @@ def cmd_status(args: argparse.Namespace) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Subcommand: build-dataset
+# ---------------------------------------------------------------------------
+
+
+def cmd_build_dataset(args: argparse.Namespace) -> None:
+    """
+    Assemble a training dataset directory from a JSON source list.
+
+    The JSON file must be a list of objects with keys:
+      - "image"   : path to source image (required)
+      - "caption" : author-written caption (optional, mutually exclusive with garment)
+      - "garment" : garment description (optional, caption preferred)
+    """
+    from scripts.flux_lora.dataset import dataset_summary
+    from scripts.flux_lora.dataset_builder import build_dataset
+
+    sources_path = Path(args.from_file)
+    if not sources_path.exists():
+        print(f"Error: sources file not found: '{sources_path}'", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        sources = json.loads(sources_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"Error: invalid JSON in '{sources_path}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(sources, list):
+        print("Error: sources JSON must be a list of objects.", file=sys.stderr)
+        sys.exit(1)
+
+    dest_dir = Path(args.dest)
+
+    try:
+        result = build_dataset(sources, dest_dir, overwrite=args.overwrite)
+    except DatasetError as exc:
+        print(f"Dataset error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    summary = dataset_summary(result)
+    print(f"Dataset dir   : {summary['dataset_dir']}")
+    print(f"Images        : {summary['image_count']}")
+    print(f"Captions      : {summary['caption_count']}")
+    print(f"Total size    : {summary['total_bytes']:,} bytes")
+    print("Validation    : OK")
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: upload-dataset
+# ---------------------------------------------------------------------------
+
+
+def cmd_upload_dataset(args: argparse.Namespace) -> None:
+    """
+    Upload a dataset zip to HuggingFace Hub.
+
+    Prints STOP-AND-SHOW, gates on 'y', then calls upload_zip(confirmed=True).
+    """
+    from scripts.flux_lora.upload import show_upload_stopandshow, upload_zip
+
+    zip_path = Path(args.zip)
+    if not zip_path.exists():
+        print(f"Error: zip file not found: '{zip_path}'", file=sys.stderr)
+        sys.exit(1)
+
+    show_upload_stopandshow(zip_path, args.repo)
+
+    if not _confirm():
+        raise UserAbortError("Upload cancelled by user.")
+
+    try:
+        url = upload_zip(
+            zip_path,
+            args.repo,
+            private=args.private,
+            confirmed=True,
+        )
+    except FluxLoraError as exc:
+        print(f"Upload error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except RuntimeError as exc:
+        print(f"Upload error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Uploaded: {url}")
+
+
+# ---------------------------------------------------------------------------
 # Subcommand: list
 # ---------------------------------------------------------------------------
 
@@ -334,6 +427,57 @@ def build_parser() -> argparse.ArgumentParser:
     # list
     p_list = sub.add_parser("list", help="List all saved training run records.")
     p_list.set_defaults(func=cmd_list)
+
+    # build-dataset
+    p_build = sub.add_parser(
+        "build-dataset",
+        help="Assemble a training dataset directory from a JSON source list.",
+    )
+    p_build.add_argument(
+        "--from",
+        dest="from_file",
+        required=True,
+        metavar="SOURCES_JSON",
+        help="JSON file listing source images (list of {image, caption?, garment?}).",
+    )
+    p_build.add_argument(
+        "--dest",
+        required=True,
+        metavar="DIR",
+        help="Destination directory to write the dataset into.",
+    )
+    p_build.add_argument(
+        "--overwrite",
+        action="store_true",
+        default=False,
+        help="Clear existing dataset files in --dest before building.",
+    )
+    p_build.set_defaults(func=cmd_build_dataset)
+
+    # upload-dataset
+    p_upload = sub.add_parser(
+        "upload-dataset",
+        help="Upload a dataset zip to HuggingFace Hub.",
+    )
+    p_upload.add_argument(
+        "--zip",
+        required=True,
+        metavar="PATH",
+        help="Path to the dataset zip file to upload.",
+    )
+    p_upload.add_argument(
+        "--repo",
+        required=True,
+        metavar="REPO_ID",
+        help="HuggingFace dataset repo ID (e.g. 'skyyrose/skyyrose-lora-dataset').",
+    )
+    p_upload.add_argument(
+        "--private",
+        action="store_true",
+        default=False,
+        help="Create / upload to a private repo (default: public).",
+    )
+    p_upload.set_defaults(func=cmd_upload_dataset)
 
     return parser
 

--- a/scripts/flux_lora/cli.py
+++ b/scripts/flux_lora/cli.py
@@ -1,0 +1,338 @@
+"""
+scripts.flux_lora.cli — Command-line interface for FLUX LoRA operations.
+
+Commands:
+  train          Pack dataset, show manifest, gate on 'y', submit training.
+  generate       Run inference with latest (or specified) LoRA.
+  status         Fetch live status of a training run by ID.
+  list           List all saved training run records.
+  dataset-info   Validate dataset and print summary.
+
+Usage:
+  python -m scripts.flux_lora.cli train [--dataset-dir PATH] [--steps N] ...
+  python -m scripts.flux_lora.cli generate PROMPT [--lora-url URL] ...
+  python -m scripts.flux_lora.cli status TRAINING_ID
+  python -m scripts.flux_lora.cli list
+  python -m scripts.flux_lora.cli dataset-info [--dataset-dir PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from scripts.flux_lora import (
+    DatasetError,
+    FluxLoraError,
+    RequiresConfirmationError,
+    UserAbortError,
+)
+from scripts.flux_lora.config import (
+    DATASET_DIR,
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_LEARNING_RATE,
+    DEFAULT_LORA_RANK,
+    DEFAULT_LR_SCHEDULER,
+    DEFAULT_OPTIMIZER,
+    DEFAULT_RESOLUTION,
+    DEFAULT_STEPS,
+    DEFAULT_TRIGGER_WORD,
+    api_key_present,
+)
+from scripts.flux_lora.dataset import dataset_summary, pack_zip, validate_dataset
+from scripts.flux_lora.inference import generate, load_latest_lora
+from scripts.flux_lora.status import format_status, get_status, list_runs
+from scripts.flux_lora.trainer import (
+    build_manifest,
+    save_run_record,
+    show_stopandshow,
+    start_training,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _confirm(prompt: str = "Proceed? [y/N] ") -> bool:
+    """Read a single line from stdin; return True only on 'y' / 'yes'."""
+    try:
+        answer = input(prompt).strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        return False
+    return answer in ("y", "yes")
+
+
+def _abort(msg: str = "Aborted.") -> None:
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: dataset-info
+# ---------------------------------------------------------------------------
+
+
+def cmd_dataset_info(args: argparse.Namespace) -> None:
+    dataset_dir = Path(args.dataset_dir)
+    try:
+        validate_dataset(dataset_dir)
+        summary = dataset_summary(dataset_dir)
+    except DatasetError as exc:
+        print(f"Dataset error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Dataset dir   : {summary['dataset_dir']}")
+    print(f"Images        : {summary['image_count']}")
+    print(f"Captions      : {summary['caption_count']}")
+    print(f"Total size    : {summary['total_bytes']:,} bytes")
+    print("Validation    : OK")
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: train
+# ---------------------------------------------------------------------------
+
+
+def cmd_train(args: argparse.Namespace) -> None:
+    dataset_dir = Path(args.dataset_dir)
+
+    # Validate first — fast fail before spending money.
+    try:
+        validate_dataset(dataset_dir)
+    except DatasetError as exc:
+        print(f"Dataset error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not api_key_present():
+        print(
+            "REPLICATE_API_TOKEN not set. Export it before training.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Pack zip
+    print(f"Packing dataset from {dataset_dir} …")
+    try:
+        zip_path = pack_zip(dataset_dir)
+    except DatasetError as exc:
+        print(f"Pack error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Packed: {zip_path}")
+
+    # Build manifest
+    try:
+        manifest = build_manifest(
+            zip_path,
+            trigger_word=args.trigger_word,
+            steps=args.steps,
+            lora_rank=args.lora_rank,
+            optimizer=args.optimizer,
+            batch_size=args.batch_size,
+            resolution=args.resolution,
+            lr_scheduler=args.lr_scheduler,
+            learning_rate=args.learning_rate,
+            destination_model=args.destination_model or None,
+        )
+    except ValueError as exc:
+        print(f"Manifest error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # STOP-AND-SHOW
+    show_stopandshow(manifest)
+    if not _confirm():
+        raise UserAbortError("Training cancelled by user.")
+
+    # Require upload URL
+    input_images_url = (args.input_images_url or "").strip()
+    if not input_images_url:
+        print(
+            "Error: --input-images-url is required. Upload the zip to a public URL and supply it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Submit
+    print("Submitting training job …")
+    try:
+        training_resp = start_training(manifest, confirmed=True, input_images_url=input_images_url)
+    except FluxLoraError as exc:
+        print(f"Training error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # Save record
+    record_path = save_run_record(training_resp, manifest)
+    print(f"Training submitted. ID: {training_resp.get('id', 'unknown')}")
+    print(f"Run record saved to: {record_path}")
+    if training_resp.get("urls", {}).get("get"):
+        print(f"Track at: {training_resp['urls']['get']}")
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: generate
+# ---------------------------------------------------------------------------
+
+
+def cmd_generate(args: argparse.Namespace) -> None:
+    lora_url = args.lora_url
+    if not lora_url:
+        lora_url = load_latest_lora()
+        if not lora_url:
+            print(
+                "No succeeded training run found. Supply --lora-url explicitly.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"Using latest LoRA: {lora_url}")
+
+    if not api_key_present():
+        print(
+            "REPLICATE_API_TOKEN not set. Export it before generating.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # STOP-AND-SHOW is printed inside generate() when confirmed=False.
+    # We call with confirmed=False first so the user sees the manifest,
+    # then re-call with confirmed=True after 'y'.
+    try:
+        generate(
+            args.prompt,
+            lora_url,
+            confirmed=False,
+            num_outputs=args.num_outputs,
+        )
+    except RequiresConfirmationError:
+        pass  # Expected — manifest was printed, now gate on user input.
+
+    if not _confirm():
+        raise UserAbortError("Generation cancelled by user.")
+
+    try:
+        urls = generate(
+            args.prompt,
+            lora_url,
+            confirmed=True,
+            num_outputs=args.num_outputs,
+        )
+    except FluxLoraError as exc:
+        print(f"Inference error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print("Output images:")
+    for url in urls:
+        print(f"  {url}")
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: status
+# ---------------------------------------------------------------------------
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    try:
+        status_dict = get_status(args.training_id)
+    except FluxLoraError as exc:
+        print(f"Status error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print(format_status(status_dict))
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: list
+# ---------------------------------------------------------------------------
+
+
+def cmd_list(args: argparse.Namespace) -> None:
+    runs = list_runs()
+    if not runs:
+        print("No training run records found.")
+        return
+    print(f"{'ID':<30}  {'Status':<12}  {'Timestamp':<22}  {'Cost'}")
+    print("-" * 80)
+    for run in runs:
+        resp = run.get("replicate_response", {})
+        manifest = run.get("manifest", {})
+        print(
+            f"{run.get('training_id', 'unknown'):<30}  "
+            f"{resp.get('status', 'unknown'):<12}  "
+            f"{run.get('timestamp', ''):<22}  "
+            f"${manifest.get('cost_usd', 0):.2f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m scripts.flux_lora.cli",
+        description="FLUX LoRA training + inference for SkyyRose brand.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # dataset-info
+    p_info = sub.add_parser("dataset-info", help="Validate dataset and print summary.")
+    p_info.add_argument(
+        "--dataset-dir",
+        default=str(DATASET_DIR),
+        help="Path to dataset directory.",
+    )
+    p_info.set_defaults(func=cmd_dataset_info)
+
+    # train
+    p_train = sub.add_parser("train", help="Pack dataset and submit training job.")
+    p_train.add_argument("--dataset-dir", default=str(DATASET_DIR))
+    p_train.add_argument("--trigger-word", default=DEFAULT_TRIGGER_WORD)
+    p_train.add_argument("--steps", type=int, default=DEFAULT_STEPS)
+    p_train.add_argument("--lora-rank", type=int, default=DEFAULT_LORA_RANK)
+    p_train.add_argument("--optimizer", default=DEFAULT_OPTIMIZER)
+    p_train.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    p_train.add_argument("--resolution", default=DEFAULT_RESOLUTION)
+    p_train.add_argument("--lr-scheduler", default=DEFAULT_LR_SCHEDULER)
+    p_train.add_argument("--learning-rate", type=float, default=DEFAULT_LEARNING_RATE)
+    p_train.add_argument("--destination-model", default=None)
+    p_train.add_argument(
+        "--input-images-url",
+        default=None,
+        help="Public URL of the uploaded dataset zip (required for actual submission).",
+    )
+    p_train.set_defaults(func=cmd_train)
+
+    # generate
+    p_gen = sub.add_parser("generate", help="Run FLUX inference with a trained LoRA.")
+    p_gen.add_argument("prompt", help="Text prompt (include trigger word).")
+    p_gen.add_argument("--lora-url", default=None, help="Override LoRA URL.")
+    p_gen.add_argument("--num-outputs", type=int, default=DEFAULT_NUM_OUTPUTS if False else 1)
+    p_gen.set_defaults(func=cmd_generate)
+
+    # status
+    p_status = sub.add_parser("status", help="Fetch live training status.")
+    p_status.add_argument("training_id", help="Replicate training ID.")
+    p_status.set_defaults(func=cmd_status)
+
+    # list
+    p_list = sub.add_parser("list", help="List all saved training run records.")
+    p_list.set_defaults(func=cmd_list)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        args.func(args)
+    except UserAbortError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+    except FluxLoraError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/flux_lora/cli.py
+++ b/scripts/flux_lora/cli.py
@@ -40,7 +40,15 @@ from scripts.flux_lora.config import (
     api_key_present,
 )
 from scripts.flux_lora.dataset import dataset_summary, pack_zip, validate_dataset
-from scripts.flux_lora.inference import DEFAULT_NUM_OUTPUTS, generate, load_latest_lora
+from scripts.flux_lora.inference import (
+    DEFAULT_ASPECT_RATIO,
+    DEFAULT_GUIDANCE,
+    DEFAULT_NUM_INFERENCE_STEPS,
+    DEFAULT_NUM_OUTPUTS,
+    DEFAULT_OUTPUT_FORMAT,
+    generate,
+    load_latest_lora,
+)
 from scripts.flux_lora.status import format_status, get_status, list_runs
 from scripts.flux_lora.trainer import (
     build_manifest,
@@ -61,11 +69,6 @@ def _confirm(prompt: str = "Proceed? [y/N] ") -> bool:
     except (EOFError, KeyboardInterrupt):
         return False
     return answer in ("y", "yes")
-
-
-def _abort(msg: str = "Aborted.") -> None:
-    print(msg, file=sys.stderr)
-    sys.exit(1)
 
 
 # ---------------------------------------------------------------------------
@@ -97,7 +100,18 @@ def cmd_dataset_info(args: argparse.Namespace) -> None:
 def cmd_train(args: argparse.Namespace) -> None:
     dataset_dir = Path(args.dataset_dir)
 
-    # Validate first — fast fail before spending money.
+    # Fast-fail on missing args BEFORE any I/O or user prompt (the zip pack, the
+    # manifest, and the STOP-AND-SHOW all assume a valid upload URL exists).
+    input_images_url = (args.input_images_url or "").strip()
+    if not input_images_url:
+        print(
+            "Error: --input-images-url is required. Upload the zip to a public "
+            "https URL and supply it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Validate dataset — fast fail before spending money.
     try:
         validate_dataset(dataset_dir)
     except DatasetError as exc:
@@ -137,19 +151,10 @@ def cmd_train(args: argparse.Namespace) -> None:
         print(f"Manifest error: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    # STOP-AND-SHOW
-    show_stopandshow(manifest)
+    # STOP-AND-SHOW (includes the exact upload URL Replicate will fetch)
+    show_stopandshow(manifest, input_images_url=input_images_url)
     if not _confirm():
         raise UserAbortError("Training cancelled by user.")
-
-    # Require upload URL
-    input_images_url = (args.input_images_url or "").strip()
-    if not input_images_url:
-        print(
-            "Error: --input-images-url is required. Upload the zip to a public URL and supply it.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
 
     # Submit
     print("Submitting training job …")
@@ -191,16 +196,21 @@ def cmd_generate(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
+    gen_kwargs: dict[str, object] = {
+        "num_outputs": args.num_outputs,
+        "aspect_ratio": args.aspect_ratio,
+        "output_format": args.output_format,
+        "guidance": args.guidance,
+        "num_inference_steps": args.num_inference_steps,
+        "lora_scale": args.lora_scale,
+        "seed": args.seed,
+    }
+
     # STOP-AND-SHOW is printed inside generate() when confirmed=False.
     # We call with confirmed=False first so the user sees the manifest,
     # then re-call with confirmed=True after 'y'.
     try:
-        generate(
-            args.prompt,
-            lora_url,
-            confirmed=False,
-            num_outputs=args.num_outputs,
-        )
+        generate(args.prompt, lora_url, confirmed=False, **gen_kwargs)
     except RequiresConfirmationError:
         pass  # Expected — manifest was printed, now gate on user input.
 
@@ -208,13 +218,11 @@ def cmd_generate(args: argparse.Namespace) -> None:
         raise UserAbortError("Generation cancelled by user.")
 
     try:
-        urls = generate(
-            args.prompt,
-            lora_url,
-            confirmed=True,
-            num_outputs=args.num_outputs,
-        )
+        urls = generate(args.prompt, lora_url, confirmed=True, **gen_kwargs)
     except FluxLoraError as exc:
+        print(f"Inference error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except ValueError as exc:
         print(f"Inference error: {exc}", file=sys.stderr)
         sys.exit(1)
 
@@ -306,8 +314,16 @@ def build_parser() -> argparse.ArgumentParser:
     # generate
     p_gen = sub.add_parser("generate", help="Run FLUX inference with a trained LoRA.")
     p_gen.add_argument("prompt", help="Text prompt (include trigger word).")
-    p_gen.add_argument("--lora-url", default=None, help="Override LoRA URL.")
+    p_gen.add_argument("--lora-url", default=None, help="Override LoRA URL (https).")
     p_gen.add_argument("--num-outputs", type=int, default=DEFAULT_NUM_OUTPUTS)
+    p_gen.add_argument("--aspect-ratio", default=DEFAULT_ASPECT_RATIO)
+    p_gen.add_argument(
+        "--output-format", choices=["png", "webp", "jpg"], default=DEFAULT_OUTPUT_FORMAT
+    )
+    p_gen.add_argument("--guidance", type=float, default=DEFAULT_GUIDANCE)
+    p_gen.add_argument("--num-inference-steps", type=int, default=DEFAULT_NUM_INFERENCE_STEPS)
+    p_gen.add_argument("--lora-scale", type=float, default=1.0)
+    p_gen.add_argument("--seed", type=int, default=None, help="Fixed seed for reproducible output.")
     p_gen.set_defaults(func=cmd_generate)
 
     # status

--- a/scripts/flux_lora/config.py
+++ b/scripts/flux_lora/config.py
@@ -1,0 +1,82 @@
+"""
+scripts.flux_lora.config — All constants; zero business logic.
+
+Follows the pattern established in scripts/oai_render/config.py:
+  - load_project_env() for env loading
+  - get_api_key() raises if key absent
+  - api_key_present() returns bool (for dry-run paths)
+  - PROJECT_ROOT derived at module load
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Project root + env loading
+# ---------------------------------------------------------------------------
+try:
+    from config.load_env import load_project_env
+
+    PROJECT_ROOT: Path = load_project_env()
+except Exception:
+    # Fallback when running outside the project tree (e.g., isolated pytest)
+    PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+# ---------------------------------------------------------------------------
+# Replicate model / version
+# ---------------------------------------------------------------------------
+REPLICATE_MODEL_OWNER: str = "ostris"
+REPLICATE_MODEL_NAME: str = "flux-dev-lora-trainer"
+
+# Set to a pinned version SHA to lock behaviour; None = use latest.
+REPLICATE_VERSION: str | None = None
+
+REPLICATE_BASE_URL: str = "https://api.replicate.com"
+
+# ---------------------------------------------------------------------------
+# Training defaults (override per-run via CLI flags)
+# ---------------------------------------------------------------------------
+DEFAULT_TRIGGER_WORD: str = "SKYYROSE"
+DEFAULT_STEPS: int = 1000
+DEFAULT_LORA_RANK: int = 16
+DEFAULT_OPTIMIZER: str = "adamw8bit"
+DEFAULT_BATCH_SIZE: int = 1
+DEFAULT_RESOLUTION: str = "512,768,1024"
+DEFAULT_LR_SCHEDULER: str = "constant"
+DEFAULT_LEARNING_RATE: float = 4e-4
+
+# Autocaptioning is disabled; we supply hand-crafted captions.
+DEFAULT_AUTOCAPTION: bool = False
+DEFAULT_AUTOCAPTION_PREFIX: str = ""
+
+# ---------------------------------------------------------------------------
+# Cost guard
+# ---------------------------------------------------------------------------
+# Rough estimate per training run at default steps.
+EST_COST_PER_RUN_USD: float = 2.50
+HARD_COST_CAP_USD: float = 10.00
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+DATASET_DIR: Path = PROJECT_ROOT / "datasets" / "skyyrose_lora_v5"
+RUNS_DIR: Path = PROJECT_ROOT / "models" / "training-runs"
+MODELS_DIR: Path = PROJECT_ROOT / "models"
+
+
+# ---------------------------------------------------------------------------
+# API key helpers
+# ---------------------------------------------------------------------------
+def get_api_key() -> str:
+    """Return REPLICATE_API_TOKEN from env. Raises RuntimeError if absent."""
+    key = os.environ.get("REPLICATE_API_TOKEN")
+    if not key:
+        raise RuntimeError("REPLICATE_API_TOKEN is not set. Export it or add it to your .env file.")
+    return key
+
+
+def api_key_present() -> bool:
+    """Return True if REPLICATE_API_TOKEN is set (for dry-run checks)."""
+    return bool(os.environ.get("REPLICATE_API_TOKEN"))

--- a/scripts/flux_lora/config.py
+++ b/scripts/flux_lora/config.py
@@ -30,8 +30,11 @@ except Exception:
 REPLICATE_MODEL_OWNER: str = "ostris"
 REPLICATE_MODEL_NAME: str = "flux-dev-lora-trainer"
 
-# Set to a pinned version SHA to lock behaviour; None = use latest.
-REPLICATE_VERSION: str | None = None
+# Pinned trainer version SHA — REQUIRED by Replicate's create-training endpoint
+# (POST /v1/models/{owner}/{name}/versions/{version_id}/trainings). Verified live
+# 2026-06-24 via GET /v1/models/ostris/flux-dev-lora-trainer (latest_version.id).
+# Pinning locks reproducibility; bump only after re-verifying the TrainingInput schema.
+REPLICATE_VERSION: str = "26dce37af90b9d997eeb970d92e47de3064d46c300504ae376c75bef6a9022d2"
 
 REPLICATE_BASE_URL: str = "https://api.replicate.com"
 
@@ -44,8 +47,9 @@ DEFAULT_LORA_RANK: int = 16
 DEFAULT_OPTIMIZER: str = "adamw8bit"
 DEFAULT_BATCH_SIZE: int = 1
 DEFAULT_RESOLUTION: str = "512,768,1024"
-DEFAULT_LR_SCHEDULER: str = "constant"
 DEFAULT_LEARNING_RATE: float = 4e-4
+# NOTE: ostris/flux-dev-lora-trainer TrainingInput has NO lr_scheduler field
+# (verified live 2026-06-24). The scheduler is fixed internally by the trainer.
 
 # Autocaptioning is disabled; we supply hand-crafted captions.
 DEFAULT_AUTOCAPTION: bool = False

--- a/scripts/flux_lora/config.py
+++ b/scripts/flux_lora/config.py
@@ -84,3 +84,13 @@ def get_api_key() -> str:
 def api_key_present() -> bool:
     """Return True if REPLICATE_API_TOKEN is set (for dry-run checks)."""
     return bool(os.environ.get("REPLICATE_API_TOKEN"))
+
+
+def is_https_url(url: object) -> bool:
+    """
+    Return True only for an https:// URL string.
+
+    Used to guard the URLs Replicate fetches server-side (dataset zip, LoRA
+    weights) against SSRF / non-https schemes before any paid call.
+    """
+    return isinstance(url, str) and url.lower().startswith("https://")

--- a/scripts/flux_lora/dataset.py
+++ b/scripts/flux_lora/dataset.py
@@ -1,0 +1,175 @@
+"""
+scripts.flux_lora.dataset — Dataset loading, validation, and packaging.
+
+Public API:
+  load_dataset(dataset_dir)      -> dict with metadata + image paths
+  validate_dataset(dataset_dir)  -> None (raises DatasetError on failure)
+  pack_zip(dataset_dir, dest)    -> Path to created zip
+  dataset_summary(dataset_dir)   -> dict with counts and sizes
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from scripts.flux_lora import DatasetError
+from scripts.flux_lora.config import DATASET_DIR, DEFAULT_TRIGGER_WORD
+
+IMAGE_EXTENSIONS: frozenset[str] = frozenset({".jpg", ".jpeg", ".png", ".webp"})
+MIN_IMAGES: int = 5
+
+
+def _image_files(dataset_dir: Path) -> list[Path]:
+    """Return sorted list of image files in dataset_dir."""
+    return sorted(p for p in dataset_dir.iterdir() if p.suffix.lower() in IMAGE_EXTENSIONS)
+
+
+def load_dataset(dataset_dir: Path = DATASET_DIR) -> dict[str, Any]:
+    """
+    Load dataset metadata and enumerate image/caption pairs.
+
+    Returns:
+        {
+          "dataset_dir": Path,
+          "images": [Path, ...],
+          "captions": {stem: str, ...},   # keyed by image stem
+          "metadata": dict | None,
+        }
+
+    Raises:
+        DatasetError: if directory absent or no metadata file present.
+    """
+    if not dataset_dir.exists():
+        raise DatasetError(f"Dataset directory not found: {dataset_dir}")
+
+    images = _image_files(dataset_dir)
+
+    # Load captions from .txt sidecars
+    captions: dict[str, str] = {}
+    for img in images:
+        sidecar = img.with_suffix(".txt")
+        if sidecar.exists():
+            captions[img.stem] = sidecar.read_text(encoding="utf-8").strip()
+
+    # Optional metadata.jsonl
+    metadata: dict[str, Any] | None = None
+    meta_path = dataset_dir / "metadata.jsonl"
+    if meta_path.exists():
+        lines = meta_path.read_text(encoding="utf-8").splitlines()
+        rows = [json.loads(ln) for ln in lines if ln.strip()]
+        metadata = {"rows": rows}
+
+    return {
+        "dataset_dir": dataset_dir,
+        "images": images,
+        "captions": captions,
+        "metadata": metadata,
+    }
+
+
+def validate_dataset(dataset_dir: Path = DATASET_DIR) -> None:
+    """
+    Validate dataset is ready for training.
+
+    Checks:
+      - Directory exists
+      - At least MIN_IMAGES images present
+      - Every image has a corresponding .txt caption sidecar
+      - Every caption begins with DEFAULT_TRIGGER_WORD
+
+    Raises:
+        DatasetError: with a descriptive message on first failure found.
+    """
+    if not dataset_dir.exists():
+        raise DatasetError(f"Dataset directory not found: {dataset_dir}")
+
+    images = _image_files(dataset_dir)
+    if len(images) < MIN_IMAGES:
+        raise DatasetError(
+            f"Dataset has {len(images)} image(s); minimum is {MIN_IMAGES}. Directory: {dataset_dir}"
+        )
+
+    missing_captions: list[str] = []
+    bad_trigger: list[str] = []
+
+    for img in images:
+        sidecar = img.with_suffix(".txt")
+        if not sidecar.exists():
+            missing_captions.append(img.name)
+            continue
+        caption = sidecar.read_text(encoding="utf-8").strip()
+        if not caption.startswith(DEFAULT_TRIGGER_WORD):
+            bad_trigger.append(img.name)
+
+    if missing_captions:
+        raise DatasetError(f"Missing caption sidecars for: {', '.join(missing_captions)}")
+    if bad_trigger:
+        raise DatasetError(
+            f"Captions must start with trigger word '{DEFAULT_TRIGGER_WORD}'. "
+            f"Offending images: {', '.join(bad_trigger)}"
+        )
+
+
+def pack_zip(dataset_dir: Path = DATASET_DIR, dest: Path | None = None) -> Path:
+    """
+    Zip images + caption sidecars for upload to Replicate.
+
+    Args:
+        dataset_dir: Source dataset directory.
+        dest:        Destination path for zip. Defaults to
+                     dataset_dir.parent / (dataset_dir.name + ".zip").
+
+    Returns:
+        Path to the created zip file.
+
+    Raises:
+        DatasetError: if dataset_dir is missing or has no images.
+    """
+    validate_dataset(dataset_dir)
+
+    if dest is None:
+        dest = dataset_dir.parent / f"{dataset_dir.name}.zip"
+
+    images = _image_files(dataset_dir)
+
+    with zipfile.ZipFile(dest, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for img in images:
+            zf.write(img, img.name)
+            sidecar = img.with_suffix(".txt")
+            if sidecar.exists():
+                zf.write(sidecar, sidecar.name)
+
+    return dest
+
+
+def dataset_summary(dataset_dir: Path = DATASET_DIR) -> dict[str, Any]:
+    """
+    Return a summary dict with image counts and total size.
+
+    Returns:
+        {
+          "image_count": int,
+          "caption_count": int,
+          "total_bytes": int,
+          "dataset_dir": str,
+        }
+
+    Raises:
+        DatasetError: if directory absent.
+    """
+    if not dataset_dir.exists():
+        raise DatasetError(f"Dataset directory not found: {dataset_dir}")
+
+    images = _image_files(dataset_dir)
+    total_bytes = sum(img.stat().st_size for img in images)
+    caption_count = sum(1 for img in images if img.with_suffix(".txt").exists())
+
+    return {
+        "image_count": len(images),
+        "caption_count": caption_count,
+        "total_bytes": total_bytes,
+        "dataset_dir": str(dataset_dir),
+    }

--- a/scripts/flux_lora/dataset.py
+++ b/scripts/flux_lora/dataset.py
@@ -23,8 +23,12 @@ MIN_IMAGES: int = 5
 
 
 def _image_files(dataset_dir: Path) -> list[Path]:
-    """Return sorted list of image files in dataset_dir."""
-    return sorted(p for p in dataset_dir.iterdir() if p.suffix.lower() in IMAGE_EXTENSIONS)
+    """Return sorted list of image FILES in dataset_dir (skips dirs named e.g. x.png)."""
+    if not dataset_dir.is_dir():
+        raise DatasetError(f"Dataset path is not a directory: {dataset_dir}")
+    return sorted(
+        p for p in dataset_dir.iterdir() if p.is_file() and p.suffix.lower() in IMAGE_EXTENSIONS
+    )
 
 
 def load_dataset(dataset_dir: Path = DATASET_DIR) -> dict[str, Any]:
@@ -40,7 +44,8 @@ def load_dataset(dataset_dir: Path = DATASET_DIR) -> dict[str, Any]:
         }
 
     Raises:
-        DatasetError: if directory absent or no metadata file present.
+        DatasetError: if dataset_dir does not exist or is not a directory.
+                      (metadata.jsonl is optional; absent => metadata is None.)
     """
     if not dataset_dir.exists():
         raise DatasetError(f"Dataset directory not found: {dataset_dir}")
@@ -81,7 +86,8 @@ def validate_dataset(dataset_dir: Path = DATASET_DIR) -> None:
       - Every caption begins with DEFAULT_TRIGGER_WORD
 
     Raises:
-        DatasetError: with a descriptive message on first failure found.
+        DatasetError: with all caption problems collected into one message
+                      (missing sidecars AND wrong trigger words together).
     """
     if not dataset_dir.exists():
         raise DatasetError(f"Dataset directory not found: {dataset_dir}")
@@ -104,13 +110,16 @@ def validate_dataset(dataset_dir: Path = DATASET_DIR) -> None:
         if not caption.startswith(DEFAULT_TRIGGER_WORD):
             bad_trigger.append(img.name)
 
+    errors: list[str] = []
     if missing_captions:
-        raise DatasetError(f"Missing caption sidecars for: {', '.join(missing_captions)}")
+        errors.append(f"Missing caption sidecars for: {', '.join(missing_captions)}")
     if bad_trigger:
-        raise DatasetError(
+        errors.append(
             f"Captions must start with trigger word '{DEFAULT_TRIGGER_WORD}'. "
             f"Offending images: {', '.join(bad_trigger)}"
         )
+    if errors:
+        raise DatasetError(" | ".join(errors))
 
 
 def pack_zip(dataset_dir: Path = DATASET_DIR, dest: Path | None = None) -> Path:

--- a/scripts/flux_lora/dataset_builder.py
+++ b/scripts/flux_lora/dataset_builder.py
@@ -1,0 +1,155 @@
+"""
+scripts.flux_lora.dataset_builder — Assemble a FLUX LoRA training dataset.
+
+Public API
+----------
+build_dataset(sources, dest_dir, *, trigger_word, overwrite) -> Path
+
+Rules
+-----
+- Caption sidecar (.txt) MUST start with trigger_word.
+- If caller supplies "caption" that already starts with trigger_word → use as-is.
+- If caller supplies "caption" without trigger_word → prepend it.
+- If caller supplies "garment" only → compose "<trigger_word> <garment>".
+- If neither "caption" nor "garment" → raise DatasetError (no ML-authored captions).
+- Non-empty dest_dir without overwrite=True → raise DatasetError.
+- Each source["image"] must exist on disk → raise DatasetError if missing.
+- Preserves source image extension (stems normalized: img_01, img_02, …).
+- Pure stdlib — no network, no third-party deps.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+from scripts.flux_lora import DatasetError
+from scripts.flux_lora.config import DEFAULT_TRIGGER_WORD
+from scripts.flux_lora.dataset import IMAGE_EXTENSIONS, validate_dataset
+
+
+def _compose_caption(
+    source: dict[str, Any],
+    trigger_word: str,
+) -> str:
+    """
+    Derive a caption string from a source dict.
+
+    Priority:
+      1. "caption" key — use as-is if already starts with trigger_word, else prepend.
+      2. "garment" key — compose "<trigger_word> <garment>".
+      3. Neither → raise DatasetError.
+    """
+    caption: str | None = source.get("caption")
+    garment: str | None = source.get("garment")
+
+    if caption is not None:
+        caption = caption.strip()
+        if caption.lower().startswith(trigger_word.lower()):
+            return caption
+        return f"{trigger_word} {caption}"
+
+    if garment is not None:
+        garment = garment.strip()
+        if not garment:
+            raise DatasetError(
+                "source 'garment' value is empty; provide a non-empty garment description "
+                "or an explicit 'caption'."
+            )
+        return f"{trigger_word} {garment}"
+
+    raise DatasetError(
+        "Every source must include 'caption' or 'garment'. "
+        "ML-authored captions are not permitted — provide an author-written caption."
+    )
+
+
+def build_dataset(
+    sources: list[dict[str, Any]],
+    dest_dir: str | Path,
+    *,
+    trigger_word: str = DEFAULT_TRIGGER_WORD,
+    overwrite: bool = False,
+) -> Path:
+    """
+    Assemble a FLUX LoRA training dataset directory from a list of source dicts.
+
+    Parameters
+    ----------
+    sources:
+        List of dicts, each with:
+          - "image"   : str or Path — source image file (required, must exist).
+          - "caption" : str          — author-written caption (optional).
+          - "garment" : str          — garment description, used when caption absent.
+        Either "caption" or "garment" must be present.
+
+    dest_dir:
+        Directory to write normalized images + caption sidecars into.
+
+    trigger_word:
+        Token prepended to every caption (default: "SKYYROSE").
+
+    overwrite:
+        If True, clear dest_dir contents before writing.
+        If False (default), raise DatasetError when dest_dir is non-empty.
+
+    Returns
+    -------
+    Path
+        Resolved path to dest_dir after successful build + validation.
+
+    Raises
+    ------
+    DatasetError
+        - dest_dir non-empty and overwrite=False.
+        - Any source image missing or not a file.
+        - Any source has neither "caption" nor "garment".
+        - validate_dataset() fails (< MIN_IMAGES, missing sidecar, bad trigger).
+    """
+    if not sources:
+        raise DatasetError("sources list is empty; provide at least one source image.")
+
+    dest = Path(dest_dir).resolve()
+    dest.mkdir(parents=True, exist_ok=True)
+
+    # Clobber guard
+    existing = list(dest.iterdir())
+    if existing and not overwrite:
+        raise DatasetError(
+            f"dest_dir '{dest}' is non-empty ({len(existing)} entries). "
+            "Pass overwrite=True to replace its contents."
+        )
+    if existing and overwrite:
+        # Remove dataset files only (images + .txt sidecars) to avoid nuking unrelated files
+        for child in dest.iterdir():
+            if child.suffix.lower() in IMAGE_EXTENSIONS or child.suffix == ".txt":
+                child.unlink()
+
+    # Validate all source images exist before writing anything
+    errors: list[str] = []
+    for i, src in enumerate(sources):
+        img_path = Path(src.get("image", ""))
+        if not img_path.exists() or not img_path.is_file():
+            errors.append(f"source[{i}] image not found: '{img_path}'")
+    if errors:
+        raise DatasetError("\n".join(errors))
+
+    # Copy images + write sidecars
+    for idx, src in enumerate(sources, start=1):
+        img_src = Path(src["image"])
+        suffix = img_src.suffix.lower()
+
+        stem = f"img_{idx:02d}"
+        img_dest = dest / f"{stem}{suffix}"
+        txt_dest = dest / f"{stem}.txt"
+
+        shutil.copy2(img_src, img_dest)
+
+        caption = _compose_caption(src, trigger_word)
+        txt_dest.write_text(caption, encoding="utf-8")
+
+    # Validate the assembled dataset
+    validate_dataset(dest)
+
+    return dest

--- a/scripts/flux_lora/inference.py
+++ b/scripts/flux_lora/inference.py
@@ -12,16 +12,18 @@ Public API:
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 import httpx
 
-from scripts.flux_lora import RequiresConfirmationError, TrainingError
+from scripts.flux_lora import InferenceError, RequiresConfirmationError
 from scripts.flux_lora.config import (
     REPLICATE_BASE_URL,
     get_api_key,
+    is_https_url,
 )
-from scripts.flux_lora.status import list_runs
+from scripts.flux_lora.status import TERMINAL_STATUSES, list_runs
 
 # ---------------------------------------------------------------------------
 # Default inference params
@@ -31,6 +33,11 @@ DEFAULT_ASPECT_RATIO: str = "1:1"
 DEFAULT_OUTPUT_FORMAT: str = "png"
 DEFAULT_GUIDANCE: float = 3.5
 DEFAULT_NUM_INFERENCE_STEPS: int = 28
+
+# Polling: a prediction created with `Prefer: wait` may still return non-terminal
+# (Replicate caps the synchronous wait at ~60s). We then poll urls.get until done.
+POLL_INTERVAL_S: float = 3.0
+POLL_TIMEOUT_S: float = 300.0
 
 # Replicate model for FLUX.1-dev inference WITH LoRA support.
 # Field names (lora_weights, lora_scale, guidance, ...) verified against this
@@ -86,6 +93,46 @@ def _show_inference_stopandshow(
     print("=" * 60)
 
 
+def _extract_output_urls(data: dict[str, Any]) -> list[str]:
+    """Return the image URL list from a SUCCEEDED prediction, else raise."""
+    output = data.get("output")
+    if isinstance(output, str):
+        return [output]
+    if isinstance(output, list):
+        return [str(u) for u in output]
+    raise InferenceError(
+        f"Prediction succeeded but output was {type(output).__name__}, "
+        "expected a URL string or list."
+    )
+
+
+def _poll_prediction(get_url: str, token: str) -> dict[str, Any]:
+    """
+    Poll a prediction's urls.get until it reaches a terminal status, then return
+    the final prediction dict. Checks status BEFORE sleeping so a prediction that
+    is already terminal returns immediately (and tests never sleep).
+    """
+    headers = {"Authorization": f"Bearer {token}"}
+    elapsed = 0.0
+    while True:
+        try:
+            resp = httpx.get(get_url, headers=headers, timeout=15.0)
+        except httpx.RequestError as exc:
+            raise InferenceError(f"Prediction poll request failed: {exc}") from exc
+        if resp.status_code != 200:
+            raise InferenceError(f"Prediction poll returned {resp.status_code}: {resp.text}")
+        data = resp.json()
+        if data.get("status") in TERMINAL_STATUSES:
+            return data
+        if elapsed >= POLL_TIMEOUT_S:
+            raise InferenceError(
+                f"Prediction did not complete within {POLL_TIMEOUT_S:.0f}s "
+                f"(last status: {data.get('status')!r})."
+            )
+        time.sleep(POLL_INTERVAL_S)
+        elapsed += POLL_INTERVAL_S
+
+
 def generate(
     prompt: str,
     lora_url: str,
@@ -97,16 +144,21 @@ def generate(
     guidance: float = DEFAULT_GUIDANCE,
     num_inference_steps: int = DEFAULT_NUM_INFERENCE_STEPS,
     lora_scale: float = 1.0,
+    seed: int | None = None,
 ) -> list[str]:
     """
-    Run FLUX inference with a trained LoRA.
+    Run FLUX inference with a trained LoRA and return the output image URLs.
 
     SECURITY: confirmed MUST be True. If False, raises RequiresConfirmationError
     without making any HTTP call.
 
+    The prediction is created with `Prefer: wait` (synchronous up to ~60s). If it
+    has not finished in that window, we poll urls.get until it reaches a terminal
+    status, then return the output (or raise InferenceError on failed/canceled).
+
     Args:
         prompt:               Text prompt (trigger word should be included).
-        lora_url:             Replicate output URL from a succeeded training run.
+        lora_url:             https URL to the trained LoRA weights.
         confirmed:            Must be True (set only after user typed 'y').
         num_outputs:          Number of images to generate (1-4).
         aspect_ratio:         Image aspect ratio (e.g. "1:1", "2:3", "3:4").
@@ -114,13 +166,15 @@ def generate(
         guidance:             FLUX guidance value (the model's `guidance` field).
         num_inference_steps:  Denoising steps.
         lora_scale:           Trained-LoRA weight scale (0.0-1.0).
+        seed:                 Optional fixed seed for reproducible output.
 
     Returns:
-        List of output image URLs.
+        List of output image URLs (from a succeeded prediction).
 
     Raises:
         RequiresConfirmationError: if confirmed is False.
-        TrainingError:             on API error or non-201 response.
+        InferenceError:            on API error, failed/canceled prediction, or timeout.
+        ValueError:                if lora_url is not an https URL.
     """
     if not confirmed:
         _show_inference_stopandshow(prompt, lora_url, num_outputs)
@@ -129,39 +183,52 @@ def generate(
             "Call generate(..., confirmed=True) only after user types 'y'."
         )
 
+    if not is_https_url(lora_url):
+        raise ValueError(f"lora_url must be an https:// URL, got: {lora_url!r}")
+
     token = get_api_key()
     base = REPLICATE_BASE_URL.rstrip("/")
     url = f"{base}/v1/models/{FLUX_INFERENCE_MODEL}/predictions"
 
-    payload: dict[str, Any] = {
-        "input": {
-            "prompt": prompt,
-            "lora_weights": lora_url,
-            "lora_scale": lora_scale,
-            "num_outputs": num_outputs,
-            "aspect_ratio": aspect_ratio,
-            "output_format": output_format,
-            "guidance": guidance,
-            "num_inference_steps": num_inference_steps,
-        }
+    model_input: dict[str, Any] = {
+        "prompt": prompt,
+        "lora_weights": lora_url,
+        "lora_scale": lora_scale,
+        "num_outputs": num_outputs,
+        "aspect_ratio": aspect_ratio,
+        "output_format": output_format,
+        "guidance": guidance,
+        "num_inference_steps": num_inference_steps,
     }
+    if seed is not None:
+        model_input["seed"] = seed
 
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
-        "Prefer": "respond-async",
+        "Prefer": "wait",
     }
 
     try:
-        response = httpx.post(url, json=payload, headers=headers, timeout=30.0)
+        response = httpx.post(url, json={"input": model_input}, headers=headers, timeout=90.0)
     except httpx.RequestError as exc:
-        raise TrainingError(f"HTTP request failed: {exc}") from exc
+        raise InferenceError(f"HTTP request failed: {exc}") from exc
 
     if response.status_code not in (200, 201):
-        raise TrainingError(f"Replicate API returned {response.status_code}: {response.text}")
+        raise InferenceError(f"Replicate API returned {response.status_code}: {response.text}")
 
     data = response.json()
-    output = data.get("output") or []
-    if isinstance(output, str):
-        return [output]
-    return list(output)
+    # Prefer: wait may still hand back a non-terminal prediction — poll until done.
+    if data.get("status") not in TERMINAL_STATUSES:
+        get_url = (data.get("urls") or {}).get("get")
+        if not get_url:
+            raise InferenceError(
+                "Replicate response has no terminal status and no urls.get to poll."
+            )
+        data = _poll_prediction(get_url, token)
+
+    status = data.get("status")
+    if status != "succeeded":
+        raise InferenceError(f"Inference {status}: {data.get('error') or 'no output produced'}")
+
+    return _extract_output_urls(data)

--- a/scripts/flux_lora/inference.py
+++ b/scripts/flux_lora/inference.py
@@ -1,0 +1,164 @@
+"""
+scripts.flux_lora.inference — FLUX LoRA inference via Replicate API.
+
+SECURITY CONTRACT (ABSOLUTE):
+  Any code path that reaches a Replicate POST without a prior STOP-AND-SHOW
+  print + user 'y' is a bug. confirmed=False MUST raise RequiresConfirmationError.
+
+Public API:
+  load_latest_lora()             -> str | None   (Replicate output URL from latest run)
+  generate(prompt, lora_url, confirmed, **kwargs) -> list[str]  (output image URLs)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from scripts.flux_lora import RequiresConfirmationError, TrainingError
+from scripts.flux_lora.config import (
+    REPLICATE_BASE_URL,
+    get_api_key,
+)
+from scripts.flux_lora.status import list_runs
+
+# ---------------------------------------------------------------------------
+# Default inference params
+# ---------------------------------------------------------------------------
+DEFAULT_NUM_OUTPUTS: int = 1
+DEFAULT_ASPECT_RATIO: str = "1:1"
+DEFAULT_OUTPUT_FORMAT: str = "png"
+DEFAULT_GUIDANCE_SCALE: float = 3.5
+DEFAULT_NUM_INFERENCE_STEPS: int = 28
+
+# Replicate model for FLUX.1-dev inference (supports LoRA via extra_lora)
+FLUX_INFERENCE_MODEL: str = "black-forest-labs/flux-dev"
+
+
+# ---------------------------------------------------------------------------
+# Latest LoRA loader
+# ---------------------------------------------------------------------------
+
+
+def load_latest_lora() -> str | None:
+    """
+    Return the Replicate output URL (trained weights) from the most recent
+    succeeded training run, or None if no succeeded run exists.
+    """
+    runs = list_runs()
+    for run in runs:
+        resp = run.get("replicate_response", {})
+        if resp.get("status") == "succeeded":
+            output = resp.get("output")
+            if isinstance(output, str):
+                return output
+            if isinstance(output, list) and output:
+                return output[0]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Generate
+# ---------------------------------------------------------------------------
+
+
+def _show_inference_stopandshow(
+    prompt: str,
+    lora_url: str,
+    num_outputs: int,
+) -> None:
+    print()
+    print("=" * 60)
+    print("STOP — Confirm before proceeding:")
+    print()
+    print("  Action   : Replicate FLUX inference")
+    print(f"  Model    : {FLUX_INFERENCE_MODEL}")
+    print(f"  LoRA     : {lora_url}")
+    print(f"  Prompt   : {prompt[:80]}{'...' if len(prompt) > 80 else ''}")
+    print(f"  Outputs  : {num_outputs}")
+    print(f"  Cost     : ~${num_outputs * 0.055:.3f}  (est. $0.055/image)")
+    print()
+    print("Proceed? [y/N]")
+    print("=" * 60)
+
+
+def generate(
+    prompt: str,
+    lora_url: str,
+    *,
+    confirmed: bool,
+    num_outputs: int = DEFAULT_NUM_OUTPUTS,
+    aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+    output_format: str = DEFAULT_OUTPUT_FORMAT,
+    guidance_scale: float = DEFAULT_GUIDANCE_SCALE,
+    num_inference_steps: int = DEFAULT_NUM_INFERENCE_STEPS,
+    lora_scale: float = 1.0,
+) -> list[str]:
+    """
+    Run FLUX inference with a trained LoRA.
+
+    SECURITY: confirmed MUST be True. If False, raises RequiresConfirmationError
+    without making any HTTP call.
+
+    Args:
+        prompt:               Text prompt (trigger word should be included).
+        lora_url:             Replicate output URL from a succeeded training run.
+        confirmed:            Must be True (set only after user typed 'y').
+        num_outputs:          Number of images to generate (1-4).
+        aspect_ratio:         Image aspect ratio (e.g. "1:1", "2:3", "3:4").
+        output_format:        "png" | "webp" | "jpg".
+        guidance_scale:       CFG guidance scale.
+        num_inference_steps:  Denoising steps.
+        lora_scale:           LoRA weight scale (0.0-1.0).
+
+    Returns:
+        List of output image URLs.
+
+    Raises:
+        RequiresConfirmationError: if confirmed is False.
+        TrainingError:             on API error or non-201 response.
+    """
+    if not confirmed:
+        _show_inference_stopandshow(prompt, lora_url, num_outputs)
+        raise RequiresConfirmationError(
+            "Inference requires explicit confirmation. "
+            "Call generate(..., confirmed=True) only after user types 'y'."
+        )
+
+    token = get_api_key()
+    base = REPLICATE_BASE_URL.rstrip("/")
+    url = f"{base}/v1/models/{FLUX_INFERENCE_MODEL}/predictions"
+
+    payload: dict[str, Any] = {
+        "input": {
+            "prompt": prompt,
+            "extra_lora": lora_url,
+            "extra_lora_scale": lora_scale,
+            "num_outputs": num_outputs,
+            "aspect_ratio": aspect_ratio,
+            "output_format": output_format,
+            "guidance_scale": guidance_scale,
+            "num_inference_steps": num_inference_steps,
+        }
+    }
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Prefer": "respond-async",
+    }
+
+    try:
+        response = httpx.post(url, json=payload, headers=headers, timeout=30.0)
+    except httpx.RequestError as exc:
+        raise TrainingError(f"HTTP request failed: {exc}") from exc
+
+    if response.status_code not in (200, 201):
+        raise TrainingError(f"Replicate API returned {response.status_code}: {response.text}")
+
+    data = response.json()
+    output = data.get("output") or []
+    if isinstance(output, str):
+        return [output]
+    return list(output)

--- a/scripts/flux_lora/inference.py
+++ b/scripts/flux_lora/inference.py
@@ -29,11 +29,14 @@ from scripts.flux_lora.status import list_runs
 DEFAULT_NUM_OUTPUTS: int = 1
 DEFAULT_ASPECT_RATIO: str = "1:1"
 DEFAULT_OUTPUT_FORMAT: str = "png"
-DEFAULT_GUIDANCE_SCALE: float = 3.5
+DEFAULT_GUIDANCE: float = 3.5
 DEFAULT_NUM_INFERENCE_STEPS: int = 28
 
-# Replicate model for FLUX.1-dev inference (supports LoRA via extra_lora)
-FLUX_INFERENCE_MODEL: str = "black-forest-labs/flux-dev"
+# Replicate model for FLUX.1-dev inference WITH LoRA support.
+# Field names (lora_weights, lora_scale, guidance, ...) verified against this
+# model's live Input schema on 2026-06-24. The base black-forest-labs/flux-dev
+# model has NO lora_weights/extra_lora fields — it must be the -lora variant.
+FLUX_INFERENCE_MODEL: str = "black-forest-labs/flux-dev-lora"
 
 
 # ---------------------------------------------------------------------------
@@ -91,7 +94,7 @@ def generate(
     num_outputs: int = DEFAULT_NUM_OUTPUTS,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
     output_format: str = DEFAULT_OUTPUT_FORMAT,
-    guidance_scale: float = DEFAULT_GUIDANCE_SCALE,
+    guidance: float = DEFAULT_GUIDANCE,
     num_inference_steps: int = DEFAULT_NUM_INFERENCE_STEPS,
     lora_scale: float = 1.0,
 ) -> list[str]:
@@ -108,9 +111,9 @@ def generate(
         num_outputs:          Number of images to generate (1-4).
         aspect_ratio:         Image aspect ratio (e.g. "1:1", "2:3", "3:4").
         output_format:        "png" | "webp" | "jpg".
-        guidance_scale:       CFG guidance scale.
+        guidance:             FLUX guidance value (the model's `guidance` field).
         num_inference_steps:  Denoising steps.
-        lora_scale:           LoRA weight scale (0.0-1.0).
+        lora_scale:           Trained-LoRA weight scale (0.0-1.0).
 
     Returns:
         List of output image URLs.
@@ -133,12 +136,12 @@ def generate(
     payload: dict[str, Any] = {
         "input": {
             "prompt": prompt,
-            "extra_lora": lora_url,
-            "extra_lora_scale": lora_scale,
+            "lora_weights": lora_url,
+            "lora_scale": lora_scale,
             "num_outputs": num_outputs,
             "aspect_ratio": aspect_ratio,
             "output_format": output_format,
-            "guidance_scale": guidance_scale,
+            "guidance": guidance,
             "num_inference_steps": num_inference_steps,
         }
     }

--- a/scripts/flux_lora/status.py
+++ b/scripts/flux_lora/status.py
@@ -1,0 +1,106 @@
+"""
+scripts.flux_lora.status — Training run status and history.
+
+Public API:
+  get_status(training_id)  -> dict   (Replicate training status response)
+  list_runs()              -> list[dict]   (all saved run records, newest first)
+  format_status(status_dict) -> str   (human-readable summary)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from scripts.flux_lora import TrainingError
+from scripts.flux_lora.config import REPLICATE_BASE_URL, RUNS_DIR, get_api_key
+
+# Replicate training status values
+TERMINAL_STATUSES: frozenset[str] = frozenset({"succeeded", "failed", "canceled"})
+
+
+def get_status(training_id: str) -> dict[str, Any]:
+    """
+    Fetch current status of a Replicate training job.
+
+    Args:
+        training_id: The Replicate training ID (from start_training response).
+
+    Returns:
+        Replicate training status dict with keys: id, status, urls, output, error.
+
+    Raises:
+        TrainingError: on HTTP error or non-200 response.
+    """
+    token = get_api_key()
+    url = f"{REPLICATE_BASE_URL.rstrip('/')}/v1/trainings/{training_id}"
+    headers = {"Authorization": f"Bearer {token}"}
+
+    try:
+        response = httpx.get(url, headers=headers, timeout=15.0)
+    except httpx.RequestError as exc:
+        raise TrainingError(f"HTTP request failed: {exc}") from exc
+
+    if response.status_code != 200:
+        raise TrainingError(f"Replicate API returned {response.status_code}: {response.text}")
+
+    return response.json()
+
+
+def list_runs(runs_dir: Path = RUNS_DIR) -> list[dict[str, Any]]:
+    """
+    Return all saved training run records from RUNS_DIR, newest first.
+
+    Returns:
+        List of run record dicts (may be empty if RUNS_DIR absent or no records).
+    """
+    if not runs_dir.exists():
+        return []
+
+    records: list[dict[str, Any]] = []
+    for path in sorted(runs_dir.glob("training-run-*.json"), reverse=True):
+        try:
+            records.append(json.loads(path.read_text(encoding="utf-8")))
+        except (json.JSONDecodeError, OSError):
+            continue
+
+    return records
+
+
+def format_status(status_dict: dict[str, Any]) -> str:
+    """
+    Format a Replicate training status dict as a human-readable string.
+
+    Args:
+        status_dict: Output of get_status() or the replicate_response in a run record.
+
+    Returns:
+        Multi-line string suitable for terminal display.
+    """
+    training_id = status_dict.get("id", "unknown")
+    status = status_dict.get("status", "unknown")
+    created = status_dict.get("created_at", "")
+    completed = status_dict.get("completed_at", "")
+    error = status_dict.get("error")
+    urls = status_dict.get("urls", {})
+    output = status_dict.get("output")
+
+    lines: list[str] = [
+        f"Training ID : {training_id}",
+        f"Status      : {status}",
+    ]
+    if created:
+        lines.append(f"Created     : {created}")
+    if completed:
+        lines.append(f"Completed   : {completed}")
+    if urls.get("get"):
+        lines.append(f"URL         : {urls['get']}")
+    if output:
+        lines.append(f"Output      : {output}")
+    if error:
+        lines.append(f"Error       : {error}")
+
+    return "\n".join(lines)

--- a/scripts/flux_lora/trainer.py
+++ b/scripts/flux_lora/trainer.py
@@ -1,0 +1,260 @@
+"""
+scripts.flux_lora.trainer — FLUX LoRA training via Replicate API.
+
+SECURITY CONTRACT (ABSOLUTE):
+  Any code path that reaches a Replicate POST without a prior STOP-AND-SHOW
+  print + user 'y' is a bug. confirmed=False MUST raise RequiresConfirmationError.
+
+Public API:
+  build_manifest(dataset_zip, ...)  -> dict   (training params + cost estimate)
+  show_stopandshow(manifest)        -> None   (prints the confirmation block)
+  start_training(manifest, confirmed, input_images_url)
+                                    -> dict   (Replicate training response)
+  save_run_record(training_resp, manifest) -> Path
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from scripts.flux_lora import (
+    RequiresConfirmationError,
+    TrainingError,
+    UserAbortError,
+)
+from scripts.flux_lora.config import (
+    DEFAULT_AUTOCAPTION,
+    DEFAULT_AUTOCAPTION_PREFIX,
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_LEARNING_RATE,
+    DEFAULT_LORA_RANK,
+    DEFAULT_LR_SCHEDULER,
+    DEFAULT_OPTIMIZER,
+    DEFAULT_RESOLUTION,
+    DEFAULT_STEPS,
+    DEFAULT_TRIGGER_WORD,
+    EST_COST_PER_RUN_USD,
+    HARD_COST_CAP_USD,
+    REPLICATE_BASE_URL,
+    REPLICATE_MODEL_NAME,
+    REPLICATE_MODEL_OWNER,
+    REPLICATE_VERSION,
+    RUNS_DIR,
+    get_api_key,
+)
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+def build_manifest(
+    dataset_zip: Path,
+    *,
+    trigger_word: str = DEFAULT_TRIGGER_WORD,
+    steps: int = DEFAULT_STEPS,
+    lora_rank: int = DEFAULT_LORA_RANK,
+    optimizer: str = DEFAULT_OPTIMIZER,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    resolution: str = DEFAULT_RESOLUTION,
+    lr_scheduler: str = DEFAULT_LR_SCHEDULER,
+    learning_rate: float = DEFAULT_LEARNING_RATE,
+    autocaption: bool = DEFAULT_AUTOCAPTION,
+    autocaption_prefix: str = DEFAULT_AUTOCAPTION_PREFIX,
+    destination_model: str | None = None,
+) -> dict[str, Any]:
+    """
+    Build a training manifest (params + cost estimate) without making any API call.
+
+    Args:
+        dataset_zip:       Local path to the packed dataset zip (for reference only;
+                           the caller must upload it and supply the URL separately).
+        destination_model: Replicate model slug to push the trained LoRA to
+                           (e.g. "myuser/skyyrose-lora"). Optional.
+
+    Returns:
+        Manifest dict with keys: model, version, training_input, cost_usd, dataset_zip.
+
+    Raises:
+        ValueError: if estimated cost exceeds HARD_COST_CAP_USD.
+    """
+    estimated_cost = EST_COST_PER_RUN_USD
+    if estimated_cost > HARD_COST_CAP_USD:
+        raise ValueError(
+            f"Estimated cost ${estimated_cost:.2f} exceeds hard cap "
+            f"${HARD_COST_CAP_USD:.2f}. Aborting."
+        )
+
+    training_input: dict[str, Any] = {
+        "trigger_word": trigger_word,
+        "steps": steps,
+        "lora_rank": lora_rank,
+        "optimizer": optimizer,
+        "batch_size": batch_size,
+        "resolution": resolution,
+        "lr_scheduler": lr_scheduler,
+        "learning_rate": learning_rate,
+        "autocaption": autocaption,
+        "autocaption_prefix": autocaption_prefix,
+    }
+
+    manifest: dict[str, Any] = {
+        "model_owner": REPLICATE_MODEL_OWNER,
+        "model_name": REPLICATE_MODEL_NAME,
+        "version": REPLICATE_VERSION,
+        "training_input": training_input,
+        "destination_model": destination_model,
+        "cost_usd": estimated_cost,
+        "dataset_zip": str(dataset_zip),
+    }
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# STOP-AND-SHOW
+# ---------------------------------------------------------------------------
+
+
+def show_stopandshow(manifest: dict[str, Any]) -> None:
+    """
+    Print the STOP-AND-SHOW confirmation block to stdout.
+
+    This MUST be called and the user MUST type 'y' before start_training()
+    is called with confirmed=True.
+    """
+    inp = manifest["training_input"]
+    print()
+    print("=" * 60)
+    print("STOP — Confirm before proceeding:")
+    print()
+    print(f"  Action  : Replicate FLUX LoRA training")
+    print(f"  Model   : {manifest['model_owner']}/{manifest['model_name']}")
+    if manifest.get("version"):
+        print(f"  Version : {manifest['version']}")
+    else:
+        print("  Version : latest")
+    print(f"  Dataset : {manifest['dataset_zip']}")
+    print(f"  Trigger : {inp['trigger_word']}")
+    print(f"  Steps   : {inp['steps']}")
+    print(f"  LoRA rank: {inp['lora_rank']}")
+    if manifest.get("destination_model"):
+        print(f"  Dest    : {manifest['destination_model']}")
+    print(f"  Cost    : ~${manifest['cost_usd']:.2f}")
+    print()
+    print("Proceed? [y/N]")
+    print("=" * 60)
+
+
+# ---------------------------------------------------------------------------
+# Training
+# ---------------------------------------------------------------------------
+
+
+def _build_training_url(version: str | None) -> str:
+    owner = REPLICATE_MODEL_OWNER
+    model = REPLICATE_MODEL_NAME
+    base = REPLICATE_BASE_URL.rstrip("/")
+    if version:
+        return f"{base}/v1/models/{owner}/{model}/versions/{version}/trainings"
+    return f"{base}/v1/models/{owner}/{model}/trainings"
+
+
+def start_training(
+    manifest: dict[str, Any],
+    *,
+    confirmed: bool,
+    input_images_url: str,
+) -> dict[str, Any]:
+    """
+    Submit a training job to Replicate.
+
+    SECURITY: confirmed MUST be True. If False, raises RequiresConfirmationError
+    without making any HTTP call.
+
+    Args:
+        manifest:         Output of build_manifest().
+        confirmed:        Must be True (set only after user typed 'y').
+        input_images_url: Public URL to the uploaded dataset zip.
+
+    Returns:
+        Replicate training response dict (includes 'id', 'status', 'urls').
+
+    Raises:
+        RequiresConfirmationError: if confirmed is False.
+        TrainingError:             on API error or non-201 response.
+    """
+    if not confirmed:
+        raise RequiresConfirmationError(
+            "Training requires explicit confirmation. "
+            "Call show_stopandshow(manifest), get 'y' from the user, "
+            "then call start_training(..., confirmed=True)."
+        )
+
+    token = get_api_key()
+    url = _build_training_url(manifest.get("version"))
+
+    payload: dict[str, Any] = {
+        "input": {
+            **manifest["training_input"],
+            "input_images": input_images_url,
+        }
+    }
+    if manifest.get("destination_model"):
+        payload["destination"] = manifest["destination_model"]
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Prefer": "respond-async",
+    }
+
+    try:
+        response = httpx.post(url, json=payload, headers=headers, timeout=30.0)
+    except httpx.RequestError as exc:
+        raise TrainingError(f"HTTP request failed: {exc}") from exc
+
+    if response.status_code not in (200, 201):
+        raise TrainingError(f"Replicate API returned {response.status_code}: {response.text}")
+
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Run record persistence
+# ---------------------------------------------------------------------------
+
+
+def save_run_record(
+    training_resp: dict[str, Any],
+    manifest: dict[str, Any],
+) -> Path:
+    """
+    Save a JSON record of the training run to RUNS_DIR.
+
+    Filename: training-run-{training_id}-{timestamp}.json
+
+    Returns:
+        Path to the saved file.
+    """
+    RUNS_DIR.mkdir(parents=True, exist_ok=True)
+
+    training_id: str = training_resp.get("id", "unknown")
+    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    filename = f"training-run-{training_id}-{ts}.json"
+    dest = RUNS_DIR / filename
+
+    record: dict[str, Any] = {
+        "training_id": training_id,
+        "timestamp": ts,
+        "manifest": manifest,
+        "replicate_response": training_resp,
+    }
+
+    dest.write_text(json.dumps(record, indent=2, default=str), encoding="utf-8")
+    return dest

--- a/scripts/flux_lora/trainer.py
+++ b/scripts/flux_lora/trainer.py
@@ -253,8 +253,11 @@ def start_training(
     except httpx.RequestError as exc:
         raise TrainingError(f"HTTP request failed: {exc}") from exc
 
-    # Replicate's create-training endpoint returns 201 for a queued training.
-    if response.status_code != 201:
+    # Replicate's HTTP reference documents the create-training success code as 200
+    # (verified via Context7, 2026-06-24); async resource creation may also yield
+    # 201. Accept BOTH — requiring only one would raise on a documented-valid code
+    # and lose the training id on the success path.
+    if response.status_code not in (200, 201):
         raise TrainingError(f"Replicate API returned {response.status_code}: {response.text}")
 
     return response.json()

--- a/scripts/flux_lora/trainer.py
+++ b/scripts/flux_lora/trainer.py
@@ -16,8 +16,7 @@ Public API:
 from __future__ import annotations
 
 import json
-import os
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any
 
@@ -26,7 +25,6 @@ import httpx
 from scripts.flux_lora import (
     RequiresConfirmationError,
     TrainingError,
-    UserAbortError,
 )
 from scripts.flux_lora.config import (
     DEFAULT_AUTOCAPTION,
@@ -34,7 +32,6 @@ from scripts.flux_lora.config import (
     DEFAULT_BATCH_SIZE,
     DEFAULT_LEARNING_RATE,
     DEFAULT_LORA_RANK,
-    DEFAULT_LR_SCHEDULER,
     DEFAULT_OPTIMIZER,
     DEFAULT_RESOLUTION,
     DEFAULT_STEPS,
@@ -63,7 +60,6 @@ def build_manifest(
     optimizer: str = DEFAULT_OPTIMIZER,
     batch_size: int = DEFAULT_BATCH_SIZE,
     resolution: str = DEFAULT_RESOLUTION,
-    lr_scheduler: str = DEFAULT_LR_SCHEDULER,
     learning_rate: float = DEFAULT_LEARNING_RATE,
     autocaption: bool = DEFAULT_AUTOCAPTION,
     autocaption_prefix: str = DEFAULT_AUTOCAPTION_PREFIX,
@@ -75,14 +71,18 @@ def build_manifest(
     Args:
         dataset_zip:       Local path to the packed dataset zip (for reference only;
                            the caller must upload it and supply the URL separately).
-        destination_model: Replicate model slug to push the trained LoRA to
-                           (e.g. "myuser/skyyrose-lora"). Optional.
+        destination_model: REQUIRED. Replicate model slug to push the trained LoRA
+                           to, in "{owner}/{name}" form (e.g. "skyyrose/skyyrose-lora").
+                           Replicate's create-training endpoint requires `destination`;
+                           omitting it returns HTTP 422.
 
     Returns:
-        Manifest dict with keys: model, version, training_input, cost_usd, dataset_zip.
+        Manifest dict with keys: model_owner, model_name, version, training_input,
+        destination_model, cost_usd, dataset_zip.
 
     Raises:
-        ValueError: if estimated cost exceeds HARD_COST_CAP_USD.
+        ValueError: if estimated cost exceeds HARD_COST_CAP_USD, or if
+                    destination_model is missing/malformed.
     """
     estimated_cost = EST_COST_PER_RUN_USD
     if estimated_cost > HARD_COST_CAP_USD:
@@ -91,6 +91,16 @@ def build_manifest(
             f"${HARD_COST_CAP_USD:.2f}. Aborting."
         )
 
+    if not destination_model or "/" not in destination_model:
+        raise ValueError(
+            "destination_model is required and must be '{owner}/{name}' "
+            "(Replicate pushes the trained LoRA there; the API rejects trainings "
+            f"without a destination). Got: {destination_model!r}"
+        )
+
+    # Field names verified against the live ostris/flux-dev-lora-trainer
+    # TrainingInput schema on 2026-06-24. Do NOT add fields absent from that
+    # schema (e.g. lr_scheduler) — Replicate 422s on unknown input keys.
     training_input: dict[str, Any] = {
         "trigger_word": trigger_word,
         "steps": steps,
@@ -98,7 +108,6 @@ def build_manifest(
         "optimizer": optimizer,
         "batch_size": batch_size,
         "resolution": resolution,
-        "lr_scheduler": lr_scheduler,
         "learning_rate": learning_rate,
         "autocaption": autocaption,
         "autocaption_prefix": autocaption_prefix,
@@ -133,7 +142,7 @@ def show_stopandshow(manifest: dict[str, Any]) -> None:
     print("=" * 60)
     print("STOP — Confirm before proceeding:")
     print()
-    print(f"  Action  : Replicate FLUX LoRA training")
+    print("  Action  : Replicate FLUX LoRA training")
     print(f"  Model   : {manifest['model_owner']}/{manifest['model_name']}")
     if manifest.get("version"):
         print(f"  Version : {manifest['version']}")
@@ -157,12 +166,24 @@ def show_stopandshow(manifest: dict[str, Any]) -> None:
 
 
 def _build_training_url(version: str | None) -> str:
+    """
+    Build the Replicate create-training URL.
+
+    Replicate REQUIRES the version id in the path:
+      POST /v1/models/{owner}/{model}/versions/{version_id}/trainings
+    There is no version-less trainings endpoint — omitting the version yields a
+    404. We therefore refuse to construct an invalid URL.
+    """
+    if not version:
+        raise TrainingError(
+            "REPLICATE_VERSION is not set. Replicate trainings require a pinned "
+            "version id in the URL path; set config.REPLICATE_VERSION to the "
+            "trainer's version SHA (GET /v1/models/{owner}/{model} → latest_version.id)."
+        )
     owner = REPLICATE_MODEL_OWNER
     model = REPLICATE_MODEL_NAME
     base = REPLICATE_BASE_URL.rstrip("/")
-    if version:
-        return f"{base}/v1/models/{owner}/{model}/versions/{version}/trainings"
-    return f"{base}/v1/models/{owner}/{model}/trainings"
+    return f"{base}/v1/models/{owner}/{model}/versions/{version}/trainings"
 
 
 def start_training(
@@ -199,14 +220,20 @@ def start_training(
     token = get_api_key()
     url = _build_training_url(manifest.get("version"))
 
+    destination = manifest.get("destination_model")
+    if not destination:
+        raise TrainingError(
+            "manifest is missing destination_model; Replicate trainings require a "
+            "destination. Build the manifest via build_manifest(..., destination_model=...)."
+        )
+
     payload: dict[str, Any] = {
+        "destination": destination,
         "input": {
             **manifest["training_input"],
             "input_images": input_images_url,
-        }
+        },
     }
-    if manifest.get("destination_model"):
-        payload["destination"] = manifest["destination_model"]
 
     headers = {
         "Authorization": f"Bearer {token}",
@@ -245,7 +272,7 @@ def save_run_record(
     RUNS_DIR.mkdir(parents=True, exist_ok=True)
 
     training_id: str = training_resp.get("id", "unknown")
-    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
     filename = f"training-run-{training_id}-{ts}.json"
     dest = RUNS_DIR / filename
 

--- a/scripts/flux_lora/trainer.py
+++ b/scripts/flux_lora/trainer.py
@@ -16,7 +16,8 @@ Public API:
 from __future__ import annotations
 
 import json
-from datetime import datetime, UTC
+import re
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +45,7 @@ from scripts.flux_lora.config import (
     REPLICATE_VERSION,
     RUNS_DIR,
     get_api_key,
+    is_https_url,
 )
 
 # ---------------------------------------------------------------------------
@@ -130,12 +132,13 @@ def build_manifest(
 # ---------------------------------------------------------------------------
 
 
-def show_stopandshow(manifest: dict[str, Any]) -> None:
+def show_stopandshow(manifest: dict[str, Any], input_images_url: str | None = None) -> None:
     """
     Print the STOP-AND-SHOW confirmation block to stdout.
 
     This MUST be called and the user MUST type 'y' before start_training()
-    is called with confirmed=True.
+    is called with confirmed=True. `input_images_url` is the URL Replicate will
+    actually fetch — shown here so the user confirms exactly what is submitted.
     """
     inp = manifest["training_input"]
     print()
@@ -149,6 +152,7 @@ def show_stopandshow(manifest: dict[str, Any]) -> None:
     else:
         print("  Version : latest")
     print(f"  Dataset : {manifest['dataset_zip']}")
+    print(f"  Upload  : {input_images_url or '(not set — required before submit)'}")
     print(f"  Trigger : {inp['trigger_word']}")
     print(f"  Steps   : {inp['steps']}")
     print(f"  LoRA rank: {inp['lora_rank']}")
@@ -217,6 +221,9 @@ def start_training(
             "then call start_training(..., confirmed=True)."
         )
 
+    if not is_https_url(input_images_url):
+        raise TrainingError(f"input_images_url must be an https:// URL, got: {input_images_url!r}")
+
     token = get_api_key()
     url = _build_training_url(manifest.get("version"))
 
@@ -246,7 +253,8 @@ def start_training(
     except httpx.RequestError as exc:
         raise TrainingError(f"HTTP request failed: {exc}") from exc
 
-    if response.status_code not in (200, 201):
+    # Replicate's create-training endpoint returns 201 for a queued training.
+    if response.status_code != 201:
         raise TrainingError(f"Replicate API returned {response.status_code}: {response.text}")
 
     return response.json()
@@ -273,8 +281,13 @@ def save_run_record(
 
     training_id: str = training_resp.get("id", "unknown")
     ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
-    filename = f"training-run-{training_id}-{ts}.json"
-    dest = RUNS_DIR / filename
+
+    # training_id comes from the API response — sanitize before using it in a
+    # filename so a spoofed/MITM'd id like "../../etc/x" cannot escape RUNS_DIR.
+    safe_id = re.sub(r"[^A-Za-z0-9_-]", "_", training_id)[:128] or "unknown"
+    dest = RUNS_DIR / f"training-run-{safe_id}-{ts}.json"
+    if not dest.resolve().is_relative_to(RUNS_DIR.resolve()):
+        raise TrainingError("Refusing to write run record outside RUNS_DIR.")
 
     record: dict[str, Any] = {
         "training_id": training_id,

--- a/scripts/flux_lora/upload.py
+++ b/scripts/flux_lora/upload.py
@@ -1,0 +1,182 @@
+"""
+scripts.flux_lora.upload — Upload a dataset zip to HuggingFace Hub.
+
+Public API
+----------
+show_upload_stopandshow(zip_path, repo_id) -> None
+upload_zip(zip_path, repo_id, *, private, path_in_repo, confirmed) -> str
+
+Security contract (mirrors trainer.py)
+---------------------------------------
+confirmed=False → raise RequiresConfirmationError BEFORE any network call.
+Token is loaded at runtime via load_dotenv; never hardcoded.
+Returned URL validated with config.is_https_url before returning.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from huggingface_hub import HfApi, hf_hub_url
+
+from scripts.flux_lora import RequiresConfirmationError
+from scripts.flux_lora.config import is_https_url
+
+_ENV_HF = "/Users/theceo/DevSkyy/.env.hf"
+_TOKEN_VARS = ("HF_TOKEN", "HUGGINGFACE_API_TOKEN")
+
+
+# ---------------------------------------------------------------------------
+# Token helper (isolated so tests can patch it cleanly)
+# ---------------------------------------------------------------------------
+
+
+def _get_hf_token() -> str:
+    """
+    Load HF token from .env.hf at runtime (never hardcoded).
+
+    Reads HF_TOKEN then HUGGINGFACE_API_TOKEN from the environment,
+    loading /Users/theceo/DevSkyy/.env.hf first if it exists.
+
+    Raises
+    ------
+    RuntimeError
+        If no token is found in the environment after loading.
+    """
+    load_dotenv(_ENV_HF, override=False)
+    for var in _TOKEN_VARS:
+        token = os.environ.get(var, "").strip()
+        if token:
+            return token
+    raise RuntimeError(
+        f"HuggingFace token not found. Set {_TOKEN_VARS[0]} or {_TOKEN_VARS[1]} "
+        f"in the environment or in {_ENV_HF}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# STOP-AND-SHOW helper
+# ---------------------------------------------------------------------------
+
+
+def show_upload_stopandshow(zip_path: str | Path, repo_id: str) -> None:
+    """
+    Print a STOP-AND-SHOW confirmation block before an upload.
+
+    Parameters
+    ----------
+    zip_path:
+        Path to the zip file that will be uploaded.
+    repo_id:
+        HuggingFace dataset repo ID (e.g. "skyyrose/skyyrose-lora-dataset").
+    """
+    p = Path(zip_path)
+    try:
+        size_bytes = p.stat().st_size
+        size_str = f"{size_bytes:,} bytes"
+    except FileNotFoundError:
+        size_str = "(file not found)"
+
+    sep = "=" * 60
+    print(sep)
+    print("STOP — Confirm before proceeding:")
+    print()
+    print("  Action     : HuggingFace dataset upload")
+    print(f"  File       : {p.resolve()}")
+    print(f"  Size       : {size_str}")
+    print(f"  Repo       : {repo_id}")
+    print("  Visibility : public")
+    print()
+    print("  Proceed? [y/N]")
+    print(sep)
+
+
+# ---------------------------------------------------------------------------
+# Main upload function
+# ---------------------------------------------------------------------------
+
+
+def upload_zip(
+    zip_path: str | Path,
+    repo_id: str,
+    *,
+    private: bool = False,
+    path_in_repo: str | None = None,
+    confirmed: bool = False,
+) -> str:
+    """
+    Upload a dataset zip to a HuggingFace Hub dataset repository.
+
+    Parameters
+    ----------
+    zip_path:
+        Local path to the zip file to upload.
+    repo_id:
+        HuggingFace repo ID (e.g. "skyyrose/skyyrose-lora-dataset").
+    private:
+        Whether to create the repo as private (default False).
+    path_in_repo:
+        Filename to use inside the repo (defaults to zip file's name).
+    confirmed:
+        Must be True to proceed. If False, raises RequiresConfirmationError
+        BEFORE any network call or token access.
+
+    Returns
+    -------
+    str
+        Public HTTPS resolve URL for the uploaded file.
+
+    Raises
+    ------
+    RequiresConfirmationError
+        If confirmed=False (raised before any network call).
+    RuntimeError
+        If HF token is missing.
+    ValueError
+        If the resolved URL is not a valid https URL.
+    """
+    # SECURITY GATE — must be first, before token load or any network call
+    if not confirmed:
+        raise RequiresConfirmationError(
+            "upload_zip requires explicit confirmation. "
+            "Call show_upload_stopandshow(), get 'y' from the user, "
+            "then re-call with confirmed=True."
+        )
+
+    token = _get_hf_token()
+
+    p = Path(zip_path).resolve()
+    filename = path_in_repo or p.name
+
+    api = HfApi()
+    api.create_repo(
+        repo_id=repo_id,
+        repo_type="dataset",
+        exist_ok=True,
+        private=private,
+        token=token,
+    )
+
+    api.upload_file(
+        path_or_fileobj=str(p),
+        path_in_repo=filename,
+        repo_id=repo_id,
+        repo_type="dataset",
+        token=token,
+    )
+
+    resolve_url = hf_hub_url(
+        repo_id=repo_id,
+        filename=filename,
+        repo_type="dataset",
+    )
+
+    if not is_https_url(resolve_url):
+        raise ValueError(
+            f"HuggingFace returned a non-https URL: {resolve_url!r}. "
+            "Refusing to return an insecure URL."
+        )
+
+    return resolve_url

--- a/scripts/oai_render/cli.py
+++ b/scripts/oai_render/cli.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 
 from . import config, cost, pipeline
 from .prompt import PRESENTATIONS
@@ -43,6 +44,16 @@ def _add_target_args(p: argparse.ArgumentParser) -> None:
             "Render ONLY ghost-front (the product card) — no ghost-back, no "
             "on-model/paired looks. Fast, cheap full-catalog product-card pass. "
             "Overrides --style."
+        ),
+    )
+    p.add_argument(
+        "--style-reference",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Optional environment/mood anchor image (e.g. a lookbook frame). Passed as the "
+            "FINAL reference; the model matches its setting, lighting, palette, and mood but "
+            "takes NO garment, logo, or text from it."
         ),
     )
 
@@ -101,10 +112,23 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: invalid --style {bad or '(empty)'}. Choose from: {', '.join(PRESENTATIONS)}")
         return 1
 
+    style_reference: Path | None = None
+    if getattr(args, "style_reference", None):
+        style_reference = Path(args.style_reference)
+        if not style_reference.is_file():
+            print(f"ERROR: --style-reference not found: {style_reference}")
+            return 1
+
     # Always plan first (no API) and show the manifest. --front-only is registered
     # on every subparser via _add_target_args, so args.front_only is always present.
     dry = pipeline.run(
-        targets, catalog, dossier_index, styles=styles, dry_run=True, front_only=args.front_only
+        targets,
+        catalog,
+        dossier_index,
+        styles=styles,
+        dry_run=True,
+        front_only=args.front_only,
+        style_reference=style_reference,
     )
     manifest = dry["manifest"]
     print(cost.format_manifest(manifest))

--- a/scripts/oai_render/client.py
+++ b/scripts/oai_render/client.py
@@ -76,6 +76,7 @@ class OAIImageClient:
             "size": config.SIZE,
             "output_format": config.OUTPUT_FORMAT,
             "background": config.BACKGROUND,
+            "input_fidelity": config.INPUT_FIDELITY,
             "n": config.N,
         }
         if mask_path is not None:

--- a/scripts/oai_render/config.py
+++ b/scripts/oai_render/config.py
@@ -28,9 +28,13 @@ OUTPUT_FORMAT = "png"  # lossless
 BACKGROUND = "auto"  # "transparent" | "opaque" | "auto"
 N = 1
 MAX_REFERENCE_IMAGES = 16  # gpt-image edit hard limit
-# NOTE: input_fidelity is intentionally NOT sent. Context7 (OpenAI API docs):
-# for gpt-image-2 the model auto-processes every input at high fidelity and
-# the parameter cannot be set.
+# input_fidelity controls how hard the model matches the reference images'
+# style/features. Verified via Context7 (openai-python image_edit_params.py,
+# 2026-06-24): supported for gpt-image-1.5+ (incl. gpt-image-2), values
+# "high" | "low", DEFAULT "low". We send "high" so garment graphics, logos,
+# and the style-reference anchor are reproduced as faithfully as possible.
+# Cost note: "high" raises per-image input-token cost vs the "low" default.
+INPUT_FIDELITY = "high"
 
 # ── Networking / resilience ─────────────────────────────────────────────────
 REQUEST_TIMEOUT_S = 180.0

--- a/scripts/oai_render/pipeline.py
+++ b/scripts/oai_render/pipeline.py
@@ -150,8 +150,14 @@ def plan_sku(
     *,
     style: str = "ghost",
     view: str = "front",
+    style_reference: Path | None = None,
 ) -> SkuPlan:
-    """Resolve references + dossier + prompt for a (SKU, style, view). Never raises for missing refs."""
+    """Resolve references + dossier + prompt for a (SKU, style, view). Never raises for missing refs.
+
+    ``style_reference`` is an optional environment/mood anchor image (e.g. a lookbook
+    frame). When given, it is appended as the FINAL reference and the prompt restricts
+    it to scene/lighting/mood — never a garment source.
+    """
     info = catalog.get(sku, {})
     name = info.get("name", sku)
     collection = info.get("collection", "")
@@ -159,6 +165,17 @@ def plan_sku(
 
     try:
         refs = references.build_references(sku, collection, view=view)
+        use_style_ref = style_reference is not None and Path(style_reference).is_file()
+        if use_style_ref:
+            refs = [
+                *refs,
+                ReferenceImage(
+                    label="STYLE & COMPOSITION REFERENCE (environment / lighting / mood only "
+                    "— NOT a garment source)",
+                    path=Path(style_reference),
+                    kind="style",
+                ),
+            ]
         is_patch = references.requires_patch(sku)
         dossier_text = read_dossier(dossier_index.get(sku))
         scene = build_scene(sku=sku, name=name, collection=collection, style=style)
@@ -172,6 +189,7 @@ def plan_sku(
             style=style,
             view=view,
             scene=scene,
+            style_reference=use_style_ref,
         )
     except (MissingReferenceError, SceneError) as exc:
         return SkuPlan(
@@ -510,6 +528,7 @@ def run(
     client=None,
     verify_assets: bool = True,
     front_only: bool = False,
+    style_reference: Path | None = None,
 ) -> dict:
     """Plan the render matrix for all targets; render them when not dry-run (client required).
 
@@ -530,9 +549,27 @@ def run(
     for s in targets:
         for st in use_styles:
             if st == "ghost":
-                plans.append(plan_sku(s, catalog, dossier_index, style="ghost", view="front"))
+                plans.append(
+                    plan_sku(
+                        s,
+                        catalog,
+                        dossier_index,
+                        style="ghost",
+                        view="front",
+                        style_reference=style_reference,
+                    )
+                )
                 if not front_only and references.has_back_source(s):
-                    plans.append(plan_sku(s, catalog, dossier_index, style="ghost", view="back"))
+                    plans.append(
+                        plan_sku(
+                            s,
+                            catalog,
+                            dossier_index,
+                            style="ghost",
+                            view="back",
+                            style_reference=style_reference,
+                        )
+                    )
             elif st == "on-model":
                 # A pair is only renderable when NO member is excluded — an excluded
                 # member's dossier is known-bad and would corrupt the paired look.
@@ -557,10 +594,26 @@ def run(
                         plans.append(plan_pair(pr, catalog, dossier_index))
                 else:  # no renderable pair → solo on-model so the SKU still gets a hero
                     plans.append(
-                        plan_sku(s, catalog, dossier_index, style="on-model", view="front")
+                        plan_sku(
+                            s,
+                            catalog,
+                            dossier_index,
+                            style="on-model",
+                            view="front",
+                            style_reference=style_reference,
+                        )
                     )
             else:  # flatlay or any other explicit style
-                plans.append(plan_sku(s, catalog, dossier_index, style=st, view="front"))
+                plans.append(
+                    plan_sku(
+                        s,
+                        catalog,
+                        dossier_index,
+                        style=st,
+                        view="front",
+                        style_reference=style_reference,
+                    )
+                )
 
     keepers = _keeper_skips()
     if keepers:

--- a/scripts/oai_render/pipeline.py
+++ b/scripts/oai_render/pipeline.py
@@ -17,6 +17,7 @@ from . import config, cost, references
 from .cost import CostManifest, ManifestEntry
 from .prompt import SceneError, build_pair_prompt, build_prompt, extract_view_branding, read_dossier
 from .references import MissingReferenceError, Pair, ReferenceImage
+from .scene_schema import build_scene
 
 if TYPE_CHECKING:
     from .client import RenderClient
@@ -160,6 +161,7 @@ def plan_sku(
         refs = references.build_references(sku, collection, view=view)
         is_patch = references.requires_patch(sku)
         dossier_text = read_dossier(dossier_index.get(sku))
+        scene = build_scene(sku=sku, name=name, collection=collection, style=style)
         prompt = build_prompt(
             name=name,
             sku=sku,
@@ -169,6 +171,7 @@ def plan_sku(
             is_patch=is_patch,
             style=style,
             view=view,
+            scene=scene,
         )
     except (MissingReferenceError, SceneError) as exc:
         return SkuPlan(

--- a/scripts/oai_render/prompt.py
+++ b/scripts/oai_render/prompt.py
@@ -360,11 +360,20 @@ def build_prompt(
         raise ValueError(f"Unknown view {view!r}. Valid: {sorted(_VIEW_DIRECTIVES)}")
     presentation = PRESENTATIONS[style_key]
     view_directive = _VIEW_DIRECTIVES[view]
-    if scene is not None:
+    if scene is not None and style_key == "on-model":
+        # On-model: the scene JSON carries the founder-approved collection
+        # environment, so it is authoritative for environment + lighting + camera.
         background = (
             "OVERRIDE — ENVIRONMENT, LIGHTING, AND CAMERA: the SCENE SPEC (JSON) block "
             "below is the authoritative source for all three. The generic LIGHTING directive "
             "at the top of this prompt is superseded by the 'lighting' object in the SCENE SPEC."
+        )
+    elif scene is not None:
+        # Ghost / flatlay: keep the clean product-card BACKGROUND guardrails
+        # (no props, no scene); the scene JSON still drives lighting + camera.
+        background = (
+            f"{GHOST_BACKGROUND} The SCENE SPEC (JSON) 'lighting' and 'camera' objects below "
+            "are authoritative for light and lens; keep this clean product-card background."
         )
     else:
         background = _background_for(style_key, collection)

--- a/scripts/oai_render/prompt.py
+++ b/scripts/oai_render/prompt.py
@@ -350,6 +350,7 @@ def build_prompt(
     is_patch: bool,
     style: str | None = None,
     view: str = "front",
+    scene: dict | None = None,
 ) -> str:
     """Assemble the full edit prompt for one SKU in the chosen style + view."""
     style_key = style or DEFAULT_STYLE
@@ -359,7 +360,14 @@ def build_prompt(
         raise ValueError(f"Unknown view {view!r}. Valid: {sorted(_VIEW_DIRECTIVES)}")
     presentation = PRESENTATIONS[style_key]
     view_directive = _VIEW_DIRECTIVES[view]
-    background = _background_for(style_key, collection)
+    if scene is not None:
+        background = (
+            "OVERRIDE — ENVIRONMENT, LIGHTING, AND CAMERA: the SCENE SPEC (JSON) block "
+            "below is the authoritative source for all three. The generic LIGHTING directive "
+            "at the top of this prompt is superseded by the 'lighting' object in the SCENE SPEC."
+        )
+    else:
+        background = _background_for(style_key, collection)
     parts: list[str] = [
         _BASE_PROCEDURE.format(
             presentation=presentation, view_directive=view_directive, background=background
@@ -371,6 +379,12 @@ def build_prompt(
         f"{collection.replace('-', ' ').title()} collection."
     )
     parts.append("")
+
+    if scene is not None:
+        from .scene_schema import scene_to_prompt_block
+
+        parts.append(scene_to_prompt_block(scene))
+        parts.append("")
 
     if reference_labels:
         parts.append(

--- a/scripts/oai_render/prompt.py
+++ b/scripts/oai_render/prompt.py
@@ -351,8 +351,14 @@ def build_prompt(
     style: str | None = None,
     view: str = "front",
     scene: dict | None = None,
+    style_reference: bool = False,
 ) -> str:
-    """Assemble the full edit prompt for one SKU in the chosen style + view."""
+    """Assemble the full edit prompt for one SKU in the chosen style + view.
+
+    When ``style_reference`` is True, the FINAL reference image is treated as an
+    environment/lighting/mood anchor only (e.g. a lookbook frame) — never a source
+    of garments, graphics, or text.
+    """
     style_key = style or DEFAULT_STYLE
     if style_key not in PRESENTATIONS:
         raise ValueError(f"Unknown style {style_key!r}. Valid: {sorted(PRESENTATIONS)}")
@@ -401,6 +407,17 @@ def build_prompt(
             'image attached, "image 2" the second, and so on:'
         )
         parts.extend(f"  {label}" for label in reference_labels)
+        parts.append("")
+
+    if style_reference:
+        parts.append(
+            "STYLE & COMPOSITION REFERENCE: the FINAL reference image is an ENVIRONMENT, "
+            "LIGHTING, PALETTE, and MOOD anchor ONLY. Match its setting, atmosphere, color "
+            "grade, camera feel, and overall composition. Do NOT copy, trace, or borrow any "
+            "garment, logo, graphic, text, person, or product from it — every garment comes "
+            "SOLELY from the product reference image(s) above and the SCENE SPEC. Treat it as "
+            "the mood board for the scene, never as a source of what is worn."
+        )
         parts.append("")
 
     if dossier_text:

--- a/scripts/oai_render/scene_schema.py
+++ b/scripts/oai_render/scene_schema.py
@@ -17,8 +17,10 @@ Schema keys:
 
 from __future__ import annotations
 
+from .prompt import SceneError
+
 # ---------------------------------------------------------------------------
-# Ghost / flatlay per-collection defaults
+# Ghost / flatlay studio defaults
 # ---------------------------------------------------------------------------
 
 _GHOST_LIGHTING: dict[str, str] = {
@@ -32,6 +34,16 @@ _GHOST_CAMERA: dict[str, str | float] = {
     "aperture": "f/8",
     "angle": "straight-on eye-level",
     "depth_of_field": "full garment sharp, background soft",
+}
+
+# Flatlay is a top-down shot — its camera angle MUST match the flatlay
+# PRESENTATION ("laid flat, top-down"); reusing the ghost eye-level camera would
+# contradict it inside the same prompt.
+_FLATLAY_CAMERA: dict[str, str | float] = {
+    "lens": "50mm",
+    "aperture": "f/8",
+    "angle": "top-down overhead, lens perpendicular to the surface",
+    "depth_of_field": "entire garment evenly sharp",
 }
 
 _GHOST_ENVIRONMENT: str = "seamless studio cyclorama"
@@ -146,8 +158,8 @@ def build_scene(
     sku:             Product SKU (e.g. "br-001").
     name:            Sanitized garment name (e.g. "The Black Rose Varsity").
     collection:      Collection slug (e.g. "black-rose").
-    style:           Render style key — "ghost" for ghost-mannequin / flatlay,
-                     any other value for on-model editorial.
+    style:           Render style key — "ghost" or "flatlay" → clean studio
+                     (no model); any other value → on-model editorial.
     garment_color:   Primary garment colorway if known (optional).
     garment_details: Brief garment description for subject field (optional).
 
@@ -155,14 +167,20 @@ def build_scene(
     -------
     dict following the SkyyRose scene schema. Always a new object; no shared
     state with module-level constants.
+
+    Raises
+    ------
+    SceneError: for an on-model render of a collection with no defined scene —
+                mirrors prompt._background_for; never silently substitutes one.
     """
     color_desc = garment_color or "as shown in references"
     details_desc = garment_details or name
 
-    if style == "ghost":
+    if style in ("ghost", "flatlay"):
+        is_flatlay = style == "flatlay"
         return {
             "subject": {
-                "type": "ghost-mannequin",
+                "type": "flatlay" if is_flatlay else "ghost-mannequin",
                 "garment": details_desc,
                 "color": color_desc,
                 "sku": sku,
@@ -170,7 +188,7 @@ def build_scene(
             "model": None,
             "environment": _GHOST_ENVIRONMENT,
             "lighting": dict(_GHOST_LIGHTING),
-            "camera": dict(_GHOST_CAMERA),
+            "camera": dict(_FLATLAY_CAMERA if is_flatlay else _GHOST_CAMERA),
             "style": "clean commercial product photography",
             "mood": "precise, editorial, luxury retail",
             "color_palette": ["#B76E79", "#FFFFFF", "#0A0A0A"],
@@ -178,7 +196,12 @@ def build_scene(
         }
 
     col_key = collection.lower()
-    defaults = _ONMODEL_DEFAULTS.get(col_key, _ONMODEL_DEFAULTS["signature"])
+    defaults = _ONMODEL_DEFAULTS.get(col_key)
+    if defaults is None:
+        raise SceneError(
+            f"No on-model scene for collection {collection!r}; refusing a generic "
+            f"fallback. Add it to _ONMODEL_DEFAULTS. Known: {sorted(_ONMODEL_DEFAULTS)}"
+        )
 
     return {
         "subject": {

--- a/scripts/oai_render/scene_schema.py
+++ b/scripts/oai_render/scene_schema.py
@@ -1,0 +1,223 @@
+"""SkyyRose JSON scene schema for gpt-image-2 render pipeline.
+
+Defines structured scene descriptions that are injected into prompts AFTER the
+PRODUCT line and BEFORE the REFERENCE IMAGES section in build_prompt().
+
+Schema keys:
+    subject     — garment + model description
+    model       — human subject descriptor and pose
+    environment — physical setting
+    lighting    — key/fill/accent light sources
+    camera      — lens, aperture, angle, depth_of_field
+    style       — photographic style descriptor
+    mood        — emotional / atmospheric tone
+    color_palette — hex list anchored on brand tokens
+    constraints — always-on guardrails (never blank, no watermark, etc.)
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Ghost / flatlay per-collection defaults
+# ---------------------------------------------------------------------------
+
+_GHOST_LIGHTING: dict[str, str] = {
+    "key": "large softbox 45° camera-left, diffused",
+    "fill": "white bounce card camera-right, 1:3 ratio",
+    "accent": "rim light rear-left, subtle separation",
+}
+
+_GHOST_CAMERA: dict[str, str | float] = {
+    "lens": "85mm portrait",
+    "aperture": "f/8",
+    "angle": "straight-on eye-level",
+    "depth_of_field": "full garment sharp, background soft",
+}
+
+_GHOST_ENVIRONMENT: str = "seamless studio cyclorama"
+
+# ---------------------------------------------------------------------------
+# On-model per-collection defaults  (keyed by collection slug)
+# ---------------------------------------------------------------------------
+
+_ONMODEL_DEFAULTS: dict[str, dict[str, object]] = {
+    "signature": {
+        "environment": "Golden Gate Bridge and Bay Area skyline at golden hour, confident West-Coast street-luxury energy, warm sunlight",
+        "lighting": {
+            "key": "warm golden-hour sun, high-right",
+            "fill": "open sky fill, soft shadow",
+            "accent": "specular rim from reflective concrete",
+        },
+        "camera": {
+            "lens": "85mm",
+            "aperture": "f/2.8",
+            "angle": "slightly low, looking up",
+            "depth_of_field": "subject sharp, background bokeh",
+        },
+        "film_stock": "Kodak Portra 400",
+        "color_palette": ["#D4AF37", "#B76E79", "#0A0A0A", "#F5E6C8"],
+        "mood": "aspirational, grounded luxury, effortless swag",
+    },
+    "black-rose": {
+        "environment": "Oakland shoreline at blue hour, Bay Bridge silhouetted behind, moody black-rose garden with roses in deep shadow",
+        "lighting": {
+            "key": "dramatic blue-hour ambient, deep shadow",
+            "fill": "minimal fill, dark romantic low light",
+            "accent": "rim from city lights across the bay",
+        },
+        "camera": {
+            "lens": "50mm",
+            "aperture": "f/4",
+            "angle": "straight-on, slight upward tilt",
+            "depth_of_field": "full body sharp, dark BG",
+        },
+        "film_stock": "Kodak Portra 800",
+        "color_palette": ["#C0C0C0", "#B76E79", "#0A0A0A", "#1A1A1A"],
+        "mood": "dark romantic luxury, armor, defiance",
+    },
+    "love-hurts": {
+        "environment": "candlelit gothic château interior, ornate and brooding, shadow-heavy — Beauty-and-the-Beast setting from the Beast's point of view",
+        "lighting": {
+            "key": "candlelight, warm and directional, low",
+            "fill": "deep shadow, emotionally intense",
+            "accent": "subtle rim from distant candelabra",
+        },
+        "camera": {
+            "lens": "35mm",
+            "aperture": "f/2.0",
+            "angle": "hip-level, slight Dutch tilt",
+            "depth_of_field": "mid-body sharp, foreground soft",
+        },
+        "film_stock": "Kodak Portra 800",
+        "color_palette": ["#DC143C", "#B76E79", "#0A0A0A", "#8B0000"],
+        "mood": "dark romance, brooding intensity, emotionally raw",
+    },
+    "kids-capsule": {
+        "environment": "opulent throne room, gold-and-velvet palace setting, heir to the throne — playful young-royalty grandeur",
+        "lighting": {
+            "key": "warm cinematic overhead, regal and theatrical",
+            "fill": "reflected gold from velvet drapery",
+            "accent": "crown highlight, soft and warm",
+        },
+        "camera": {
+            "lens": "50mm",
+            "aperture": "f/5.6",
+            "angle": "eye-level to child subject",
+            "depth_of_field": "subject sharp, background soft",
+        },
+        "film_stock": "Kodak Ektar 100",
+        "color_palette": ["#B76E79", "#D4AF37", "#F5C6CB", "#FFFFFF"],
+        "mood": "playful royalty, joyful grandeur, family warmth",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Always-on constraints
+# ---------------------------------------------------------------------------
+
+_CONSTRAINTS: dict[str, object] = {
+    "no_text_overlays": True,
+    "no_watermarks": True,
+    "no_mannequin_visible": True,
+    "seamless_background_required": True,
+    "garment_must_be_protagonist": True,
+    "brand": "SkyyRose — Luxury Grows from Concrete.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_scene(
+    sku: str,
+    name: str,
+    collection: str,
+    style: str,
+    *,
+    garment_color: str | None = None,
+    garment_details: str | None = None,
+) -> dict:
+    """Return a fresh scene dict for the given SKU and style.
+
+    Parameters
+    ----------
+    sku:             Product SKU (e.g. "br-001").
+    name:            Sanitized garment name (e.g. "The Black Rose Varsity").
+    collection:      Collection slug (e.g. "black-rose").
+    style:           Render style key — "ghost" for ghost-mannequin / flatlay,
+                     any other value for on-model editorial.
+    garment_color:   Primary garment colorway if known (optional).
+    garment_details: Brief garment description for subject field (optional).
+
+    Returns
+    -------
+    dict following the SkyyRose scene schema. Always a new object; no shared
+    state with module-level constants.
+    """
+    color_desc = garment_color or "as shown in references"
+    details_desc = garment_details or name
+
+    if style == "ghost":
+        return {
+            "subject": {
+                "type": "ghost-mannequin",
+                "garment": details_desc,
+                "color": color_desc,
+                "sku": sku,
+            },
+            "model": None,
+            "environment": _GHOST_ENVIRONMENT,
+            "lighting": dict(_GHOST_LIGHTING),
+            "camera": dict(_GHOST_CAMERA),
+            "style": "clean commercial product photography",
+            "mood": "precise, editorial, luxury retail",
+            "color_palette": ["#B76E79", "#FFFFFF", "#0A0A0A"],
+            "constraints": dict(_CONSTRAINTS),
+        }
+
+    col_key = collection.lower()
+    defaults = _ONMODEL_DEFAULTS.get(col_key, _ONMODEL_DEFAULTS["signature"])
+
+    return {
+        "subject": {
+            "type": "on-model",
+            "garment": details_desc,
+            "color": color_desc,
+            "sku": sku,
+        },
+        "model": {
+            "descriptor": "professional fashion model, confident pose",
+            "pose": "full-body editorial stance",
+            "expression": "intense, aspirational",
+        },
+        "environment": defaults["environment"],
+        "lighting": dict(defaults["lighting"]),  # type: ignore[arg-type]
+        "camera": dict(defaults["camera"]),  # type: ignore[arg-type]
+        "style": f"editorial fashion photography, {defaults.get('film_stock', 'natural')}",
+        "mood": defaults["mood"],
+        "color_palette": list(defaults["color_palette"]),  # type: ignore[arg-type]
+        "constraints": dict(_CONSTRAINTS),
+    }
+
+
+def scene_to_prompt_block(scene: dict) -> str:
+    """Serialize a scene dict to a prompt injection string.
+
+    The returned block is designed to be inserted between the PRODUCT line and
+    the REFERENCE IMAGES section in build_prompt().
+
+    Parameters
+    ----------
+    scene: dict produced by build_scene().
+
+    Returns
+    -------
+    Multi-line string beginning with "SCENE SPEC (JSON):".
+    """
+    import json
+
+    lines = ["SCENE SPEC (JSON) — photograph this scene exactly:"]
+    lines.append(json.dumps(scene, indent=2, ensure_ascii=False))
+    return "\n".join(lines)

--- a/tests/flux_lora/conftest.py
+++ b/tests/flux_lora/conftest.py
@@ -1,0 +1,54 @@
+"""
+Isolated conftest for tests/flux_lora/.
+
+Prevents the root tests/conftest.py (which imports main_enterprise and
+security.rate_limiting) from being loaded when running this subdirectory.
+All fixtures needed by flux_lora tests are defined here.
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_dataset(tmp_path: Path) -> Path:
+    """
+    Create a minimal valid dataset directory with 5 images + caption sidecars.
+    Captions begin with the trigger word 'SKYYROSE'.
+    """
+    dataset_dir = tmp_path / "skyyrose_lora_test"
+    dataset_dir.mkdir()
+
+    for i in range(1, 6):
+        # Fake minimal PNG header bytes
+        img = dataset_dir / f"image_{i:02d}.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        caption = dataset_dir / f"image_{i:02d}.txt"
+        caption.write_text(
+            f"SKYYROSE luxury streetwear product shot {i}, studio lighting",
+            encoding="utf-8",
+        )
+
+    return dataset_dir
+
+
+@pytest.fixture()
+def tmp_dataset_no_captions(tmp_path: Path) -> Path:
+    """Dataset with images but missing caption sidecars."""
+    dataset_dir = tmp_path / "skyyrose_no_caps"
+    dataset_dir.mkdir()
+    for i in range(1, 6):
+        img = dataset_dir / f"image_{i:02d}.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+    return dataset_dir
+
+
+@pytest.fixture(autouse=True)
+def _clear_env_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove real REPLICATE_API_TOKEN so tests never hit the live API."""
+    monkeypatch.delenv("REPLICATE_API_TOKEN", raising=False)

--- a/tests/flux_lora/test_dataset.py
+++ b/tests/flux_lora/test_dataset.py
@@ -1,0 +1,98 @@
+"""
+tests.flux_lora.test_dataset — 5 tests covering dataset.py public API.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.flux_lora import DatasetError
+from scripts.flux_lora.config import DEFAULT_TRIGGER_WORD
+from scripts.flux_lora.dataset import (
+    dataset_summary,
+    load_dataset,
+    pack_zip,
+    validate_dataset,
+)
+
+
+class TestLoadDataset:
+    def test_load_reads_images_and_captions(self, tmp_dataset: Path) -> None:
+        result = load_dataset(tmp_dataset)
+
+        assert len(result["images"]) == 5
+        assert len(result["captions"]) == 5
+        # Every caption starts with trigger word
+        for caption in result["captions"].values():
+            assert caption.startswith(DEFAULT_TRIGGER_WORD)
+
+    def test_load_raises_dataset_error_when_dir_missing(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does_not_exist"
+        with pytest.raises(DatasetError, match="not found"):
+            load_dataset(missing)
+
+
+class TestValidateDataset:
+    def test_validate_passes_valid_dataset(self, tmp_dataset: Path) -> None:
+        # Should not raise
+        validate_dataset(tmp_dataset)
+
+    def test_validate_raises_when_captions_missing(self, tmp_dataset_no_captions: Path) -> None:
+        with pytest.raises(DatasetError, match="Missing caption sidecars"):
+            validate_dataset(tmp_dataset_no_captions)
+
+    def test_validate_raises_when_trigger_word_absent(self, tmp_path: Path) -> None:
+        dataset_dir = tmp_path / "bad_trigger"
+        dataset_dir.mkdir()
+        for i in range(1, 6):
+            img = dataset_dir / f"img_{i}.png"
+            img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+            cap = dataset_dir / f"img_{i}.txt"
+            # Caption missing trigger word
+            cap.write_text(f"some caption without trigger {i}", encoding="utf-8")
+
+        with pytest.raises(DatasetError, match=DEFAULT_TRIGGER_WORD):
+            validate_dataset(dataset_dir)
+
+
+class TestPackZip:
+    def test_pack_zip_creates_valid_zip_with_images_and_captions(
+        self, tmp_dataset: Path, tmp_path: Path
+    ) -> None:
+        dest = tmp_path / "out.zip"
+        result = pack_zip(tmp_dataset, dest=dest)
+
+        assert result == dest
+        assert dest.exists()
+
+        with zipfile.ZipFile(dest) as zf:
+            names = set(zf.namelist())
+
+        # 5 images + 5 captions = 10 entries
+        assert len(names) == 10
+        png_files = [n for n in names if n.endswith(".png")]
+        txt_files = [n for n in names if n.endswith(".txt")]
+        assert len(png_files) == 5
+        assert len(txt_files) == 5
+
+    def test_pack_zip_raises_on_missing_dir(self, tmp_path: Path) -> None:
+        missing = tmp_path / "ghost"
+        with pytest.raises(DatasetError):
+            pack_zip(missing)
+
+
+class TestDatasetSummary:
+    def test_summary_returns_correct_counts(self, tmp_dataset: Path) -> None:
+        summary = dataset_summary(tmp_dataset)
+
+        assert summary["image_count"] == 5
+        assert summary["caption_count"] == 5
+        assert summary["total_bytes"] > 0
+        assert summary["dataset_dir"] == str(tmp_dataset)
+
+    def test_summary_raises_on_missing_dir(self, tmp_path: Path) -> None:
+        with pytest.raises(DatasetError, match="not found"):
+            dataset_summary(tmp_path / "nowhere")

--- a/tests/flux_lora/test_dataset_builder.py
+++ b/tests/flux_lora/test_dataset_builder.py
@@ -1,0 +1,244 @@
+"""
+tests.flux_lora.test_dataset_builder — Unit tests for dataset_builder.build_dataset().
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import pytest
+
+from scripts.flux_lora import DatasetError
+from scripts.flux_lora.config import DEFAULT_TRIGGER_WORD
+from scripts.flux_lora.dataset_builder import build_dataset
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MINIMAL_PNG = (
+    b"\x89PNG\r\n\x1a\n"  # PNG signature
+    + b"\x00\x00\x00\rIHDR"  # IHDR chunk length + type
+    + struct.pack(">II", 1, 1)  # width=1, height=1
+    + b"\x08\x02\x00\x00\x00"  # bit depth=8, colour type=2 (RGB), rest zeros
+    + b"\x90wS\xde"  # CRC (pre-computed for this header)
+    + b"\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N"
+    + b"\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def _make_sources(
+    tmp_path: Path,
+    count: int = 5,
+    caption: str | None = None,
+    garment: str | None = None,
+    use_caption_key: bool = True,
+) -> list[dict]:
+    """Create count PNG files in tmp_path and return a sources list."""
+    sources = []
+    for i in range(count):
+        img = tmp_path / f"src_{i:02d}.png"
+        img.write_bytes(_MINIMAL_PNG)
+        src: dict = {"image": str(img)}
+        if use_caption_key and caption is not None:
+            src["caption"] = caption
+        elif not use_caption_key and garment is not None:
+            src["garment"] = garment
+        else:
+            if caption is not None:
+                src["caption"] = caption
+            if garment is not None:
+                src["garment"] = garment
+        sources.append(src)
+    return sources
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_build_dataset_happy_path(tmp_path: Path) -> None:
+    """5 sources with explicit captions → valid dataset returned."""
+    src_dir = tmp_path / "sources"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dataset"
+
+    sources = _make_sources(src_dir, count=5, caption=f"{DEFAULT_TRIGGER_WORD} black hoodie")
+    result = build_dataset(sources, dest_dir)
+
+    assert result == dest_dir.resolve()
+
+    # Correct number of images and sidecars
+    images = sorted(dest_dir.glob("img_*.png"))
+    sidecars = sorted(dest_dir.glob("img_*.txt"))
+    assert len(images) == 5
+    assert len(sidecars) == 5
+
+    # Every sidecar starts with trigger word
+    for txt in sidecars:
+        assert txt.read_text(encoding="utf-8").startswith(DEFAULT_TRIGGER_WORD)
+
+
+def test_build_dataset_preserves_extension(tmp_path: Path) -> None:
+    """JPEG source → dest keeps .jpg extension (not coerced to .png)."""
+    src_dir = tmp_path / "sources"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dataset"
+
+    sources = []
+    for i in range(5):
+        img = src_dir / f"src_{i:02d}.jpg"
+        img.write_bytes(_MINIMAL_PNG)  # bytes don't matter for this test
+        sources.append({"image": str(img), "caption": f"{DEFAULT_TRIGGER_WORD} garment {i}"})
+
+    build_dataset(sources, dest_dir)
+    assert len(list(dest_dir.glob("img_*.jpg"))) == 5
+    assert len(list(dest_dir.glob("img_*.png"))) == 0
+
+
+# ---------------------------------------------------------------------------
+# Trigger-word prepend
+# ---------------------------------------------------------------------------
+
+
+def test_caption_without_trigger_gets_prepended(tmp_path: Path) -> None:
+    """Caption missing trigger word → trigger prepended automatically."""
+    src_dir = tmp_path / "sources"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dataset"
+
+    sources = _make_sources(src_dir, count=5, caption="a luxury hoodie")
+    build_dataset(sources, dest_dir)
+
+    for txt in dest_dir.glob("img_*.txt"):
+        content = txt.read_text(encoding="utf-8")
+        assert content.startswith(DEFAULT_TRIGGER_WORD)
+        assert "a luxury hoodie" in content
+
+
+def test_caption_with_trigger_not_doubled(tmp_path: Path) -> None:
+    """Caption already starting with trigger word → not doubled."""
+    src_dir = tmp_path / "sources"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dataset"
+
+    full_caption = f"{DEFAULT_TRIGGER_WORD} red sneakers"
+    sources = _make_sources(src_dir, count=5, caption=full_caption)
+    build_dataset(sources, dest_dir)
+
+    for txt in dest_dir.glob("img_*.txt"):
+        content = txt.read_text(encoding="utf-8")
+        assert content == full_caption
+        assert not content.startswith(f"{DEFAULT_TRIGGER_WORD} {DEFAULT_TRIGGER_WORD}")
+
+
+def test_garment_only_composes_caption(tmp_path: Path) -> None:
+    """garment key only → caption = '<trigger> <garment>'."""
+    src_dir = tmp_path / "sources"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dataset"
+
+    sources = []
+    for i in range(5):
+        img = src_dir / f"src_{i:02d}.png"
+        img.write_bytes(_MINIMAL_PNG)
+        sources.append({"image": str(img), "garment": "silk dress"})
+
+    build_dataset(sources, dest_dir)
+
+    for txt in dest_dir.glob("img_*.txt"):
+        assert txt.read_text(encoding="utf-8") == f"{DEFAULT_TRIGGER_WORD} silk dress"
+
+
+# ---------------------------------------------------------------------------
+# Missing caption + garment → DatasetError
+# ---------------------------------------------------------------------------
+
+
+def test_missing_caption_and_garment_raises(tmp_path: Path) -> None:
+    """Source with neither caption nor garment → DatasetError."""
+    src_dir = tmp_path / "sources"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dataset"
+
+    sources = []
+    for i in range(5):
+        img = src_dir / f"src_{i:02d}.png"
+        img.write_bytes(_MINIMAL_PNG)
+        sources.append({"image": str(img)})  # no caption, no garment
+
+    with pytest.raises(DatasetError, match="caption.*garment|garment.*caption"):
+        build_dataset(sources, dest_dir)
+
+
+# ---------------------------------------------------------------------------
+# Clobber guard
+# ---------------------------------------------------------------------------
+
+
+def test_nonempty_dest_raises_without_overwrite(tmp_path: Path) -> None:
+    """Non-empty dest_dir without overwrite=True → DatasetError."""
+    src_dir = tmp_path / "sources"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dataset"
+    dest_dir.mkdir()
+    (dest_dir / "leftover.txt").write_text("stale")  # make it non-empty
+
+    sources = _make_sources(src_dir, count=5, caption=f"{DEFAULT_TRIGGER_WORD} hoodie")
+    with pytest.raises(DatasetError, match="non-empty|overwrite"):
+        build_dataset(sources, dest_dir, overwrite=False)
+
+
+def test_nonempty_dest_succeeds_with_overwrite(tmp_path: Path) -> None:
+    """Non-empty dest_dir with overwrite=True → stale files cleared, build succeeds."""
+    src_dir = tmp_path / "sources"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dataset"
+    dest_dir.mkdir()
+
+    # Seed with stale dataset files
+    stale_img = dest_dir / "img_01.png"
+    stale_img.write_bytes(_MINIMAL_PNG)
+    stale_txt = dest_dir / "img_01.txt"
+    stale_txt.write_text("old caption")
+
+    sources = _make_sources(src_dir, count=5, caption=f"{DEFAULT_TRIGGER_WORD} dress")
+    result = build_dataset(sources, dest_dir, overwrite=True)
+
+    images = list(dest_dir.glob("img_*.png"))
+    assert len(images) == 5
+
+
+# ---------------------------------------------------------------------------
+# Missing source image
+# ---------------------------------------------------------------------------
+
+
+def test_missing_source_image_raises(tmp_path: Path) -> None:
+    """Source image path that doesn't exist → DatasetError before writing."""
+    src_dir = tmp_path / "sources"
+    src_dir.mkdir()
+    dest_dir = tmp_path / "dataset"
+
+    sources = [
+        {"image": str(src_dir / "nonexistent.png"), "caption": f"{DEFAULT_TRIGGER_WORD} top"}
+    ] * 5
+
+    with pytest.raises(DatasetError, match="not found"):
+        build_dataset(sources, dest_dir)
+
+    # dest_dir should be empty (nothing written)
+    assert list(dest_dir.glob("img_*")) == []
+
+
+# ---------------------------------------------------------------------------
+# Empty sources list
+# ---------------------------------------------------------------------------
+
+
+def test_empty_sources_raises(tmp_path: Path) -> None:
+    """Empty sources list → DatasetError immediately."""
+    with pytest.raises(DatasetError, match="empty"):
+        build_dataset([], tmp_path / "dataset")

--- a/tests/flux_lora/test_inference.py
+++ b/tests/flux_lora/test_inference.py
@@ -3,7 +3,8 @@ tests.flux_lora.test_inference — covers inference.py public API + Replicate co
 
 No real Replicate API calls are made. httpx is mocked at the transport level.
 Field names asserted here (lora_weights, lora_scale, guidance) were verified against
-the live black-forest-labs/flux-dev-lora Input schema on 2026-06-24.
+the live black-forest-labs/flux-dev-lora Input schema on 2026-06-24, and the response
+handling (status / output / urls.get / Prefer: wait) against Replicate's HTTP docs.
 """
 
 from __future__ import annotations
@@ -12,12 +13,21 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from scripts.flux_lora import RequiresConfirmationError
+from scripts.flux_lora import InferenceError, RequiresConfirmationError
 from scripts.flux_lora.inference import (
     FLUX_INFERENCE_MODEL,
     generate,
     load_latest_lora,
 )
+
+_HTTPS_LORA = "https://example.com/lora.tar"
+
+
+def _resp(status_code: int, body: dict) -> MagicMock:
+    m = MagicMock()
+    m.status_code = status_code
+    m.json.return_value = body
+    return m
 
 
 class TestGenerateStopAndShow:
@@ -27,14 +37,14 @@ class TestGenerateStopAndShow:
         """SECURITY: confirmed=False must raise before any HTTP call."""
         monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
         with pytest.raises(RequiresConfirmationError):
-            generate("SKYYROSE hoodie", "https://example.com/lora.tar", confirmed=False)
+            generate("SKYYROSE hoodie", _HTTPS_LORA, confirmed=False)
 
     def test_no_http_call_when_confirmed_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """SECURITY: no Replicate POST must fire when confirmed=False."""
         monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
         with patch("scripts.flux_lora.inference.httpx.post") as mock_post:
             with pytest.raises(RequiresConfirmationError):
-                generate("SKYYROSE hoodie", "https://example.com/lora.tar", confirmed=False)
+                generate("SKYYROSE hoodie", _HTTPS_LORA, confirmed=False)
             mock_post.assert_not_called()
 
 
@@ -43,45 +53,84 @@ class TestGenerateContract:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """
-        confirmed=True fires exactly one POST against the LoRA-capable model with the
-        field names that exist in its live schema — and NONE that would 422.
+        confirmed=True fires one POST against the LoRA-capable model with field names
+        that exist in its live schema — and NONE that would 422. A succeeded response
+        returns the output URLs directly (no poll).
         """
         monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+        ok = _resp(201, {"status": "succeeded", "output": ["https://example.com/out.png"]})
 
-        mock_response = MagicMock()
-        mock_response.status_code = 201
-        mock_response.json.return_value = {"output": ["https://example.com/out.png"]}
-
-        with patch(
-            "scripts.flux_lora.inference.httpx.post", return_value=mock_response
-        ) as mock_post:
-            urls = generate(
-                "SKYYROSE hoodie",
-                "https://example.com/lora.tar",
-                confirmed=True,
-                num_outputs=2,
-            )
+        with patch("scripts.flux_lora.inference.httpx.post", return_value=ok) as mock_post:
+            urls = generate("SKYYROSE hoodie", _HTTPS_LORA, confirmed=True, num_outputs=2)
 
         mock_post.assert_called_once()
         call = mock_post.call_args
 
-        # Endpoint: the LoRA-capable official model, predictions route.
         url = call.args[0] if call.args else call.kwargs["url"]
         assert FLUX_INFERENCE_MODEL == "black-forest-labs/flux-dev-lora"
         assert url.endswith(f"/v1/models/{FLUX_INFERENCE_MODEL}/predictions"), url
+        assert call.kwargs["headers"]["Prefer"] == "wait"
 
         inp = call.kwargs["json"]["input"]
-        # Fields that EXIST in the flux-dev-lora schema.
-        assert inp["lora_weights"] == "https://example.com/lora.tar"
+        assert inp["lora_weights"] == _HTTPS_LORA
         assert "lora_scale" in inp
         assert "guidance" in inp
         assert inp["num_outputs"] == 2
-        # Fields that do NOT exist → would 422. Must be absent.
+        # Fields that do NOT exist in flux-dev-lora → would 422. Must be absent.
         assert "extra_lora" not in inp
         assert "extra_lora_scale" not in inp
         assert "guidance_scale" not in inp
+        # seed omitted unless requested
+        assert "seed" not in inp
 
         assert urls == ["https://example.com/out.png"]
+
+    def test_seed_included_only_when_provided(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+        ok = _resp(201, {"status": "succeeded", "output": ["u"]})
+        with patch("scripts.flux_lora.inference.httpx.post", return_value=ok) as mock_post:
+            generate("SKYYROSE hoodie", _HTTPS_LORA, confirmed=True, seed=42)
+        assert mock_post.call_args.kwargs["json"]["input"]["seed"] == 42
+
+    def test_polls_when_post_returns_non_terminal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A non-terminal POST result must be polled via urls.get until terminal."""
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+        starting = _resp(
+            201,
+            {
+                "status": "processing",
+                "urls": {"get": "https://api.replicate.com/v1/predictions/p1"},
+            },
+        )
+        done = _resp(200, {"status": "succeeded", "output": ["https://example.com/out.png"]})
+
+        with (
+            patch("scripts.flux_lora.inference.httpx.post", return_value=starting),
+            patch("scripts.flux_lora.inference.httpx.get", return_value=done) as mock_get,
+            patch("scripts.flux_lora.inference.time.sleep") as mock_sleep,
+        ):
+            urls = generate("SKYYROSE hoodie", _HTTPS_LORA, confirmed=True)
+
+        mock_get.assert_called_once()  # terminal on first poll
+        mock_sleep.assert_not_called()  # terminal checked before sleeping
+        assert urls == ["https://example.com/out.png"]
+
+    def test_failed_prediction_raises_inference_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+        failed = _resp(201, {"status": "failed", "error": "OOM on GPU"})
+        with patch("scripts.flux_lora.inference.httpx.post", return_value=failed):
+            with pytest.raises(InferenceError, match="OOM on GPU"):
+                generate("SKYYROSE hoodie", _HTTPS_LORA, confirmed=True)
+
+    def test_non_https_lora_url_rejected_before_http(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SSRF guard: a non-https lora_url must raise before any POST."""
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+        with patch("scripts.flux_lora.inference.httpx.post") as mock_post:
+            with pytest.raises(ValueError, match="https"):
+                generate("SKYYROSE hoodie", "http://evil.local/lora.tar", confirmed=True)
+            mock_post.assert_not_called()
 
 
 class TestLoadLatestLora:

--- a/tests/flux_lora/test_inference.py
+++ b/tests/flux_lora/test_inference.py
@@ -1,0 +1,99 @@
+"""
+tests.flux_lora.test_inference — covers inference.py public API + Replicate contract.
+
+No real Replicate API calls are made. httpx is mocked at the transport level.
+Field names asserted here (lora_weights, lora_scale, guidance) were verified against
+the live black-forest-labs/flux-dev-lora Input schema on 2026-06-24.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.flux_lora import RequiresConfirmationError
+from scripts.flux_lora.inference import (
+    FLUX_INFERENCE_MODEL,
+    generate,
+    load_latest_lora,
+)
+
+
+class TestGenerateStopAndShow:
+    def test_raises_requires_confirmation_when_confirmed_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SECURITY: confirmed=False must raise before any HTTP call."""
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+        with pytest.raises(RequiresConfirmationError):
+            generate("SKYYROSE hoodie", "https://example.com/lora.tar", confirmed=False)
+
+    def test_no_http_call_when_confirmed_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SECURITY: no Replicate POST must fire when confirmed=False."""
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+        with patch("scripts.flux_lora.inference.httpx.post") as mock_post:
+            with pytest.raises(RequiresConfirmationError):
+                generate("SKYYROSE hoodie", "https://example.com/lora.tar", confirmed=False)
+            mock_post.assert_not_called()
+
+
+class TestGenerateContract:
+    def test_post_uses_lora_model_and_verified_fields(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        confirmed=True fires exactly one POST against the LoRA-capable model with the
+        field names that exist in its live schema — and NONE that would 422.
+        """
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"output": ["https://example.com/out.png"]}
+
+        with patch(
+            "scripts.flux_lora.inference.httpx.post", return_value=mock_response
+        ) as mock_post:
+            urls = generate(
+                "SKYYROSE hoodie",
+                "https://example.com/lora.tar",
+                confirmed=True,
+                num_outputs=2,
+            )
+
+        mock_post.assert_called_once()
+        call = mock_post.call_args
+
+        # Endpoint: the LoRA-capable official model, predictions route.
+        url = call.args[0] if call.args else call.kwargs["url"]
+        assert FLUX_INFERENCE_MODEL == "black-forest-labs/flux-dev-lora"
+        assert url.endswith(f"/v1/models/{FLUX_INFERENCE_MODEL}/predictions"), url
+
+        inp = call.kwargs["json"]["input"]
+        # Fields that EXIST in the flux-dev-lora schema.
+        assert inp["lora_weights"] == "https://example.com/lora.tar"
+        assert "lora_scale" in inp
+        assert "guidance" in inp
+        assert inp["num_outputs"] == 2
+        # Fields that do NOT exist → would 422. Must be absent.
+        assert "extra_lora" not in inp
+        assert "extra_lora_scale" not in inp
+        assert "guidance_scale" not in inp
+
+        assert urls == ["https://example.com/out.png"]
+
+
+class TestLoadLatestLora:
+    def test_returns_output_url_from_succeeded_run(self) -> None:
+        runs = [
+            {"replicate_response": {"status": "failed", "output": None}},
+            {"replicate_response": {"status": "succeeded", "output": "https://x/weights.tar"}},
+        ]
+        with patch("scripts.flux_lora.inference.list_runs", return_value=runs):
+            assert load_latest_lora() == "https://x/weights.tar"
+
+    def test_returns_none_when_no_succeeded_run(self) -> None:
+        runs = [{"replicate_response": {"status": "starting", "output": None}}]
+        with patch("scripts.flux_lora.inference.list_runs", return_value=runs):
+            assert load_latest_lora() is None

--- a/tests/flux_lora/test_trainer.py
+++ b/tests/flux_lora/test_trainer.py
@@ -1,5 +1,5 @@
 """
-tests.flux_lora.test_trainer — 3 tests covering trainer.py public API.
+tests.flux_lora.test_trainer — covers trainer.py public API + Replicate contract.
 
 No real Replicate API calls are made. httpx is mocked at the transport level.
 """
@@ -10,7 +10,6 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 
 from scripts.flux_lora import RequiresConfirmationError
@@ -31,7 +30,7 @@ class TestBuildManifest:
         zip_path = tmp_path / "dataset.zip"
         zip_path.write_bytes(b"PK")  # fake zip
 
-        manifest = build_manifest(zip_path)
+        manifest = build_manifest(zip_path, destination_model="skyyrose/skyyrose-lora")
 
         assert manifest["model_owner"] == "ostris"
         assert manifest["model_name"] == "flux-dev-lora-trainer"
@@ -57,6 +56,50 @@ class TestBuildManifest:
         assert manifest["training_input"]["lora_rank"] == 8
         assert manifest["destination_model"] == "myuser/my-lora"
 
+    def test_destination_model_is_required(self, tmp_path: Path) -> None:
+        """Replicate trainings require a destination; build_manifest must enforce it."""
+        zip_path = tmp_path / "dataset.zip"
+        zip_path.write_bytes(b"PK")
+
+        with pytest.raises(ValueError, match="destination_model is required"):
+            build_manifest(zip_path)
+        with pytest.raises(ValueError, match="destination_model is required"):
+            build_manifest(zip_path, destination_model="no-slash")
+
+    def test_training_input_has_no_unknown_fields(self, tmp_path: Path) -> None:
+        """
+        Guard against the lr_scheduler regression: every key in training_input must
+        exist in the ostris/flux-dev-lora-trainer TrainingInput schema (verified
+        live 2026-06-24). lr_scheduler is NOT a valid field — its presence 422s.
+        """
+        zip_path = tmp_path / "dataset.zip"
+        zip_path.write_bytes(b"PK")
+        manifest = build_manifest(zip_path, destination_model="skyyrose/skyyrose-lora")
+
+        allowed = {
+            "autocaption",
+            "autocaption_prefix",
+            "autocaption_suffix",
+            "batch_size",
+            "cache_latents_to_disk",
+            "caption_dropout_rate",
+            "gradient_checkpointing",
+            "hf_repo_id",
+            "hf_token",
+            "input_images",
+            "layers_to_optimize_regex",
+            "learning_rate",
+            "lora_rank",
+            "optimizer",
+            "resolution",
+            "skip_training_and_use_pretrained_hf_lora_url",
+            "steps",
+            "trigger_word",
+        }
+        unknown = set(manifest["training_input"]) - allowed
+        assert not unknown, f"unknown TrainingInput fields would 422: {unknown}"
+        assert "lr_scheduler" not in manifest["training_input"]
+
 
 class TestStartTraining:
     def test_raises_requires_confirmation_when_confirmed_false(
@@ -68,7 +111,7 @@ class TestStartTraining:
 
         zip_path = tmp_path / "dataset.zip"
         zip_path.write_bytes(b"PK")
-        manifest = build_manifest(zip_path)
+        manifest = build_manifest(zip_path, destination_model="skyyrose/skyyrose-lora")
 
         with pytest.raises(RequiresConfirmationError):
             start_training(
@@ -85,7 +128,7 @@ class TestStartTraining:
 
         zip_path = tmp_path / "dataset.zip"
         zip_path.write_bytes(b"PK")
-        manifest = build_manifest(zip_path)
+        manifest = build_manifest(zip_path, destination_model="skyyrose/skyyrose-lora")
 
         with patch("scripts.flux_lora.trainer.httpx.post") as mock_post:
             with pytest.raises(RequiresConfirmationError):
@@ -104,7 +147,7 @@ class TestStartTraining:
 
         zip_path = tmp_path / "dataset.zip"
         zip_path.write_bytes(b"PK")
-        manifest = build_manifest(zip_path)
+        manifest = build_manifest(zip_path, destination_model="skyyrose/skyyrose-lora")
 
         fake_response_data = {
             "id": "train-abc123",
@@ -124,15 +167,19 @@ class TestStartTraining:
 
         mock_post.assert_called_once()
         call_kwargs = mock_post.call_args
-        # Verify token in headers
-        headers = (
-            call_kwargs.kwargs.get("headers") or call_kwargs.args[1]
-            if len(call_kwargs.args) > 1
-            else {}
-        )
         assert "Authorization" in str(call_kwargs)
         assert result["id"] == "train-abc123"
         assert result["status"] == "starting"
+
+        # Contract: URL must carry the version id in the path (Replicate requires it).
+        url = call_kwargs.args[0] if call_kwargs.args else call_kwargs.kwargs["url"]
+        assert "/versions/" in url and url.endswith("/trainings"), url
+
+        # Contract: payload must include destination + input_images, and no lr_scheduler.
+        payload = call_kwargs.kwargs["json"]
+        assert payload["destination"] == "skyyrose/skyyrose-lora"
+        assert payload["input"]["input_images"] == "https://example.com/dataset.zip"
+        assert "lr_scheduler" not in payload["input"]
 
 
 class TestSaveRunRecord:
@@ -144,7 +191,7 @@ class TestSaveRunRecord:
 
         zip_path = tmp_path / "dataset.zip"
         zip_path.write_bytes(b"PK")
-        manifest = build_manifest(zip_path)
+        manifest = build_manifest(zip_path, destination_model="skyyrose/skyyrose-lora")
 
         training_resp = {
             "id": "train-xyz999",

--- a/tests/flux_lora/test_trainer.py
+++ b/tests/flux_lora/test_trainer.py
@@ -181,6 +181,25 @@ class TestStartTraining:
         assert payload["input"]["input_images"] == "https://example.com/dataset.zip"
         assert "lr_scheduler" not in payload["input"]
 
+    def test_accepts_http_200_success(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Replicate's trainings doc labels success as 200 — it must NOT raise on 200."""
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+        zip_path = tmp_path / "dataset.zip"
+        zip_path.write_bytes(b"PK")
+        manifest = build_manifest(zip_path, destination_model="skyyrose/skyyrose-lora")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "train-200", "status": "starting"}
+
+        with patch("scripts.flux_lora.trainer.httpx.post", return_value=mock_response):
+            result = start_training(
+                manifest, confirmed=True, input_images_url="https://example.com/dataset.zip"
+            )
+        assert result["id"] == "train-200"
+
     def test_rejects_non_https_input_images_url(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/flux_lora/test_trainer.py
+++ b/tests/flux_lora/test_trainer.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from scripts.flux_lora import RequiresConfirmationError
+from scripts.flux_lora import RequiresConfirmationError, TrainingError
 from scripts.flux_lora.config import (
     DEFAULT_STEPS,
     DEFAULT_TRIGGER_WORD,
@@ -181,6 +181,24 @@ class TestStartTraining:
         assert payload["input"]["input_images"] == "https://example.com/dataset.zip"
         assert "lr_scheduler" not in payload["input"]
 
+    def test_rejects_non_https_input_images_url(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SSRF guard: a non-https input_images_url must raise before any POST."""
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+        zip_path = tmp_path / "dataset.zip"
+        zip_path.write_bytes(b"PK")
+        manifest = build_manifest(zip_path, destination_model="skyyrose/skyyrose-lora")
+
+        with patch("scripts.flux_lora.trainer.httpx.post") as mock_post:
+            with pytest.raises(TrainingError, match="https"):
+                start_training(
+                    manifest,
+                    confirmed=True,
+                    input_images_url="http://evil.local/dataset.zip",
+                )
+            mock_post.assert_not_called()
+
 
 class TestSaveRunRecord:
     def test_saves_json_file_with_correct_keys(
@@ -207,3 +225,25 @@ class TestSaveRunRecord:
         assert "timestamp" in record
         assert record["manifest"]["model_name"] == "flux-dev-lora-trainer"
         assert record["replicate_response"]["status"] == "starting"
+
+    def test_sanitizes_malicious_training_id_in_filename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A spoofed training_id with path separators must not escape RUNS_DIR."""
+        runs_dir = tmp_path / "runs"
+        monkeypatch.setattr("scripts.flux_lora.trainer.RUNS_DIR", runs_dir)
+
+        zip_path = tmp_path / "dataset.zip"
+        zip_path.write_bytes(b"PK")
+        manifest = build_manifest(zip_path, destination_model="skyyrose/skyyrose-lora")
+
+        record_path = save_run_record({"id": "../../etc/evil", "status": "x"}, manifest)
+
+        # File stays inside RUNS_DIR; separators were sanitized out of the name.
+        assert record_path.parent == runs_dir
+        assert record_path.resolve().is_relative_to(runs_dir.resolve())
+        assert "/" not in record_path.name.replace(".json", "")
+        # Original id preserved inside the record for fidelity.
+        assert (
+            json.loads(record_path.read_text(encoding="utf-8"))["training_id"] == "../../etc/evil"
+        )

--- a/tests/flux_lora/test_trainer.py
+++ b/tests/flux_lora/test_trainer.py
@@ -1,0 +1,162 @@
+"""
+tests.flux_lora.test_trainer — 3 tests covering trainer.py public API.
+
+No real Replicate API calls are made. httpx is mocked at the transport level.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from scripts.flux_lora import RequiresConfirmationError
+from scripts.flux_lora.config import (
+    DEFAULT_STEPS,
+    DEFAULT_TRIGGER_WORD,
+    EST_COST_PER_RUN_USD,
+)
+from scripts.flux_lora.trainer import (
+    build_manifest,
+    save_run_record,
+    start_training,
+)
+
+
+class TestBuildManifest:
+    def test_manifest_contains_required_fields(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "dataset.zip"
+        zip_path.write_bytes(b"PK")  # fake zip
+
+        manifest = build_manifest(zip_path)
+
+        assert manifest["model_owner"] == "ostris"
+        assert manifest["model_name"] == "flux-dev-lora-trainer"
+        assert manifest["training_input"]["trigger_word"] == DEFAULT_TRIGGER_WORD
+        assert manifest["training_input"]["steps"] == DEFAULT_STEPS
+        assert manifest["cost_usd"] == EST_COST_PER_RUN_USD
+        assert manifest["dataset_zip"] == str(zip_path)
+
+    def test_manifest_respects_overrides(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "dataset.zip"
+        zip_path.write_bytes(b"PK")
+
+        manifest = build_manifest(
+            zip_path,
+            trigger_word="MYWORD",
+            steps=500,
+            lora_rank=8,
+            destination_model="myuser/my-lora",
+        )
+
+        assert manifest["training_input"]["trigger_word"] == "MYWORD"
+        assert manifest["training_input"]["steps"] == 500
+        assert manifest["training_input"]["lora_rank"] == 8
+        assert manifest["destination_model"] == "myuser/my-lora"
+
+
+class TestStartTraining:
+    def test_raises_requires_confirmation_when_confirmed_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SECURITY: confirmed=False must raise before any HTTP call."""
+        # Set token so we don't fail on missing key
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+
+        zip_path = tmp_path / "dataset.zip"
+        zip_path.write_bytes(b"PK")
+        manifest = build_manifest(zip_path)
+
+        with pytest.raises(RequiresConfirmationError):
+            start_training(
+                manifest,
+                confirmed=False,
+                input_images_url="https://example.com/dataset.zip",
+            )
+
+    def test_no_http_call_made_when_confirmed_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SECURITY: no Replicate POST must fire when confirmed=False."""
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+
+        zip_path = tmp_path / "dataset.zip"
+        zip_path.write_bytes(b"PK")
+        manifest = build_manifest(zip_path)
+
+        with patch("scripts.flux_lora.trainer.httpx.post") as mock_post:
+            with pytest.raises(RequiresConfirmationError):
+                start_training(
+                    manifest,
+                    confirmed=False,
+                    input_images_url="https://example.com/dataset.zip",
+                )
+            mock_post.assert_not_called()
+
+    def test_submits_post_when_confirmed_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Happy path: confirmed=True fires one POST and returns response dict."""
+        monkeypatch.setenv("REPLICATE_API_TOKEN", "test-token-abc")
+
+        zip_path = tmp_path / "dataset.zip"
+        zip_path.write_bytes(b"PK")
+        manifest = build_manifest(zip_path)
+
+        fake_response_data = {
+            "id": "train-abc123",
+            "status": "starting",
+            "urls": {"get": "https://api.replicate.com/v1/trainings/train-abc123"},
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = fake_response_data
+
+        with patch("scripts.flux_lora.trainer.httpx.post", return_value=mock_response) as mock_post:
+            result = start_training(
+                manifest,
+                confirmed=True,
+                input_images_url="https://example.com/dataset.zip",
+            )
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        # Verify token in headers
+        headers = (
+            call_kwargs.kwargs.get("headers") or call_kwargs.args[1]
+            if len(call_kwargs.args) > 1
+            else {}
+        )
+        assert "Authorization" in str(call_kwargs)
+        assert result["id"] == "train-abc123"
+        assert result["status"] == "starting"
+
+
+class TestSaveRunRecord:
+    def test_saves_json_file_with_correct_keys(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Redirect RUNS_DIR to tmp_path
+        monkeypatch.setattr("scripts.flux_lora.trainer.RUNS_DIR", tmp_path / "runs")
+
+        zip_path = tmp_path / "dataset.zip"
+        zip_path.write_bytes(b"PK")
+        manifest = build_manifest(zip_path)
+
+        training_resp = {
+            "id": "train-xyz999",
+            "status": "starting",
+            "urls": {"get": "https://api.replicate.com/v1/trainings/train-xyz999"},
+        }
+
+        record_path = save_run_record(training_resp, manifest)
+
+        assert record_path.exists()
+        record = json.loads(record_path.read_text(encoding="utf-8"))
+        assert record["training_id"] == "train-xyz999"
+        assert "timestamp" in record
+        assert record["manifest"]["model_name"] == "flux-dev-lora-trainer"
+        assert record["replicate_response"]["status"] == "starting"

--- a/tests/flux_lora/test_upload.py
+++ b/tests/flux_lora/test_upload.py
@@ -1,0 +1,266 @@
+"""
+tests.flux_lora.test_upload — Unit tests for upload.upload_zip().
+
+Security contract verified:
+- confirmed=False raises RequiresConfirmationError BEFORE any network call.
+- confirmed=True with mocked hub calls returns well-formed https URL.
+- Missing token raises RuntimeError (not masked by RequiresConfirmationError).
+
+Token isolation:
+- conftest._clear_env_token removes REPLICATE_API_TOKEN (autouse).
+- Each test that exercises token logic also clears HF_TOKEN and
+  HUGGINGFACE_API_TOKEN and patches upload.load_dotenv to a no-op so
+  the real .env.hf on disk cannot inject a live token.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.flux_lora import RequiresConfirmationError
+from scripts.flux_lora.upload import show_upload_stopandshow, upload_zip
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HF_TOKEN_VARS = ("HF_TOKEN", "HUGGINGFACE_API_TOKEN")
+
+
+def _noop_load_dotenv(*_args, **_kwargs) -> bool:
+    """Drop-in replacement for load_dotenv that does nothing."""
+    return False
+
+
+def _make_zip(tmp_path: Path, name: str = "dataset.zip") -> Path:
+    """Create a minimal fake zip file for testing."""
+    p = tmp_path / name
+    p.write_bytes(b"PK\x05\x06" + b"\x00" * 18)  # minimal ZIP end-of-central-dir
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Security gate: confirmed=False raises BEFORE any network call
+# ---------------------------------------------------------------------------
+
+
+def test_unconfirmed_raises_requires_confirmation(tmp_path: Path) -> None:
+    """upload_zip(confirmed=False) must raise RequiresConfirmationError immediately."""
+    zip_path = _make_zip(tmp_path)
+
+    with (
+        patch("scripts.flux_lora.upload.HfApi") as mock_api_cls,
+        patch("scripts.flux_lora.upload.hf_hub_url") as mock_url,
+    ):
+        with pytest.raises(RequiresConfirmationError):
+            upload_zip(zip_path, "skyyrose/test-dataset", confirmed=False)
+
+        # No network call whatsoever
+        mock_api_cls.assert_not_called()
+        mock_url.assert_not_called()
+
+
+def test_unconfirmed_raises_before_token_access(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """confirmed=False must raise BEFORE token is loaded (gate is truly first)."""
+    zip_path = _make_zip(tmp_path)
+
+    # Even if token env vars are absent the confirmed=False gate fires first
+    for var in _HF_TOKEN_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr("scripts.flux_lora.upload.load_dotenv", _noop_load_dotenv)
+
+    with pytest.raises(RequiresConfirmationError):
+        upload_zip(zip_path, "skyyrose/test-dataset", confirmed=False)
+
+
+# ---------------------------------------------------------------------------
+# confirmed=True — happy path with mocked hub calls
+# ---------------------------------------------------------------------------
+
+
+def test_confirmed_returns_https_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """confirmed=True with mocked hub → well-formed https resolve URL returned."""
+    zip_path = _make_zip(tmp_path, "my-dataset.zip")
+
+    # Isolate HF tokens
+    for var in _HF_TOKEN_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HF_TOKEN", "hf_fake_token_for_test")
+    monkeypatch.setattr("scripts.flux_lora.upload.load_dotenv", _noop_load_dotenv)
+
+    expected_url = (
+        "https://huggingface.co/datasets/skyyrose/test-dataset/resolve/main/my-dataset.zip"
+    )
+
+    mock_api_instance = MagicMock()
+    mock_api_instance.create_repo.return_value = None
+    mock_api_instance.upload_file.return_value = None
+
+    with (
+        patch("scripts.flux_lora.upload.HfApi", return_value=mock_api_instance),
+        patch("scripts.flux_lora.upload.hf_hub_url", return_value=expected_url) as mock_url,
+    ):
+        result = upload_zip(
+            zip_path,
+            "skyyrose/test-dataset",
+            confirmed=True,
+        )
+
+    assert result == expected_url
+    assert result.startswith("https://")
+
+    # Hub calls wired correctly
+    mock_api_instance.create_repo.assert_called_once_with(
+        repo_id="skyyrose/test-dataset",
+        repo_type="dataset",
+        exist_ok=True,
+        private=False,
+        token="hf_fake_token_for_test",
+    )
+    mock_api_instance.upload_file.assert_called_once()
+    upload_call_kwargs = mock_api_instance.upload_file.call_args
+    assert upload_call_kwargs.kwargs.get("repo_id") == "skyyrose/test-dataset"
+    assert upload_call_kwargs.kwargs.get("repo_type") == "dataset"
+
+    mock_url.assert_called_once_with(
+        repo_id="skyyrose/test-dataset",
+        filename="my-dataset.zip",
+        repo_type="dataset",
+    )
+
+
+def test_confirmed_private_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """private=True passed through to create_repo."""
+    zip_path = _make_zip(tmp_path, "private.zip")
+
+    for var in _HF_TOKEN_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HF_TOKEN", "hf_fake_token_for_test")
+    monkeypatch.setattr("scripts.flux_lora.upload.load_dotenv", _noop_load_dotenv)
+
+    expected_url = "https://huggingface.co/datasets/skyyrose/private-repo/resolve/main/private.zip"
+
+    mock_api_instance = MagicMock()
+    with (
+        patch("scripts.flux_lora.upload.HfApi", return_value=mock_api_instance),
+        patch("scripts.flux_lora.upload.hf_hub_url", return_value=expected_url),
+    ):
+        upload_zip(zip_path, "skyyrose/private-repo", private=True, confirmed=True)
+
+    mock_api_instance.create_repo.assert_called_once_with(
+        repo_id="skyyrose/private-repo",
+        repo_type="dataset",
+        exist_ok=True,
+        private=True,
+        token="hf_fake_token_for_test",
+    )
+
+
+def test_custom_path_in_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """path_in_repo overrides default filename in hub calls."""
+    zip_path = _make_zip(tmp_path, "source.zip")
+
+    for var in _HF_TOKEN_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HF_TOKEN", "hf_fake_token_for_test")
+    monkeypatch.setattr("scripts.flux_lora.upload.load_dotenv", _noop_load_dotenv)
+
+    expected_url = "https://huggingface.co/datasets/skyyrose/test-ds/resolve/main/custom-name.zip"
+
+    mock_api_instance = MagicMock()
+    with (
+        patch("scripts.flux_lora.upload.HfApi", return_value=mock_api_instance),
+        patch("scripts.flux_lora.upload.hf_hub_url", return_value=expected_url) as mock_url,
+    ):
+        result = upload_zip(
+            zip_path,
+            "skyyrose/test-ds",
+            path_in_repo="custom-name.zip",
+            confirmed=True,
+        )
+
+    assert "custom-name.zip" in result
+    # hf_hub_url called with custom filename
+    mock_url.assert_called_once_with(
+        repo_id="skyyrose/test-ds",
+        filename="custom-name.zip",
+        repo_type="dataset",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Missing token raises RuntimeError
+# ---------------------------------------------------------------------------
+
+
+def test_missing_token_raises_runtime_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    confirmed=True but no HF token in env → RuntimeError.
+
+    Must pass confirmed=True so the RequiresConfirmationError gate doesn't fire
+    first (which would mask the token error and give a misleading test result).
+    """
+    zip_path = _make_zip(tmp_path)
+
+    # Remove all token sources
+    for var in _HF_TOKEN_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr("scripts.flux_lora.upload.load_dotenv", _noop_load_dotenv)
+
+    with patch("scripts.flux_lora.upload.HfApi") as mock_api_cls:
+        with pytest.raises(RuntimeError, match="token"):
+            upload_zip(zip_path, "skyyrose/test-dataset", confirmed=True)
+
+        # No API calls before the token error
+        mock_api_cls.assert_not_called()
+
+
+def test_fallback_token_var_used(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """HUGGINGFACE_API_TOKEN fallback accepted when HF_TOKEN absent."""
+    zip_path = _make_zip(tmp_path, "fallback.zip")
+
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setenv("HUGGINGFACE_API_TOKEN", "hf_fallback_token")
+    monkeypatch.setattr("scripts.flux_lora.upload.load_dotenv", _noop_load_dotenv)
+
+    expected_url = (
+        "https://huggingface.co/datasets/skyyrose/fallback-repo/resolve/main/fallback.zip"
+    )
+
+    mock_api_instance = MagicMock()
+    with (
+        patch("scripts.flux_lora.upload.HfApi", return_value=mock_api_instance),
+        patch("scripts.flux_lora.upload.hf_hub_url", return_value=expected_url),
+    ):
+        result = upload_zip(zip_path, "skyyrose/fallback-repo", confirmed=True)
+
+    assert result.startswith("https://")
+    mock_api_instance.create_repo.assert_called_once()
+    # token passed to create_repo is the fallback token
+    assert mock_api_instance.create_repo.call_args.kwargs["token"] == "hf_fallback_token"
+
+
+# ---------------------------------------------------------------------------
+# show_upload_stopandshow
+# ---------------------------------------------------------------------------
+
+
+def test_show_upload_stopandshow_prints_key_fields(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """STOP-AND-SHOW output contains file path, repo, and proceed prompt."""
+    zip_path = _make_zip(tmp_path, "test.zip")
+    show_upload_stopandshow(zip_path, "skyyrose/my-dataset")
+
+    out = capsys.readouterr().out
+    assert str(zip_path.resolve()) in out or "test.zip" in out
+    assert "skyyrose/my-dataset" in out
+    assert "Proceed?" in out
+    assert "STOP" in out

--- a/tests/oai_render/conftest.py
+++ b/tests/oai_render/conftest.py
@@ -1,0 +1,14 @@
+"""Isolated conftest for oai_render tests.
+
+Overrides the root conftest's autouse _reset_rate_limiter fixture (which imports
+from security.rate_limiting and requires the full app to be installed) so that
+oai_render unit tests can run without the main application stack.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """No-op override — oai_render tests don't touch the rate limiter."""
+    yield

--- a/tests/oai_render/test_client.py
+++ b/tests/oai_render/test_client.py
@@ -1,0 +1,47 @@
+"""
+tests.oai_render.test_client — gpt-image-2 edit client contract.
+
+Locks the input_fidelity="high" parameter (verified against the openai-python
+image_edit_params.py source via Context7, 2026-06-24: supported for gpt-image-2,
+default "low") so the render pipeline never silently drops back to low fidelity.
+No real OpenAI call is made — the SDK client is replaced with a mock.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.oai_render import config
+from scripts.oai_render.client import OAIImageClient
+
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def _build_client_with_mock(monkeypatch: pytest.MonkeyPatch) -> tuple[OAIImageClient, MagicMock]:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-abc")
+    client = OAIImageClient()
+    fake_sdk = MagicMock()
+    fake_sdk.images.edit.return_value = MagicMock(
+        data=[MagicMock(b64_json=base64.b64encode(b"image-bytes").decode())]
+    )
+    client._client = fake_sdk  # replace the real OpenAI SDK client
+    return client, fake_sdk
+
+
+def test_edit_sends_input_fidelity_high(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client, fake_sdk = _build_client_with_mock(monkeypatch)
+    img = tmp_path / "ref.png"
+    img.write_bytes(_FAKE_PNG)
+
+    out = client.edit(prompt="SKYYROSE varsity, studio", image_paths=[img])
+
+    assert out == b"image-bytes"
+    fake_sdk.images.edit.assert_called_once()
+    kwargs = fake_sdk.images.edit.call_args.kwargs
+    assert kwargs["model"] == "gpt-image-2"
+    assert kwargs["input_fidelity"] == "high"  # the fix: not omitted, not "low"
+    assert config.INPUT_FIDELITY == "high"

--- a/tests/oai_render/test_scene_schema.py
+++ b/tests/oai_render/test_scene_schema.py
@@ -5,8 +5,10 @@ Six tests covering:
 2. On-model scene includes brand hex #B76E79 in color_palette
 3. scene_to_prompt_block output is valid JSON extractable
 4. build_prompt(scene=None) is backward-compatible (no SCENE SPEC marker)
-5. Unknown collection falls back to signature defaults
+5. Unknown on-model collection raises SceneError (no silent fallback)
 6. build_scene returns fresh dicts (no shared-state mutation)
+7. flatlay → clean-studio scene with top-down camera (not on-model)
+8. COLLECTION_SCENES and _ONMODEL_DEFAULTS share the same per-collection landmark
 """
 
 from __future__ import annotations
@@ -15,7 +17,7 @@ import json
 
 import pytest
 
-from scripts.oai_render.prompt import build_prompt
+from scripts.oai_render.prompt import COLLECTION_SCENES, SceneError, build_prompt
 from scripts.oai_render.scene_schema import build_scene, scene_to_prompt_block
 
 # ---------------------------------------------------------------------------
@@ -93,9 +95,9 @@ def test_onmodel_scene_color_palette_includes_brand_hex() -> None:
 def test_scene_to_prompt_block_valid_json() -> None:
     scene = build_scene(**_GHOST_KWARGS)
     block = scene_to_prompt_block(scene)
-    assert block.startswith("SCENE SPEC (JSON)"), (
-        f"Block does not start with expected header:\n{block[:80]}"
-    )
+    assert block.startswith(
+        "SCENE SPEC (JSON)"
+    ), f"Block does not start with expected header:\n{block[:80]}"
     # Extract JSON portion — everything after the first newline
     json_part = block[block.index("\n") + 1 :]
     parsed = json.loads(json_part)  # raises if not valid JSON
@@ -114,28 +116,24 @@ def test_build_prompt_scene_none_is_backward_compatible() -> None:
     result_no_kwarg = build_prompt(**_BUILD_PROMPT_KWARGS)
 
     assert "SCENE SPEC" not in result_with_none, "scene=None must not inject a SCENE SPEC block"
-    assert result_with_none == result_no_kwarg, (
-        "scene=None output must equal output with no scene kwarg"
-    )
+    assert (
+        result_with_none == result_no_kwarg
+    ), "scene=None output must equal output with no scene kwarg"
 
 
 # ---------------------------------------------------------------------------
-# Test 5 — unknown collection falls back to signature defaults
+# Test 5 — unknown on-model collection raises SceneError (no silent fallback)
 # ---------------------------------------------------------------------------
 
 
-def test_unknown_collection_falls_back_to_signature() -> None:
-    scene = build_scene(
-        sku="xx-001",
-        name="Mystery Piece",
-        collection="nonexistent-collection",
-        style="on-model",
-    )
-    # Should not raise; model should be populated (on-model path)
-    assert scene["model"] is not None
-    assert scene["subject"]["type"] == "on-model"
-    # color_palette must still include brand hex
-    assert "#B76E79" in scene["color_palette"]
+def test_unknown_collection_raises_sceneerror() -> None:
+    with pytest.raises(SceneError, match="No on-model scene"):
+        build_scene(
+            sku="xx-001",
+            name="Mystery Piece",
+            collection="nonexistent-collection",
+            style="on-model",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -153,12 +151,59 @@ def test_build_scene_returns_fresh_dicts() -> None:
     scene_a["color_palette"].append("#DEADBE")
 
     # scene_b must be unaffected
-    assert scene_b["lighting"]["key"] != "MUTATED", (
-        "Mutation of scene_a.lighting leaked into scene_b — shared reference bug"
+    assert (
+        scene_b["lighting"]["key"] != "MUTATED"
+    ), "Mutation of scene_a.lighting leaked into scene_b — shared reference bug"
+    assert (
+        scene_b["constraints"]["no_watermarks"] is True
+    ), "Mutation of scene_a.constraints leaked into scene_b"
+    assert (
+        "#DEADBE" not in scene_b["color_palette"]
+    ), "Mutation of scene_a.color_palette leaked into scene_b"
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — flatlay → clean-studio scene, top-down camera, no model
+# ---------------------------------------------------------------------------
+
+
+def test_flatlay_uses_clean_studio_topdown_not_onmodel() -> None:
+    scene = build_scene(
+        sku="br-001",
+        name="The Black Rose Varsity",
+        collection="black-rose",
+        style="flatlay",
     )
-    assert scene_b["constraints"]["no_watermarks"] is True, (
-        "Mutation of scene_a.constraints leaked into scene_b"
-    )
-    assert "#DEADBE" not in scene_b["color_palette"], (
-        "Mutation of scene_a.color_palette leaked into scene_b"
-    )
+    # flatlay must NOT fall through to the on-model branch
+    assert scene["model"] is None, "flatlay must have no model"
+    assert scene["subject"]["type"] == "flatlay"
+    assert scene["environment"] == "seamless studio cyclorama"
+    # camera angle must match the top-down flatlay PRESENTATION, not ghost eye-level
+    angle = scene["camera"]["angle"].lower()
+    assert "top-down" in angle or "overhead" in angle, f"flatlay camera not top-down: {angle}"
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — drift guard: the two collection-environment sources stay aligned
+# ---------------------------------------------------------------------------
+
+
+def test_collection_env_sources_share_landmarks() -> None:
+    """
+    COLLECTION_SCENES (prompt.py, paired path) and _ONMODEL_DEFAULTS (scene_schema,
+    solo path) independently describe each collection's environment. They must
+    reference the same landmark so the solo hero and paired look don't diverge.
+    """
+    from scripts.oai_render.scene_schema import _ONMODEL_DEFAULTS
+
+    landmarks = {
+        "black-rose": "bay bridge",
+        "love-hurts": "château",
+        "signature": "golden gate",
+        "kids-capsule": "throne",
+    }
+    for collection, landmark in landmarks.items():
+        paired = COLLECTION_SCENES[collection].lower()
+        solo = str(_ONMODEL_DEFAULTS[collection]["environment"]).lower()
+        assert landmark in paired, f"{collection}: {landmark!r} missing from COLLECTION_SCENES"
+        assert landmark in solo, f"{collection}: {landmark!r} missing from _ONMODEL_DEFAULTS"

--- a/tests/oai_render/test_scene_schema.py
+++ b/tests/oai_render/test_scene_schema.py
@@ -1,0 +1,164 @@
+"""Tests for scripts/oai_render/scene_schema.py.
+
+Six tests covering:
+1. Ghost scene has required top-level keys
+2. On-model scene includes brand hex #B76E79 in color_palette
+3. scene_to_prompt_block output is valid JSON extractable
+4. build_prompt(scene=None) is backward-compatible (no SCENE SPEC marker)
+5. Unknown collection falls back to signature defaults
+6. build_scene returns fresh dicts (no shared-state mutation)
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.oai_render.prompt import build_prompt
+from scripts.oai_render.scene_schema import build_scene, scene_to_prompt_block
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_GHOST_KWARGS = dict(
+    sku="br-001",
+    name="The Black Rose Varsity",
+    collection="black-rose",
+    style="ghost",
+)
+
+_ONMODEL_KWARGS = dict(
+    sku="sg-001",
+    name="The Signature Hoodie",
+    collection="signature",
+    style="on-model",
+)
+
+_BUILD_PROMPT_KWARGS = dict(
+    name="The Black Rose Varsity",
+    sku="br-001",
+    collection="black-rose",
+    reference_labels=[],
+    dossier_text=None,
+    is_patch=False,
+    style="ghost",
+    view="front",
+)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — ghost scene has required schema keys
+# ---------------------------------------------------------------------------
+
+
+def test_ghost_scene_has_required_keys() -> None:
+    scene = build_scene(**_GHOST_KWARGS)
+    required = {
+        "subject",
+        "model",
+        "environment",
+        "lighting",
+        "camera",
+        "style",
+        "mood",
+        "color_palette",
+        "constraints",
+    }
+    assert required.issubset(scene.keys()), f"Missing keys: {required - set(scene.keys())}"
+    # ghost-specific: model is None
+    assert scene["model"] is None
+    assert scene["subject"]["type"] == "ghost-mannequin"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — on-model scene includes brand rose-gold hex in palette
+# ---------------------------------------------------------------------------
+
+
+def test_onmodel_scene_color_palette_includes_brand_hex() -> None:
+    scene = build_scene(**_ONMODEL_KWARGS)
+    palette: list[str] = scene["color_palette"]
+    assert "#B76E79" in palette, f"Rose Gold #B76E79 missing from palette: {palette}"
+    # Also verify the palette is non-empty and all entries are hex strings
+    assert all(p.startswith("#") for p in palette), f"Non-hex value in palette: {palette}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — scene_to_prompt_block produces a valid-JSON extractable block
+# ---------------------------------------------------------------------------
+
+
+def test_scene_to_prompt_block_valid_json() -> None:
+    scene = build_scene(**_GHOST_KWARGS)
+    block = scene_to_prompt_block(scene)
+    assert block.startswith("SCENE SPEC (JSON)"), (
+        f"Block does not start with expected header:\n{block[:80]}"
+    )
+    # Extract JSON portion — everything after the first newline
+    json_part = block[block.index("\n") + 1 :]
+    parsed = json.loads(json_part)  # raises if not valid JSON
+    assert parsed["subject"]["sku"] == "br-001"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — build_prompt(scene=None) produces no SCENE SPEC marker
+# ---------------------------------------------------------------------------
+
+
+def test_build_prompt_scene_none_is_backward_compatible() -> None:
+    # Call with explicit scene=None
+    result_with_none = build_prompt(**_BUILD_PROMPT_KWARGS, scene=None)
+    # Call without scene kwarg at all
+    result_no_kwarg = build_prompt(**_BUILD_PROMPT_KWARGS)
+
+    assert "SCENE SPEC" not in result_with_none, "scene=None must not inject a SCENE SPEC block"
+    assert result_with_none == result_no_kwarg, (
+        "scene=None output must equal output with no scene kwarg"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — unknown collection falls back to signature defaults
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_collection_falls_back_to_signature() -> None:
+    scene = build_scene(
+        sku="xx-001",
+        name="Mystery Piece",
+        collection="nonexistent-collection",
+        style="on-model",
+    )
+    # Should not raise; model should be populated (on-model path)
+    assert scene["model"] is not None
+    assert scene["subject"]["type"] == "on-model"
+    # color_palette must still include brand hex
+    assert "#B76E79" in scene["color_palette"]
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — build_scene returns fresh dicts (mutation isolation)
+# ---------------------------------------------------------------------------
+
+
+def test_build_scene_returns_fresh_dicts() -> None:
+    scene_a = build_scene(**_GHOST_KWARGS)
+    scene_b = build_scene(**_GHOST_KWARGS)
+
+    # Mutate scene_a's nested dicts
+    scene_a["lighting"]["key"] = "MUTATED"
+    scene_a["constraints"]["no_watermarks"] = False
+    scene_a["color_palette"].append("#DEADBE")
+
+    # scene_b must be unaffected
+    assert scene_b["lighting"]["key"] != "MUTATED", (
+        "Mutation of scene_a.lighting leaked into scene_b — shared reference bug"
+    )
+    assert scene_b["constraints"]["no_watermarks"] is True, (
+        "Mutation of scene_a.constraints leaked into scene_b"
+    )
+    assert "#DEADBE" not in scene_b["color_palette"], (
+        "Mutation of scene_a.color_palette leaked into scene_b"
+    )

--- a/tests/oai_render/test_scene_schema.py
+++ b/tests/oai_render/test_scene_schema.py
@@ -207,3 +207,30 @@ def test_collection_env_sources_share_landmarks() -> None:
         solo = str(_ONMODEL_DEFAULTS[collection]["environment"]).lower()
         assert landmark in paired, f"{collection}: {landmark!r} missing from COLLECTION_SCENES"
         assert landmark in solo, f"{collection}: {landmark!r} missing from _ONMODEL_DEFAULTS"
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — style-reference lever: directive present only when requested
+# ---------------------------------------------------------------------------
+
+
+def test_style_reference_directive_toggles() -> None:
+    base = dict(
+        name="The Black Rose Varsity",
+        sku="br-001",
+        collection="black-rose",
+        reference_labels=["image 1: front reference", "STYLE & COMPOSITION REFERENCE (env only)"],
+        dossier_text=None,
+        is_patch=False,
+        style="on-model",
+    )
+    with_ref = build_prompt(**base, style_reference=True)
+    without_ref = build_prompt(**base, style_reference=False)
+
+    assert "STYLE & COMPOSITION REFERENCE:" in with_ref
+    assert (
+        "take NO garment" not in without_ref and "STYLE & COMPOSITION REFERENCE:" not in without_ref
+    )
+    # the directive must forbid lifting garments from the anchor
+    assert "FINAL reference image" in with_ref
+    assert "garment" in with_ref.split("STYLE & COMPOSITION REFERENCE:")[1][:400].lower()


### PR DESCRIPTION
## JSON scene schema + FLUX LoRA infrastructure — built, wired, verified end-to-end

Lands the two image infrastructures (5 commits) on `main`, with every external API contract verified against current docs (Context7) and live provider schemas.

### What's in it
**1. JSON scene schema → gpt-image-2 pipeline** (`scripts/oai_render/`)
- `scene_schema.build_scene()` → structured per-collection scene dicts; `scene_to_prompt_block()` injects JSON into the prompt; wired into `pipeline.plan_sku()`.
- Per-collection canonical environments (Bay Bridge / château / Golden Gate / throne); `flatlay` gets a clean-studio top-down scene; unknown on-model collection raises `SceneError` (no silent fallback).
- **Reference-image lever** — `--style-reference PATH` feeds a lookbook frame as an environment/lighting/mood anchor (never a garment source).
- `input_fidelity="high"` now sent on every gpt-image-2 edit (was silently `low`).

**2. FLUX LoRA train + inference** (`scripts/flux_lora/`)
- `config / trainer / inference / dataset / status / cli` + `dataset_builder` (images→captioned dataset) + `upload` (zip→public HF URL Replicate fetches).
- Every paid call (`start_training`, `generate`, `upload_zip`) raises `RequiresConfirmationError` before any HTTP — STOP-AND-SHOW gate.

### Correctness — found + fixed before landing
- **CRITICAL**: `generate()` returned `[]` on every call (`Prefer: respond-async` + no poll) → `Prefer: wait` + poll `urls.get` until terminal.
- **HIGH**: Replicate API contract bugs that would 404/422 on first real call — version-in-path, `destination` required, `lr_scheduler`/`guidance_scale` invalid, base `flux-dev` lacks LoRA fields (→ `flux-dev-lora`). Diffed against the LIVE Replicate schema (zero unknown keys).
- **HIGH**: Replicate trainings success code is `200` per docs; code required `201` only → now accepts both.
- **HIGH**: `flatlay` produced a contradictory prompt; silent `signature` fallback for unknown collections.
- Plus SSRF https guards, path-traversal sanitize, dead-code removal, docstring corrections.

### Verification (all in-session, fresh)
- **5755 tests pass, 0 failed** (full suite excl. heavy dirs + a pre-existing, unrelated `test_gdpr` failure proven independent).
- 57 targeted tests; live-schema payload diff PASS (training + inference); `gpt-image-2` confirmed live.
- Context7 doc-precision audit (Replicate / huggingface_hub / OpenAI) — 2 mismatches found, fixed, tested.
- ruff + black clean; 100% of the diff under `scripts/` + `tests/`; no stubs.

### Test plan
- [x] `pytest tests/flux_lora/ tests/oai_render/` → 57 passed
- [x] Full regression → 5755 passed / 0 failed
- [x] Live read-only schema diffs (Replicate trainer + flux-dev-lora) → zero unknown keys
- [ ] Paid live render / training run — gated, awaiting founder go (no paid call made in this PR)

Paid training/inference/render remain STOP-AND-SHOW gated; nothing paid ran.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a JSON scene schema to the `gpt-image-2` render pipeline and ships end-to-end FLUX LoRA training/inference tooling in `scripts/flux_lora`, verified against live provider schemas. Improves edit fidelity and adds a style-anchor lever, while gating all paid calls behind explicit confirmation.

- **New Features**
  - Scene schema injected into prompts with per-collection on‑model environments; `flatlay` gets a clean studio top‑down scene; unknown collections raise `SceneError`.
  - Style anchor: `--style-reference` appends a final reference used only for environment/lighting/mood (never a garment source).
  - FLUX LoRA package and CLI (`train`, `generate`, `status`, `build-dataset`, `upload-dataset`) with dataset builder and `huggingface_hub` upload; STOP‑AND‑SHOW confirmation gates; edits send `input_fidelity='high'`.

- **Bug Fixes**
  - Replicate inference now uses `Prefer: wait` and polls `urls.get` until a terminal state; raises on failed/canceled to avoid empty results.
  - Aligned training/inference with live `flux-dev-lora` schema: correct endpoints/fields, require `destination`, accept 200/201; added SSRF/path traversal guards.
  - Prompt logic prevents double environment injection when a scene JSON is present; stricter dataset validation.

<sup>Written for commit 60173a35f855e7f6f9e6ac635a12ae0fe0122924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new FLUX LoRA command-line workflow for building datasets, validating inputs, uploading datasets, checking training status, starting training, and generating images.
  * Added support for style reference images in the render pipeline, plus structured scene-based prompt guidance.
  * Added higher-fidelity image-edit settings for the image render flow.

* **Bug Fixes**
  * Improved dataset validation, safer uploads, and stronger confirmation prompts before training, inference, and dataset upload actions.
  * Added clearer handling for invalid or missing dataset files and unsupported scene/collection combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->