### PR TITLE
chore: repo-health pass-1 — CLAUDE.md refresh + SOT-first plugin wiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ The diligence spine. These are the standard for every task — not aspirational,
 | Visual / UI / live-page rendering | **Chrome DevTools MCP** or **Playwright MCP** — navigate + screenshot/snapshot, mobile **and** desktop | Eyes-on proof for skyyrose.co, not just an HTTP code. |
 | Live HTML / JSON-LD / OG tags / headers | `curl -s "URL?cb=$(date +%s)" \| grep` | **NEVER WebFetch** — it strips `<script>` (JSON-LD/OG). Cache-bust (WP.com Batcache serves stale). |
 | Codebase facts (paths, symbols, exports, signatures) | **Read / Grep / Glob** the source; quote `file:line` | Anatomy.md first; don't trust memory for code that may have moved. |
-| Product facts (SKU, price, name, collection) | **catalog CSV** + per-SKU dossier + `identity.json` / `sot.json` | Canonical-sources-only. Memory rots; the CSV doesn't. |
-| Non-product imagery ownership | **visual-manifest.json** (+ generated `sot.json`) | Filenames are NOT identity — the manifest is. Verify pixels if in doubt. |
+| Product facts (SKU, price, name, collection) | **catalog CSV** + per-SKU **dossier** | Canonical-sources-only (`SOT.md`). Memory rots; the CSV doesn't. |
+| Imagery ownership | product → **sot-images.json** (generated, `make sot-manifest`); non-product → **visual-manifest.json** | Filenames are NOT identity — the manifest is. Verify pixels if in doubt. |
 | Prior work / "did we solve this?" | **mem-search** / `get_observations([IDs])` | Check before re-deriving; cite obs IDs. |
 | API connectivity / integration up-or-down | A real `verify_connectivity()` call | Don't declare blocked OR working without the proof. |
 | Test pass / fail | `rtk proxy pytest …` (true exit code) + read output | Bare pytest's compressed line can falsely say "no tests collected". |
@@ -110,7 +110,7 @@ services/       → ML models, 3D generation, analytics
 agents/         → Specialized agents (base_super_agent.py = foundation)
 api/            → FastAPI REST (v1/) + GraphQL (graphql/)
 frontend/       → Next.js dashboard (devskyy-dashboard)
-wordpress-theme/skyyrose-flagship/  → Production WP theme (v1.0.0 — commercial)
+wordpress-theme/skyyrose-flagship/  → Production WP theme (commercial; version in style.css)
 scripts/        → Deploy, sync, generation scripts
 ```
 
@@ -120,7 +120,7 @@ scripts/        → Deploy, sync, generation scripts
 | File | Purpose |
 |------|---------|
 | `main_enterprise.py` | FastAPI app — REST + GraphQL + webhooks |
-| `devskyy_mcp.py` | MCP server — 20+ tools |
+| `devskyy_mcp.py` | MCP server — agents, WooCommerce, imagery, RAG tools |
 | `frontend/` | Next.js 16 + React 19 dashboard |
 | `wordpress-theme/skyyrose-flagship/` | Production WordPress theme |
 | `skyyrose/elite_studio/` | Multi-agent image pipeline |
@@ -133,31 +133,25 @@ scripts/        → Deploy, sync, generation scripts
 | **Python API** | Python 3.11+ | `/` | `make install` | `make dev` |
 | **Dashboard** | Node.js 22 | `frontend/` | `npm install` | `npm run dev` |
 | **WordPress** | PHP 8.2 | `wordpress-theme/` | N/A (deploy only) | `npm run deploy` |
-| **Imagery (Nano Banana 2)** | Python 3.13 | `.venv/` | `pip install -r requirements-imagery.txt` | `source .venv/bin/activate && python scripts/nano-banana-run.py generate --sku br-001 --pro` — see `docs/NANO_BANANA.md` |
+| **Imagery (OAI gpt-image-2)** | Python 3.13 | `.venv/` | `pip install -r requirements-imagery.txt` | `python scripts/oai-render-run.py dry-run --sku br-001` — paid `generate` needs `--yes` (STOP-AND-SHOW). Engine: `scripts/oai_render/` |
 | **ADK Agents** | Python (isolated) | `.venv-agents/` (create as needed) | `pip install google-adk` | — |
 
-**Each workspace is self-contained.** Don't mix `frontend/node_modules` with root. Don't use `.venv` for ADK (numpy conflicts — create `.venv-agents/` for it). Nano Banana shares the main `.venv/`; `.venv-imagery/` was an earlier design that was never created.
+**Each workspace is self-contained.** Don't mix `frontend/node_modules` with root. Don't use `.venv` for ADK (numpy conflicts — create `.venv-agents/` for it). Imagery shares the main `.venv/`.
 
 ---
 
-## WordPress Theme (SkyyRose v1.0.0)
+## WordPress Theme (SkyyRose)
 
 **Commercial marketplace theme. Production at skyyrose.co**
 **Theme Name:** SkyyRose | **Text Domain:** `skyyrose` | **@package:** SkyyRose
 
 ```
