### PR TITLE
feat(elite-studio): wire SceneGeneratorAgent to gpt-image-2 (Gemini fallback)

### DIFF
--- a/scripts/oai_render/client.py
+++ b/scripts/oai_render/client.py
@@ -1,8 +1,12 @@
-"""OpenAI gpt-image-2 edit client — hardened, no silent fallback.
+"""OpenAI gpt-image-2 image client — hardened, no silent fallback.
 
-Wraps ``client.images.edit`` with explicit timeout, bounded exponential-backoff
-retry on transient errors (429 / timeout / connection / 5xx), and clear failure
-propagation. gpt-image models always return base64; this decodes to PNG bytes.
+Wraps ``client.images.edit`` (reference-guided product renders) and
+``client.images.generate`` (text-to-image scene backgrounds, no references)
+with explicit timeout, bounded exponential-backoff retry on transient errors
+(429 / timeout / connection / 5xx), and clear failure propagation. gpt-image
+models always return base64 and never accept ``response_format`` (Context7-
+verified against openai-python image_generate_params.py, 2026-06-24) — so it is
+never sent; the returned base64 is decoded to image bytes.
 """
 
 from __future__ import annotations
@@ -36,7 +40,7 @@ def _as_upload(path: Path) -> tuple[str, bytes, str]:
 
 
 class OAIImageClient:
-    """Thin, retrying wrapper around OpenAI image edits for gpt-image-2."""
+    """Thin, retrying wrapper around OpenAI image edit + generate for gpt-image-2."""
 
     def __init__(self) -> None:
         try:
@@ -55,7 +59,7 @@ class OAIImageClient:
         return errs or (Exception,)
 
     def edit(self, *, prompt: str, image_paths: list[Path], mask_path: Path | None = None) -> bytes:
-        """Run one gpt-image-2 edit and return decoded PNG bytes.
+        """Run one gpt-image-2 edit and return decoded image bytes.
 
         Retries transient failures with exponential backoff + jitter; re-raises
         after ``config.MAX_RETRIES``. Never returns a partial/placeholder image.
@@ -82,20 +86,63 @@ class OAIImageClient:
         if mask_path is not None:
             kwargs["mask"] = _as_upload(mask_path)
 
+        return self._run_with_retry(lambda: self._client.images.edit(**kwargs))
+
+    def generate(
+        self,
+        *,
+        prompt: str,
+        size: str | None = None,
+        quality: str | None = None,
+        output_format: str | None = None,
+        background: str = "opaque",
+    ) -> bytes:
+        """Run one gpt-image-2 text-to-image generation; return decoded bytes.
+
+        Unlike :meth:`edit`, sends NO reference image — used for scene
+        backgrounds. gpt-image models always return base64 and reject
+        ``response_format`` (Context7-verified), so it is never sent. ``size``
+        accepts any gpt-image-2 ``WIDTHxHEIGHT`` (both divisible by 16, aspect
+        1:3..3:1); defaults to ``config.SIZE``. ``background`` defaults to
+        ``"opaque"`` (scenes are full backdrops, not cut-outs). Retries
+        transient failures with the same backoff as :meth:`edit`.
+        """
+        kwargs: dict = {
+            "model": config.MODEL,
+            "prompt": prompt,
+            "size": size or config.SIZE,
+            "quality": quality or config.QUALITY,
+            "output_format": output_format or config.OUTPUT_FORMAT,
+            "background": background,
+            "n": config.N,
+        }
+        return self._run_with_retry(lambda: self._client.images.generate(**kwargs))
+
+    def _decode_first(self, resp) -> bytes:
+        """Decode the first image of an OpenAI images response to raw bytes."""
+        b64 = resp.data[0].b64_json
+        if not b64:
+            raise RuntimeError("OpenAI returned an empty image payload.")
+        return base64.b64decode(b64)
+
+    def _run_with_retry(self, do_call) -> bytes:
+        """Run ``do_call()`` (one image API call) with bounded backoff retry.
+
+        Retries only transient OpenAI errors (429 / timeout / connection /
+        5xx); re-raises after ``config.MAX_RETRIES``. Non-transient errors
+        (including an empty payload) propagate immediately. Never returns a
+        partial/placeholder image.
+        """
         transient = self._transient_errors()
         attempt = 0
         while True:
             try:
-                resp = self._client.images.edit(**kwargs)
-                b64 = resp.data[0].b64_json
-                if not b64:
-                    raise RuntimeError("OpenAI returned an empty image payload.")
-                return base64.b64decode(b64)
+                return self._decode_first(do_call())
             except transient as exc:
                 attempt += 1
                 if attempt > config.MAX_RETRIES:
                     log.error(
-                        "gpt-image-2 edit failed after %d retries: %s", config.MAX_RETRIES, exc
+                        "gpt-image-2 call failed after %d retries: %s", config.MAX_RETRIES, exc
                     )
                     raise
                 delay = min(

--- a/skyyrose/elite_studio/agents/scene_generator_agent.py
+++ b/skyyrose/elite_studio/agents/scene_generator_agent.py
@@ -2,13 +2,16 @@
 
 Generates atmospheric scene backgrounds (no products in frame) by reading
 canonical scene specs from ``SCENES_DIR/{collection}/{scene_name}/scene.json``
-and dispatching a text-only prompt to Gemini's image API. Designed as the
-Stage-1 step that precedes ``CompositorAgent.composite()`` — real products
-composite onto the generated scene in Stage 2.
+and dispatching a text-only prompt to OpenAI gpt-image-2 (the founder-locked
+imagery engine, 2026-06-08), with Gemini as a fallback retained until OAI scene
+renders are validated. Designed as the Stage-1 step that precedes
+``CompositorAgent.composite()`` — real products composite onto the generated
+scene in Stage 2.
 
 Replaces the bespoke ``scripts/gemini_scene_gen.py`` direct-API path. All scene
 generation now flows through the elite team for consistent budget enforcement,
-quality scoring (via QualityAgent), and canon anchoring (via scene.json).
+quality scoring (via QualityAgent), and canon anchoring (via scene.json). The
+gpt-image-2 call reuses the hardened root client ``scripts/oai_render/client``.
 
 Usage::
 
@@ -27,10 +30,11 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from adk.base import ADKProvider, AgentConfig
 from adk.super_agents import BaseSuperAgent
@@ -41,11 +45,17 @@ from ..gemini_rest import generate_image as gemini_generate_image
 from ..models import GenerationResult
 from .compositor.lighting import SCENE_LOOKBOOK, load_lighting_spec
 
+if TYPE_CHECKING:
+    from scripts.oai_render.client import OAIImageClient
+
 logger = logging.getLogger(__name__)
 
-# Per-image cost (gemini-3-pro-image-preview). Pre-checked against budget
-# before each dispatch.
-_SCENE_GENERATION_COST_USD = 0.08
+# Per-image cost estimates (USD), ensured against budget BEFORE each paid call
+# and recorded only AFTER success. gpt-image-2 "high" text-to-image at
+# ~1024x1536 (no reference-image tokens) is cheaper than the edit path; treated
+# as a conservative floor for the gate. Gemini is the fallback engine.
+_OAI_SCENE_COST_USD = 0.30
+_GEMINI_SCENE_COST_USD = 0.08
 
 # Output directory for generated scenes. Mirrors SCENES_DIR layout so
 # downstream agents resolve scene PNGs via the same canonical path.
@@ -58,7 +68,7 @@ class SceneGeneratorAgent(BaseSuperAgent):
     Reads ``scene_description``, ``color_palette``, ``lighting``, ``camera``,
     ``skyyrose_dna``, ``focal_anchor``, ``negative_prompts``, and atmospheric
     fields from ``scene.json``, composes a single prompt, and dispatches one
-    text-to-image call to the Gemini image model.
+    text-to-image call to OpenAI gpt-image-2 (Gemini fallback).
 
     The result is a PNG written to::
 
@@ -82,6 +92,10 @@ class SceneGeneratorAgent(BaseSuperAgent):
                 ),
             )
         super().__init__(config)
+        # Lazily constructed gpt-image-2 client (validates OPENAI_API_KEY on
+        # first use). Kept off __init__ so importing/constructing the agent
+        # never requires an OpenAI key.
+        self._oai: OAIImageClient | None = None
 
     async def generate_scene(
         self,
@@ -132,21 +146,6 @@ class SceneGeneratorAgent(BaseSuperAgent):
                 metadata={"scene_name": scene_name, "collection": collection},
             )
 
-        # Pre-check budget before any paid call.
-        if budget is not None:
-            try:
-                budget.ensure_within_budget(
-                    _SCENE_GENERATION_COST_USD, stage="scene_generator_agent"
-                )
-            except BudgetExceededError as exc:
-                logger.error("budget exceeded before scene generation for %s: %s", scene_name, exc)
-                return GenerationResult(
-                    success=False,
-                    provider="none",
-                    error=f"budget exceeded: {exc}",
-                    metadata={"budget_blocked": True, "scene_name": scene_name},
-                )
-
         # Build the prompt from spec fields.
         prompt = self._build_scene_prompt(spec)
 
@@ -156,17 +155,124 @@ class SceneGeneratorAgent(BaseSuperAgent):
         filename = spec.get("expected_filename") or f"{scene_name}.png"
         output_path = output_dir / filename
 
-        # Dispatch generation. Scenes are text-only (no reference images).
-        # Gemini accepts only pure aspect ratios: 1:1, 1:4, 1:8, 2:3, 3:2, 3:4, 4:1, 4:3
-        # Strip trailing descriptors (e.g. "3:4 portrait" → "3:4").
+        # Target size for gpt-image-2 + the pure aspect token Gemini still needs.
         raw_aspect = str(spec.get("render_aspect", "3:4"))
-        aspect_ratio = raw_aspect.split()[0] if raw_aspect else "3:4"
+        size = self._aspect_to_size(raw_aspect)
+        aspect_ratio = raw_aspect.split()[0] if raw_aspect.strip() else "3:4"
 
-        # Model fallback chain (2026-05-26): gemini-3.1-flash-image-preview
-        # safety filter rejects fairy-tale gothic content as "No image in response"
-        # even with softened prompts. gemini-2.5-flash-image (original Nano Banana)
-        # has a looser safety profile suitable for cathedral/dark-fantasy scenes.
-        # Try primary model first, fall back to 2.5 on safety rejection.
+        image_bytes: bytes | str | None = None
+        provider = ""
+        model_used = ""
+        cost_spent = 0.0
+        errors: list[str] = []
+        budget_blocked = False
+
+        # Primary engine: OpenAI gpt-image-2 (founder-locked, 2026-06-08).
+        try:
+            image_bytes, model_used, cost_spent = await self._dispatch_oai(prompt, size, budget)
+            provider = "openai/gpt-image-2"
+        except BudgetExceededError as exc:
+            budget_blocked = True
+            errors.append(f"openai/gpt-image-2 budget: {exc}")
+            logger.warning("OAI scene budget block for %s: %s", scene_name, exc)
+        except Exception as exc:  # noqa: BLE001 — any OAI failure falls back to Gemini
+            errors.append(f"openai/gpt-image-2: {exc}")
+            logger.warning(
+                "OAI scene generation failed for %s: %s — falling back to Gemini",
+                scene_name,
+                exc,
+            )
+
+        # Fallback engine: Gemini, retained until OAI scene renders are validated
+        # (the locked policy erases nano-banana/Gemini AFTER validation).
+        if image_bytes is None:
+            try:
+                image_bytes, model_used, cost_spent = await self._dispatch_gemini(
+                    prompt, aspect_ratio, scene_name, budget
+                )
+                provider = "google/gemini"
+            except BudgetExceededError as exc:
+                budget_blocked = True
+                errors.append(f"google/gemini budget: {exc}")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"google/gemini: {exc}")
+
+        if image_bytes is None:
+            return GenerationResult(
+                success=False,
+                provider="none",
+                model="",
+                error="all scene engines failed: " + " | ".join(errors),
+                metadata={
+                    "scene_name": scene_name,
+                    "collection": collection,
+                    "budget_blocked": budget_blocked,
+                },
+            )
+
+        # Write image bytes (Gemini may return a base64 str; OAI returns bytes).
+        if isinstance(image_bytes, str):
+            image_bytes = base64.b64decode(image_bytes)
+        output_path.write_bytes(image_bytes)
+
+        return GenerationResult(
+            success=True,
+            provider=provider,
+            model=model_used,
+            output_path=str(output_path),
+            metadata={
+                "scene_name": scene_name,
+                "collection": collection,
+                "canon_lock_date": spec.get("canon_lock_date"),
+                "founder_directed": spec.get("founder_directed"),
+                "render_aspect": spec.get("render_aspect"),
+                "size": size if provider.startswith("openai") else None,
+                "cost_usd": cost_spent,
+            },
+        )
+
+    async def _dispatch_oai(
+        self, prompt: str, size: str, budget: RunBudget | None
+    ) -> tuple[bytes, str, float]:
+        """Generate a scene via OpenAI gpt-image-2. Raises on any failure.
+
+        Budget is ensured BEFORE the call and recorded only AFTER success, so a
+        failed call never spends. The blocking SDK call runs off the event loop.
+        """
+        from scripts.oai_render import config as oai_config
+
+        if budget is not None:
+            budget.ensure_within_budget(_OAI_SCENE_COST_USD, stage="scene_generator_agent.oai")
+        image_bytes = await asyncio.to_thread(
+            self._oai_client().generate, prompt=prompt[:4000], size=size, background="opaque"
+        )
+        if budget is not None:
+            budget.spend(_OAI_SCENE_COST_USD, stage="scene_generator_agent.oai")
+        return image_bytes, oai_config.MODEL, _OAI_SCENE_COST_USD
+
+    def _oai_client(self) -> OAIImageClient:
+        """Lazily construct the gpt-image-2 client (validates OPENAI_API_KEY)."""
+        if self._oai is None:
+            from scripts.oai_render.client import OAIImageClient
+
+            self._oai = OAIImageClient()
+        return self._oai
+
+    async def _dispatch_gemini(
+        self, prompt: str, aspect_ratio: str, scene_name: str, budget: RunBudget | None
+    ) -> tuple[str | bytes, str, float]:
+        """Generate a scene via Gemini (fallback). Raises RuntimeError on failure.
+
+        Model fallback chain (2026-05-26): the primary Gemini image model's
+        safety filter rejects gothic/dark-fantasy content as "no image in
+        response"; gemini-2.5-flash-image has a looser profile. Try primary,
+        then 2.5. Gemini accepts only pure aspect ratios (e.g. "3:4").
+        """
+        if budget is not None:
+            budget.ensure_within_budget(
+                _GEMINI_SCENE_COST_USD, stage="scene_generator_agent.gemini"
+            )
+
         model_chain = [self.config.model]
         if "2.5-flash-image" not in self.config.model:
             model_chain.append("gemini-2.5-flash-image")
@@ -183,7 +289,7 @@ class SceneGeneratorAgent(BaseSuperAgent):
                     aspect_ratio=aspect_ratio,
                     mime_type="image/png",
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 last_error = f"raised on {model_id}: {exc}"
                 logger.warning("Gemini image generation raised on %s: %s", model_id, exc)
                 continue
@@ -192,52 +298,57 @@ class SceneGeneratorAgent(BaseSuperAgent):
             if result.get("success") and result.get("image_data"):
                 break
 
-            err_msg = result.get("error", "no image in response")
-            last_error = f"{model_id}: {err_msg}"
+            last_error = f"{model_id}: {result.get('error', 'no image in response')}"
             logger.warning(
                 "Scene %s rejected by %s (%s); trying next model in chain",
                 scene_name,
                 model_id,
-                err_msg[:120],
+                last_error[:120],
             )
 
         if not result or not result.get("success") or not result.get("image_data"):
-            return GenerationResult(
-                success=False,
-                provider="google/gemini",
-                model=model_used or self.config.model,
-                error=f"all models in fallback chain failed. last: {last_error}",
-                metadata={
-                    "scene_name": scene_name,
-                    "collection": collection,
-                    "model_chain_tried": model_chain,
-                },
-            )
+            raise RuntimeError(f"all Gemini models failed. last: {last_error}")
 
-        # Record spend AFTER successful API call.
         if budget is not None:
-            budget.spend(_SCENE_GENERATION_COST_USD, stage="scene_generator_agent.gemini")
+            budget.spend(_GEMINI_SCENE_COST_USD, stage="scene_generator_agent.gemini")
+        return result["image_data"], model_used, _GEMINI_SCENE_COST_USD
 
-        # Write image bytes.
-        image_bytes = result["image_data"]
-        if isinstance(image_bytes, str):
-            image_bytes = base64.b64decode(image_bytes)
-        output_path.write_bytes(image_bytes)
+    @staticmethod
+    def _aspect_to_size(raw_aspect: str) -> str:
+        """Map a scene.json ``render_aspect`` to a gpt-image-2 size string.
 