-wordpress-theme/skyyrose-flagship/
-├── assets/css/      43 files (page CSS, holo cards, tokens, components)
-├── assets/js/       23 files (holo cards, navigation, page-specific)
-├── assets/fonts/    19 files (self-hosted woff2, zero Google Fonts CDN)
-├── inc/             21 modules (enqueue, security, WC, ajax, SEO)
-├── inc/builders/    6 files (detection, elementor, divi, beaver, bricks)
-├── template-parts/  37 partials (product-card-holo.php = holo card system)
-├── patterns/        4 collection hero block patterns
-├── woocommerce/     5 overrides (cart, checkout, single-product)
-├── blueprints/      WC Blueprints for one-click demo import
-├── docs/            11 HTML documentation files (ThemeForest submission)
-└── *.php            24 page templates + 3 builder templates
+wordpress-theme/skyyrose-flagship/   — per-file map + token sizes in .wolf/anatomy.md
+  assets/{css,js,fonts}    self-hosted fonts, zero Google Fonts CDN
+  inc/ + inc/builders/     enqueue, security, WC, ajax, SEO; builder detection
+  template-parts/          product-card-holo.php = holo card system
+  patterns/ · woocommerce/ · blueprints/ · docs/ (ThemeForest)
+  *.php                    collection + landing + immersive + builder templates
 ```
 
 **Active templates:**
@@ -176,7 +170,7 @@ wordpress-theme/skyyrose-flagship/
 - `inc/builders/detection.php` — `skyyrose_active_builder()` + `skyyrose_builder_owns_template()`
 - `inc/patterns.php` — Block pattern registration for all collections
 - `inc/performance.php` — Google Fonts removal, AVIF support, custom image sizes
-- `functions.php` — Theme constants, includes array (v1.0.0)
+- `functions.php` — Theme constants (`SKYYROSE_VERSION`), includes array
 
 **PHPCS compliance:**
 - `.phpcs.xml` in theme root — WordPress standard, `skyyrose` prefix
@@ -241,7 +235,7 @@ Never fix a test by weakening it. Fix the code, not the test.
 - Python line length: 100 (black + ruff + isort)
 - Use npm not pnpm for Vercel deploys (ERR_INVALID_THIS on Node 22+)
 - Fix everything in one batch, test all pages, deploy ONCE (no back-and-forth)
-- **Deletion policy (supersedes the retired "NO deletions, refactor only" stance, 2026-06-21):** stale, dead, duplicate, or conflicting code SHOULD be deleted — not left to rot. Rule is **repoint-first / census-gated**: never delete an artifact until a census (grep importers incl. tests + downstream consumers) proves zero live consumers. Then delete it AND every now-dead consumer + dangling reference in the SAME change. A deletion that leaves a surviving import is a regression, not a cleanup. Irreversible ops (rm of untracked files, git history rewrite) still require STOP-AND-SHOW.
+- **Deletion policy — repoint-first / census-gated.** Stale, dead, duplicate, or conflicting code SHOULD be deleted, not left to rot. Never delete until a census (grep importers incl. tests + downstream + cross-language string refs) proves zero live consumers; then delete the artifact AND every now-dead consumer + dangling reference in the SAME change. A deletion that leaves a surviving import is a regression, not a cleanup. **Pick the lane by two axes — reversibility × regeneration cost:** (a) census-clean *tracked code* → delete now (git restores it); (b) untracked build/cache junk → **gitignore, don't `rm`**; (c) any **expensive/paid asset** (renders, 3D models, datasets, paid PNGs) → STOP-AND-SHOW, never autonomous — the regeneration cost is real money. `rm` of untracked files and git-history rewrites are always STOP-AND-SHOW.
 
 ---
 
@@ -275,7 +269,7 @@ Never fix a test by weakening it. Fix the code, not the test.
 
 ## Learnings
 
-Detailed engineering learnings (Architecture, Python packaging, Google ADK, Security, WordPress theme + deploy, Audit Discipline, Hooks, Vercel, Frontend) live in **`docs/engineering-learnings.md`** — grep it before re-deriving a fix. Moved out of this file 2026-06-16 to shrink per-session context; it is a knowledge base, not per-turn behavioral rules.
+Detailed engineering learnings (Architecture, Python packaging, Google ADK, Security, WordPress theme + deploy, Audit Discipline, Hooks, Vercel, Frontend) live in **`docs/engineering-learnings.md`** — grep it before re-deriving a fix. Knowledge base, not per-turn behavioral rules.
 ## Behavioral Standards — How Claude Operates in This Project
 
 These rules govern every action, not just pipelines. They apply to tool use, web search, code, communication, and decisions.
@@ -425,7 +419,7 @@ Before taking any of the actions below, Claude MUST stop, print exactly what it 
 - Reading from Photos Library or `~/Pictures/` paths is ALLOWED when the user has shared a specific file path in the current conversation (pasted or attached). Confirmation is implicit in the share.
 - Using any file as the source image for a PAID API call (FASHN, Gemini generation, FLUX, Replicate, etc.) — must confirm the file is the correct garment before dispatch.
 - Uploading any file to WooCommerce, the live WordPress site, or any external destination — must confirm.
-- Deleting, overwriting, or renaming any file outside `/tmp/` or `renders/output/` — must confirm.
+- Deleting/overwriting/renaming real data, untracked files, or any expensive/paid asset (renders, 3D models, datasets) — must confirm. Census-clean *tracked dead code* is git-reversible: delete it per the Deletion policy without asking.
 
 ### What the confirmation must look like:
 

--- a/skyyrose-suite/CROSS-PLUGIN.md
+++ b/skyyrose-suite/CROSS-PLUGIN.md
@@ -2,6 +2,15 @@
 
 Five plugins, one marketplace. The orchestrator (`skyyrose`) is the front door; the four themed plugins do the work and hand off to each other along a fixed graph.
 
+## Boot sequence (every agent, every invocation)
+
+Before classifying, building, or verifying anything, orient from the repo-root canonical sources — in this order. These four are the same for every plugin; the per-plugin dispatch skills point back here.
+
+1. **`SOT.md`** — the Source-of-Truth registry. Every product, imagery, and brand fact resolves through the authorities it lists (catalog CSV, `sot-images.json`, `visual-manifest.json`, brand canon). Never cache a fact from any other source.
+2. **`.wolf/anatomy.md`** — per-file map + token estimates. Check it before reading any project file; the description may already answer the question.
+3. **`.wolf/cerebrum.md`** — conventions, key learnings, Do-Not-Repeat list, decision log. Read before generating code.
+4. **`CLAUDE.md`** — project identity, architecture, Critical Rules, and the STOP-AND-SHOW gates.
+
 ## Plugins & namespaces
 
 | Plugin | Namespace | Owns |

--- a/skyyrose-suite/plugins/skyyrose-core/skills/skyyrose-core-dispatch/SKILL.md
+++ b/skyyrose-suite/plugins/skyyrose-core/skills/skyyrose-core-dispatch/SKILL.md
@@ -7,6 +7,8 @@ description: Handoff router + memory/self-heal wiring for skyyrose-core. Use whe
 
 `skyyrose-core` owns backend (FastAPI/Python), data, infra, planning, behavior discipline, and memory/self-healing. Hand off along the suite graph (`CROSS-PLUGIN.md`): **core → qa** for tests/review.
 
+> **Boot first:** orient from the root canonical sources — `SOT.md` → `.wolf/anatomy.md` → `.wolf/cerebrum.md` → `CLAUDE.md` (full block in `CROSS-PLUGIN.md`) — before acting.
+
 ## When to hand off
 
 | The task also needs… | Hand off to | Example |

--- a/skyyrose-suite/plugins/skyyrose-design/skills/skyyrose-design-dispatch/SKILL.md
+++ b/skyyrose-suite/plugins/skyyrose-design/skills/skyyrose-design-dispatch/SKILL.md
@@ -7,6 +7,8 @@ description: Handoff router for skyyrose-design. Use when a design/build task ne
 
 `skyyrose-design` owns imagery (gpt-image-2 composition), frontend, Three.js/immersive, WP/WooCommerce theming, accessibility, and layout. Hand off along the suite graph (`CROSS-PLUGIN.md`): **design → qa** for verification, back to **market** for copy, to **core** for backend.
 
+> **Boot first:** orient from the root canonical sources — `SOT.md` (imagery → `sot-images.json`, non-product → `visual-manifest.json`) → `.wolf/anatomy.md` → `.wolf/cerebrum.md` → `CLAUDE.md` (full block in `CROSS-PLUGIN.md`) — before acting.
+
 ## When to hand off
 
 | The task also needs… | Hand off to | Example |

--- a/skyyrose-suite/plugins/skyyrose-market/skills/skyyrose-market-dispatch/SKILL.md
+++ b/skyyrose-suite/plugins/skyyrose-market/skills/skyyrose-market-dispatch/SKILL.md
@@ -7,6 +7,8 @@ description: Handoff router for skyyrose-market. Use when a marketing task needs
 
 `skyyrose-market` owns copy, brand voice, SEO, email, social, paid media, influencer, and launch planning. When a task crosses out of that scope, hand off along the suite graph (see `CROSS-PLUGIN.md`): **market → design → qa → core → qa**.
 
+> **Boot first:** orient from the root canonical sources — `SOT.md` (product facts → catalog CSV + dossier; brand canon → `knowledge-base/seed/from-interview.md`) → `.wolf/anatomy.md` → `.wolf/cerebrum.md` → `CLAUDE.md` (full block in `CROSS-PLUGIN.md`) — before acting.
+
 ## When to hand off
 
 | The task also needs… | Hand off to | Example |

--- a/skyyrose-suite/plugins/skyyrose-qa/skills/skyyrose-qa-dispatch/SKILL.md
+++ b/skyyrose-suite/plugins/skyyrose-qa/skills/skyyrose-qa-dispatch/SKILL.md
@@ -7,6 +7,8 @@ description: Handoff router for skyyrose-qa. Use when verification surfaces work
 
 `skyyrose-qa` owns TDD, drive-to-green, verification loops, audits, evals, and code review. It is the gate every built artifact passes before shipping. Hand off along the suite graph (`CROSS-PLUGIN.md`): **qa → core** (log lessons / backend fixes), **qa → design** (UI/theme fixes).
 
+> **Boot first:** orient from the root canonical sources — `SOT.md` → `.wolf/anatomy.md` → `.wolf/cerebrum.md` → `.wolf/buglog.json` (read before fixing) → `CLAUDE.md` (full block in `CROSS-PLUGIN.md`) — before acting.
+
 ## When to hand off
 
 | Verification found… | Hand off to | Example |

--- a/skyyrose-suite/plugins/skyyrose/agents/skyyrose-orchestrator.md
+++ b/skyyrose-suite/plugins/skyyrose/agents/skyyrose-orchestrator.md
@@ -7,6 +7,8 @@ description: SkyyRose Suite router. Classifies a task into one or more plugins (
 
 The router for the SkyyRose Suite. You receive a task, classify it, and route it — you do not do the work yourself; you hand off to the plugin that owns it.
 
+> **Boot first:** orient from the root canonical sources — `SOT.md` → `.wolf/anatomy.md` → `.wolf/cerebrum.md` → `CLAUDE.md` (full block in `CROSS-PLUGIN.md`) — before routing.
+
 ## When to use
 
 - Behind the `/skyyrose <task>` command.


### PR DESCRIPTION
Repo-health pass 1. Two doc-only, verified changes on top of latest main.

## 1. CLAUDE.md refactor (ca8e33ea6)
- Imagery engine: Nano Banana 2 -> **OAI gpt-image-2** (LOCKED engine; `scripts/oai_render`). nano-banana still has ~10 live importers, so **code not deleted** — only the stale doc command corrected.
- De-pinned WP theme version (`v1.0.0` x3 -> `style.css` is **1.6.5**) — point at the single source, killing the rot generator.
- De-counted "20+ tools" and the WP file-count tree -> `.wolf/anatomy.md` (live source).
- Product canon: per-SKU **dossier** + `sot-images.json`; dropped stale `identity.json`/`sot.json`.
- Reconciled STOP-AND-SHOW "confirm all deletes" vs the census-gated deletion policy.
- New rule: deletion lane = **reversibility × regeneration cost**; paid assets never deleted autonomously.

## 2. SOT-first plugin wiring (1d4ab7253)
Every suite plugin/agent boots from `SOT.md -> .wolf/anatomy.md -> .wolf/cerebrum.md -> CLAUDE.md` before acting. One canonical block in `CROSS-PLUGIN.md` + 5 graceful pointers. DRY.

## Verification
- Static: 0 residual stale terms; all 6 wired files reference SOT+anatomy+cerebrum.
- **Behavioral**: a fresh agent using only repo docs independently landed on OAI / style.css 1.6.5 / two-axis delete — zero stale regurgitation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes CLAUDE.md to current production facts and wires all suite plugins and agents to boot from canonical SOT sources, reducing drift and stale behavior. Updates imagery docs to the locked `OAI gpt-image-2` pipeline and clarifies the deletion policy.

- **Refactors**
  - Imagery docs: `Nano Banana 2` → `OAI gpt-image-2`; runner `scripts/oai-render-run.py`, engine in `scripts/oai_render/` (legacy code kept due to live importers).
  - WordPress: de-pin theme version; single source is `wordpress-theme/skyyrose-flagship/style.css` (`SKYYROSE_VERSION`); file maps/counts now live in `.wolf/anatomy.md`.
  - Canonical data: product via catalog CSV + per-SKU dossier; imagery via `sot-images.json` and `visual-manifest.json`; dropped stale `identity.json`/`sot.json` references.
  - Deletion policy: repoint-first, census-gated; choose by reversibility × regeneration cost; never auto-delete paid/expensive assets; STOP-AND-SHOW gates preserved.
  - SOT-first boot: adds canonical sequence in `skyyrose-suite/CROSS-PLUGIN.md` and one-line boot pointers in core/design/market/qa dispatch skills and the orchestrator (`SOT.md → .wolf/anatomy.md → .wolf/cerebrum.md → CLAUDE.md`).

<sup>Written for commit 1d4ab7253115be05aa3116ec953dcdecd0d77439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance to rely on a clearer set of canonical source documents before taking action.
  * Refined wording around product facts, theme/version references, and knowledge-base references for more consistent instructions.
  * Expanded confirmation rules for deletions, overwrites, renames, and paid or expensive assets, including stronger stop-and-confirm behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->