-        return GenerationResult(
-            success=True,
-            provider="google/gemini",
-            model=self.config.model,
-            output_path=str(output_path),
-            metadata={
-                "scene_name": scene_name,
-                "collection": collection,
-                "canon_lock_date": spec.get("canon_lock_date"),
-                "founder_directed": spec.get("founder_directed"),
-                "render_aspect": spec.get("render_aspect"),
-                "cost_usd": _SCENE_GENERATION_COST_USD,
-            },
-        )
+        gpt-image-2 accepts arbitrary ``WIDTHxHEIGHT`` with both dims divisible
+        by 16 and aspect within 1:3..3:1 (Context7-verified). Targets a 1536
+        long edge for quality. Falls back to ``1024x1536`` (portrait) when the
+        aspect can't be parsed.
+
+        ``"3:4 portrait"`` → ``"1152x1536"``; ``"1:1"`` → ``"1536x1536"``;
+        ``"16:9"`` → ``"1536x864"``.
+        """
+        token = raw_aspect.strip().split()[0] if raw_aspect and raw_aspect.strip() else ""
+        ratio: float | None = None
+        if ":" in token:
+            w_str, _, h_str = token.partition(":")
+            try:
+                w, h = float(w_str), float(h_str)
+                if w > 0 and h > 0:
+                    ratio = w / h
+            except ValueError:
+                ratio = None
+        if ratio is None:
+            return "1024x1536"
+        ratio = max(1 / 3, min(3.0, ratio))  # clamp to gpt-image-2 allowed band
+
+        long_edge = 1536
+
+        def _round16(value: float) -> int:
+            return max(256, int(round(value / 16)) * 16)
+
+        if ratio >= 1.0:  # landscape or square
+            width, height = long_edge, _round16(long_edge / ratio)
+        else:  # portrait
+            width, height = _round16(long_edge * ratio), long_edge
+        return f"{width}x{height}"
 
     @staticmethod
     def _collection_from_scene_name(scene_name: str) -> str:

--- a/skyyrose/elite_studio/tests/test_scene_generator_agent.py
+++ b/skyyrose/elite_studio/tests/test_scene_generator_agent.py
@@ -1,0 +1,101 @@
+"""SceneGeneratorAgent — OAI-primary / Gemini-fallback dispatch + size mapping.
+
+No real image API call is made: both engine dispatchers (and the root client)
+are mocked. Verifies the founder-locked engine order (gpt-image-2 primary,
+Gemini fallback), the gpt-image-2 size mapping, and graceful failure.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from skyyrose.elite_studio.agents import scene_generator_agent as sga
+from skyyrose.elite_studio.agents.scene_generator_agent import SceneGeneratorAgent
+
+_SPEC = {
+    "scene_description": "gothic cathedral at night",
+    "render_aspect": "3:4 portrait",
+    "expected_filename": "scene.png",
+}
+_SCENE = "black-rose-test-scene"
+
+
+def _patch_canon(monkeypatch) -> None:
+    """Make _SCENE canonical and return a fixed spec, so no scene.json is read."""
+    monkeypatch.setattr(sga, "SCENE_LOOKBOOK", {_SCENE: {}})
+    monkeypatch.setattr(sga, "load_lighting_spec", lambda collection, scene: dict(_SPEC))
+
+
+def test_aspect_to_size_native_and_fallback() -> None:
+    f = SceneGeneratorAgent._aspect_to_size
+    assert f("3:4 portrait") == "1152x1536"  # native 3:4, both dims /16
+    assert f("1:1") == "1536x1536"
+    assert f("16:9") == "1536x864"
+    assert f("garbage") == "1024x1536"  # unparseable → portrait default
+
+
+async def test_oai_primary_success(tmp_path, monkeypatch) -> None:
+    _patch_canon(monkeypatch)
+    agent = SceneGeneratorAgent()
+    oai = AsyncMock(return_value=(b"\x89PNG-oai", "gpt-image-2", 0.30))
+    gem = AsyncMock()
+    with (
+        patch.object(agent, "_dispatch_oai", oai),
+        patch.object(agent, "_dispatch_gemini", gem),
+    ):
+        result = await agent.generate_scene(_SCENE, output_dir=tmp_path)
+
+    assert result.success
+    assert result.provider == "openai/gpt-image-2"
+    assert result.metadata["size"] == "1152x1536"
+    gem.assert_not_called()  # primary succeeded → no fallback
+    assert (tmp_path / "scene.png").read_bytes() == b"\x89PNG-oai"
+
+
+async def test_falls_back_to_gemini_on_oai_failure(tmp_path, monkeypatch) -> None:
+    _patch_canon(monkeypatch)
+    agent = SceneGeneratorAgent()
+    oai = AsyncMock(side_effect=RuntimeError("no OPENAI_API_KEY"))
+    gem = AsyncMock(return_value=(b"GEM-bytes", "gemini-2.5-flash-image", 0.08))
+    with (
+        patch.object(agent, "_dispatch_oai", oai),
+        patch.object(agent, "_dispatch_gemini", gem),
+    ):
+        result = await agent.generate_scene(_SCENE, output_dir=tmp_path)
+
+    assert result.success
+    assert result.provider == "google/gemini"
+    oai.assert_awaited_once()
+    gem.assert_awaited_once()
+    assert (tmp_path / "scene.png").read_bytes() == b"GEM-bytes"
+
+
+async def test_both_engines_fail(tmp_path, monkeypatch) -> None:
+    _patch_canon(monkeypatch)
+    agent = SceneGeneratorAgent()
+    with (
+        patch.object(agent, "_dispatch_oai", AsyncMock(side_effect=RuntimeError("oai down"))),
+        patch.object(agent, "_dispatch_gemini", AsyncMock(side_effect=RuntimeError("gem down"))),
+    ):
+        result = await agent.generate_scene(_SCENE, output_dir=tmp_path)
+
+    assert not result.success
+    assert "oai down" in result.error
+    assert "gem down" in result.error
+
+
+async def test_dispatch_oai_calls_root_client(monkeypatch) -> None:
+    """_dispatch_oai routes through scripts/oai_render/client.OAIImageClient.generate."""
+    agent = SceneGeneratorAgent()
+    fake_client = MagicMock()
+    fake_client.generate.return_value = b"scene-png"
+    with patch("scripts.oai_render.client.OAIImageClient", return_value=fake_client):
+        out, model, cost = await agent._dispatch_oai("a gothic scene", "1152x1536", None)
+
+    assert out == b"scene-png"
+    assert model == "gpt-image-2"
+    assert cost == 0.30
+    fake_client.generate.assert_called_once()
+    kwargs = fake_client.generate.call_args.kwargs
+    assert kwargs["size"] == "1152x1536"
+    assert kwargs["background"] == "opaque"

--- a/tests/oai_render/test_client.py
+++ b/tests/oai_render/test_client.py
@@ -45,3 +45,29 @@ def test_edit_sends_input_fidelity_high(tmp_path: Path, monkeypatch: pytest.Monk
     assert kwargs["model"] == "gpt-image-2"
     assert kwargs["input_fidelity"] == "high"  # the fix: not omitted, not "low"
     assert config.INPUT_FIDELITY == "high"
+
+
+def test_generate_text_to_image_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    """generate() is text-to-image: no reference image, never sends response_format.
+
+    gpt-image models reject ``response_format`` (Context7-verified) and always
+    return base64 — this locks the call shape so the scene path can't regress.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-abc")
+    client = OAIImageClient()
+    fake_sdk = MagicMock()
+    fake_sdk.images.generate.return_value = MagicMock(
+        data=[MagicMock(b64_json=base64.b64encode(b"scene-bytes").decode())]
+    )
+    client._client = fake_sdk
+
+    out = client.generate(prompt="gothic cathedral at night", size="1152x1536")
+
+    assert out == b"scene-bytes"
+    fake_sdk.images.generate.assert_called_once()
+    kwargs = fake_sdk.images.generate.call_args.kwargs
+    assert kwargs["model"] == "gpt-image-2"
+    assert kwargs["size"] == "1152x1536"
+    assert kwargs["background"] == "opaque"  # scenes are full backdrops
+    assert "response_format" not in kwargs  # rejected by gpt-image models
+    assert "image" not in kwargs  # text-to-image: no reference


### PR DESCRIPTION
Wires the elite team's Stage-1 scene generator to the founder-locked imagery engine.

## Why
`skyyrose/elite_studio/agents/scene_generator_agent.py` dispatched **only** to Gemini (nano-banana), contradicting the locked policy *imagery engine = OpenAI Image 2; erase nano-banana/Gemini* (2026-06-08).

## Changes
**`scripts/oai_render/client.py`** — add a hardened text-to-image `generate()` (no reference image) alongside the existing reference-guided `edit()`. Both now share retry/backoff via a new `_run_with_retry` helper. `generate()` never sends `response_format` — Context7-verified (openai-python `image_generate_params.py`, 2026-06-24) that gpt-image models reject it and always return base64. (Note: `generator_agent.py` still passes `response_format="b64_json"` on its own untested path — flagged, out of scope here.)

**`scene_generator_agent.py`**
- **OpenAI gpt-image-2 primary**, Gemini **fallback** — retained until OAI scene renders are validated (the locked policy erases Gemini *after* validation, not before).
- Per-engine budget: `ensure_within_budget` before each paid call, `spend` only after success.
- `_aspect_to_size` maps `scene.json` `render_aspect` to a gpt-image-2 `WIDTHxHEIGHT` (arbitrary, both ÷16, aspect 1:3..3:1) — native **3:4 → 1152x1536** (Gemini-parity on aspect).
- Reuses the canonical root client (`scripts/oai_render`) — no new OAI call site; consolidation-aligned.

## Safety
Paid scene generation stays behind the existing `RunBudget` gate (STOP-AND-SHOW). No paid call made in this PR.

## Verification
- 20 tests pass: full `tests/oai_render/` suite (edit-path refactor non-regression) + new `generate()` contract test + new `test_scene_generator_agent.py` (OAI-primary, Gemini-fallback, both-fail, size-mapping, root-client wiring).
- `ruff` + `black` clean; `py_compile` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG6kqt4UojivQPWLXhzFgR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the stage-1 `SceneGeneratorAgent` to OpenAI `gpt-image-2` for scene generation with a Gemini fallback, aligning with the locked imagery engine policy. Adds a hardened text-to-image path in the shared OpenAI client and enforces per-engine budget checks.

- New Features
  - Primary engine: `gpt-image-2` via `scripts/oai_render/client.py` (`OAIImageClient`); Gemini used only as fallback until OAI is validated.
  - Budget gating per engine: `ensure_within_budget` before the call, `spend` after success.
  - New `OAIImageClient.generate()` for text-to-image. Shares retry/backoff via `_run_with_retry`, never sends `response_format`, decodes base64 to bytes.
  - `_aspect_to_size` maps `render_aspect` to `WIDTHxHEIGHT` (both ÷16, aspect 1:3..3:1). Native 3:4 → `1152x1536`.
  - Tests cover OAI-first, Gemini fallback, both-fail handling, size mapping, and the `generate()` contract.

<sup>Written for commit dac2a0ad178afb0e3ee2d12194d10d7255306a1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

