### PR TITLE
fix(agents)+feat(api): repair AgentResult base-class bug + wire /marketing/campaigns

### DIFF
--- a/agents/base_super_agent/agent.py
+++ b/agents/base_super_agent/agent.py
@@ -672,14 +672,16 @@ class EnhancedSuperAgent(BaseDevSkyyAgent):  # Implements ISuperAgent via duck t
             self._current_model_provider = provider_used
 
             return AgentResult(
+                agent_name=self.name,
+                agent_provider=self._active_provider,
+                content=routed_response.get("text", ""),
                 status=AgentStatus.COMPLETED,
-                output=routed_response.get("text", ""),
-                usage=routed_response.get("usage", {}),
                 metadata={
                     "provider": provider_used,
                     "model": routed_response.get("model", self.config.model),
                     "routed": True,
                     "correlation_id": correlation_id,
+                    "usage": routed_response.get("usage", {}),
                 },
             )
         except Exception as e:
@@ -714,13 +716,12 @@ class EnhancedSuperAgent(BaseDevSkyyAgent):  # Implements ISuperAgent via duck t
             success = winner is not None and winner.response
 
             return AgentResult(
+                agent_name=self.name,
+                agent_provider=self._active_provider,
+                content=winner.response if winner else "",
                 status=AgentStatus.COMPLETED if success else AgentStatus.FAILED,
-                output=winner.response if winner else "",
-                usage={
-                    "cost_usd": winner.cost_usd if winner else 0.0,
-                    "latency_ms": winner.latency_ms if winner else 0.0,
-                    "round_table_entries": len(round_table_result.entries),
-                },
+                cost_usd=winner.cost_usd if winner else 0.0,
+                latency_ms=winner.latency_ms if winner else 0.0,
                 metadata={
                     "round_table": True,
                     "task_id": round_table_result.task_id,
@@ -728,6 +729,7 @@ class EnhancedSuperAgent(BaseDevSkyyAgent):  # Implements ISuperAgent via duck t
                     "winner_score": winner.total_score if winner else 0.0,
                     "judge_reasoning": round_table_result.judge_reasoning,
                     "correlation_id": correlation_id,
+                    "round_table_entries": len(round_table_result.entries),
                 },
             )
         except Exception as e:
@@ -793,15 +795,17 @@ class EnhancedSuperAgent(BaseDevSkyyAgent):  # Implements ISuperAgent via duck t
 
                 # Build result from routed response
                 result = AgentResult(
+                    agent_name=self.name,
+                    agent_provider=self._active_provider,
+                    content=routed_response.get("text", ""),
                     status=AgentStatus.COMPLETED,
-                    output=routed_response.get("text", ""),
-                    usage=routed_response.get("usage", {}),
                     metadata={
                         "provider": provider_used,
                         "model": routed_response.get("model", self.config.model),
                         "routed": True,
                         "task_category": task_category.value,
                         "technique": technique.value,
+                        "usage": routed_response.get("usage", {}),
                     },
                 )
             except Exception as e:
@@ -985,13 +989,12 @@ class EnhancedSuperAgent(BaseDevSkyyAgent):  # Implements ISuperAgent via duck t
 
             # Build result from winner
             result = AgentResult(
+                agent_name=self.name,
+                agent_provider=self._active_provider,
+                content=winner.response if winner else "",
                 status=AgentStatus.COMPLETED if success else AgentStatus.FAILED,
-                output=winner.response if winner else "",
-                usage={
-                    "cost_usd": winner.cost_usd if winner else 0.0,
-                    "latency_ms": winner.latency_ms if winner else 0.0,
-                    "round_table_entries": len(round_table_result.entries),
-                },
+                cost_usd=winner.cost_usd if winner else 0.0,
+                latency_ms=latency_ms,
                 metadata={
                     "round_table": True,
                     "task_id": round_table_result.task_id,
@@ -1000,6 +1003,7 @@ class EnhancedSuperAgent(BaseDevSkyyAgent):  # Implements ISuperAgent via duck t
                     "judge_reasoning": round_table_result.judge_reasoning,
                     "technique": technique.value,
                     "task_category": task_category.value,
+                    "round_table_entries": len(round_table_result.entries),
                 },
             )
 

--- a/api/v1/marketing.py
+++ b/api/v1/marketing.py
@@ -15,6 +15,8 @@ from uuid import uuid4
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from adk.base import AgentStatus
+from agents.marketing_agent import MarketingAgent
 from security.jwt_oauth2_auth import TokenPayload, get_current_user
 
 # Configure logging
@@ -59,16 +61,6 @@ class MarketingCampaignRequest(BaseModel):
     )
 
 
-class CampaignMetrics(BaseModel):
-    """Predicted campaign performance metrics."""
-
-    estimated_reach: int
-    estimated_engagement_rate: float
-    estimated_conversion_rate: float
-    estimated_revenue: float | None = None
-    confidence_score: float
-
-
 class MarketingCampaignResponse(BaseModel):
     """Response model for marketing campaigns."""
 
@@ -76,10 +68,41 @@ class MarketingCampaignResponse(BaseModel):
     status: str
     timestamp: str
     campaign_type: str
-    target_audience_size: int
+    channels: list[str]
     content_generated: bool
     scheduled_for: str | None = None
-    metrics: CampaignMetrics
+    campaign_content: str
+    metadata: dict[str, Any] | None = None
+
+
+_CHANNELS_BY_TYPE: dict[str, list[str]] = {
+    "email": ["email"],
+    "sms": ["sms"],
+    "social": ["instagram", "facebook", "tiktok"],
+    "multi_channel": ["instagram", "email", "sms", "website"],
+}
+
+
+def _channels_for_campaign(campaign_type: str) -> list[str]:
+    """Map a campaign type to the channels the agent should plan for."""
+    return _CHANNELS_BY_TYPE.get(campaign_type, ["instagram", "email", "website"])
+
+
+def _build_campaign_brief(request: MarketingCampaignRequest) -> str:
+    """Compose a natural-language brief for the marketing agent from the request."""
+    parts = [
+        f"Create a {request.campaign_type} marketing campaign for SkyyRose.",
+        f"Target audience: {request.target_audience}.",
+    ]
+    if request.content_template:
+        parts.append(f"Content direction: {request.content_template}")
+    if request.budget is not None:
+        parts.append(f"Budget: ${request.budget:.2f} USD.")
+    if request.schedule:
+        parts.append(f"Scheduled for: {request.schedule}.")
+    if request.ab_test:
+        parts.append("Include an A/B test plan.")
+    return " ".join(parts)
 
 
 # =============================================================================
@@ -133,67 +156,40 @@ async def create_campaign(
     """
     campaign_id = str(uuid4())
     logger.info(
-        f"Creating marketing campaign {campaign_id} for user {user.sub}: {request.campaign_type}"
+        "Creating marketing campaign %s for user %s: %s",
+        campaign_id,
+        user.sub,
+        request.campaign_type,
     )
 
+    channels = _channels_for_campaign(request.campaign_type)
+    brief = _build_campaign_brief(request)
+
     try:
-        # TODO: Integrate with agents/marketing_agent.py MarketingAgent
-        # For now, return mock data demonstrating the structure
-
-        # Calculate target audience size based on criteria
-        audience_size = 2500  # Mock value
-
-        # Generate AI content if not provided
-        content_generated = request.content_template is None
-
-        # Calculate predicted metrics
-        if request.campaign_type == "email":
-            metrics = CampaignMetrics(
-                estimated_reach=audience_size,
-                estimated_engagement_rate=0.28,
-                estimated_conversion_rate=0.045,
-                estimated_revenue=5625.0,
-                confidence_score=0.82,
-            )
-        elif request.campaign_type == "sms":
-            metrics = CampaignMetrics(
-                estimated_reach=int(audience_size * 0.95),
-                estimated_engagement_rate=0.42,
-                estimated_conversion_rate=0.08,
-                estimated_revenue=9500.0,
-                confidence_score=0.88,
-            )
-        elif request.campaign_type == "social":
-            metrics = CampaignMetrics(
-                estimated_reach=int(audience_size * 3.5),
-                estimated_engagement_rate=0.15,
-                estimated_conversion_rate=0.02,
-                estimated_revenue=3500.0,
-                confidence_score=0.75,
-            )
-        else:  # multi_channel
-            metrics = CampaignMetrics(
-                estimated_reach=int(audience_size * 4.2),
-                estimated_engagement_rate=0.35,
-                estimated_conversion_rate=0.065,
-                estimated_revenue=15750.0,
-                confidence_score=0.85,
-            )
-
-        return MarketingCampaignResponse(
-            campaign_id=campaign_id,
-            status="scheduled" if request.schedule else "draft",
-            timestamp=datetime.now(UTC).isoformat(),
-            campaign_type=request.campaign_type,
-            target_audience_size=audience_size,
-            content_generated=content_generated,
-            scheduled_for=request.schedule,
-            metrics=metrics,
-        )
-
+        agent = MarketingAgent()
+        result = await agent.create_campaign(brief, channels)
     except Exception as e:
-        logger.error(f"Marketing campaign creation failed: {e}", exc_info=True)
+        logger.exception("Marketing campaign creation failed for %s", campaign_id)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Marketing campaign creation failed: {str(e)}",
+            detail="Marketing campaign creation failed",
+        ) from e
+
+    if result.status == AgentStatus.FAILED:
+        logger.error("Marketing agent failed for %s: %s", campaign_id, result.error)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Marketing agent could not generate the campaign",
         )
+
+    return MarketingCampaignResponse(
+        campaign_id=campaign_id,
+        status="scheduled" if request.schedule else "draft",
+        timestamp=datetime.now(UTC).isoformat(),
+        campaign_type=request.campaign_type,
+        channels=channels,
+        content_generated=request.content_template is None,
+        scheduled_for=request.schedule,
+        campaign_content=result.content,
+        metadata=result.metadata,
+    )

--- a/tests/agents/test_base_super_agent_result.py
+++ b/tests/agents/test_base_super_agent_result.py
@@ -1,0 +1,75 @@
+"""Regression tests for AgentResult construction in EnhancedSuperAgent.
+
+Locks the fix for the field-name bug (claude-mem obs 17791): the base agent
+constructed ``AgentResult(output=..., usage=...)`` — both are non-fields — while
+omitting the required ``content`` / ``agent_name`` / ``agent_provider``. That
+raised ``ValidationError`` at runtime, which was swallowed by a surrounding
+``try/except`` and silently fell back to basic ``execute()``. As a result the
+router and round-table optimization paths computed a result and then threw it
+away on every call. These tests prove the router-internal path now returns a
+valid, content-bearing :class:`AgentResult`.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from adk.base import ADKProvider, AgentResult, AgentStatus
+from agents.base_super_agent.types import TaskCategory
+from agents.marketing_agent import MarketingAgent
+
+
+def test_agentresult_contract_requires_content_not_output() -> None:
+    """The corrected kwargs build a valid result; the old buggy kwargs cannot."""
+    result = AgentResult(
+        agent_name="marketing_agent",
+        agent_provider=ADKProvider.PYDANTIC,
+        content="hello",
+        status=AgentStatus.COMPLETED,
+    )
+    assert result.content == "hello"
+
+    # The pre-fix construction: ``output=`` is not a field, and the required
+    # ``content`` / ``agent_name`` / ``agent_provider`` are missing.
+    with pytest.raises(ValidationError):
+        AgentResult(status=AgentStatus.COMPLETED, output="hello")
+
+
+@pytest.mark.asyncio
+async def test_router_internal_returns_content_bearing_result(monkeypatch) -> None:
+    """The router path returns a real content-bearing result, not a fallback."""
+    agent = MarketingAgent()
+
+    async def fake_route(prompt, task_category=None, **kwargs):
+        return {
+            "text": "ROUTED_OUTPUT",
+            "provider": "openai",
+            "model": "gpt-x",
+            "usage": {"total_tokens": 5},
+        }
+
+    monkeypatch.setattr(agent, "_route_to_provider", fake_route)
+
+    # If AgentResult construction still raised, the except clause would fall back
+    # to execute(); make that failure mode loud instead of silent.
+    async def fail_if_fallback(*args, **kwargs):
+        raise AssertionError("fell back to execute() — AgentResult construction still broken")
+
+    monkeypatch.setattr(agent, "execute", fail_if_fallback)
+
+    enhanced = SimpleNamespace(enhanced_prompt="launch the drop")
+    result = await agent._execute_with_router_internal(
+        enhanced,
+        task_type="campaign",
+        task_category=TaskCategory.GENERATION,
+        correlation_id="corr-1",
+    )
+
+    assert isinstance(result, AgentResult)
+    assert result.content == "ROUTED_OUTPUT"
+    assert result.agent_name == agent.name
+    assert result.agent_provider == agent._active_provider
+    assert result.status == AgentStatus.COMPLETED
+    # usage data is preserved (folded into metadata, not dropped).
+    assert result.metadata["usage"] == {"total_tokens": 5}

--- a/tests/api/test_marketing_campaigns.py
+++ b/tests/api/test_marketing_campaigns.py
@@ -1,0 +1,107 @@
+"""Tests for the marketing campaigns endpoint (``api/v1/marketing.py``).
+
+Verifies the endpoint is wired to :class:`MarketingAgent` and returns the real
+generated campaign content. The prior implementation returned hardcoded mock
+metrics (``estimated_revenue=5625.0`` etc.); these tests lock in the real wiring
+and that no fabricated metrics remain in the response.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from adk.base import ADKProvider, AgentResult, AgentStatus
+from api.v1 import marketing as marketing_module
+from api.v1.marketing import router
+
+
+@pytest.fixture
+def mock_user():
+    """An authenticated user payload for the dependency override."""
+    from security.jwt_oauth2_auth import TokenPayload, TokenType
+
+    return TokenPayload(
+        sub="user_123",
+        jti="jti_123",
+        type=TokenType.ACCESS,
+        roles=["user"],
+        exp=datetime.now(UTC),
+        iat=datetime.now(UTC),
+    )
+
+
+def _make_client(mock_user, agent_cls, monkeypatch) -> TestClient:
+    from security.jwt_oauth2_auth import get_current_user
+
+    # Replace the real agent so the endpoint never constructs the heavy agent
+    # or makes a live LLM call during the test.
+    monkeypatch.setattr(marketing_module, "MarketingAgent", agent_cls)
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    return TestClient(app)
+
+
+def test_create_campaign_returns_real_agent_content(mock_user, monkeypatch):
+    captured: dict = {}
+
+    class _StubAgent:
+        name = "marketing_agent"
+
+        async def create_campaign(self, brief, channels):
+            captured["brief"] = brief
+            captured["channels"] = channels
+            return AgentResult(
+                agent_name="marketing_agent",
+                agent_provider=ADKProvider.PYDANTIC,
+                content="CONCEPT: bold drop. CALENDAR: 2 weeks. HASHTAGS: #SkyyRose",
+                status=AgentStatus.COMPLETED,
+                metadata={"task_type": "campaign"},
+            )
+
+    client = _make_client(mock_user, _StubAgent, monkeypatch)
+    resp = client.post(
+        "/marketing/campaigns",
+        json={
+            "campaign_type": "social",
+            "target_audience": {"segment": "high_value"},
+            "budget": 5000,
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["campaign_content"] == "CONCEPT: bold drop. CALENDAR: 2 weeks. HASHTAGS: #SkyyRose"
+    assert body["campaign_type"] == "social"
+    assert body["channels"] == ["instagram", "facebook", "tiktok"]
+    assert body["metadata"] == {"task_type": "campaign"}
+    # Fabricated metrics are gone from the response contract.
+    assert "metrics" not in body
+    # The brief handed to the agent reflects the request inputs.
+    assert "social" in captured["brief"]
+    assert "5000.00" in captured["brief"]
+    assert captured["channels"] == ["instagram", "facebook", "tiktok"]
+
+
+def test_create_campaign_agent_failure_returns_502(mock_user, monkeypatch):
+    class _FailingAgent:
+        name = "marketing_agent"
+
+        async def create_campaign(self, brief, channels):
+            return AgentResult(
+                agent_name="marketing_agent",
+                agent_provider=ADKProvider.PYDANTIC,
+                content="",
+                status=AgentStatus.FAILED,
+                error="llm unavailable",
+            )
+
+    client = _make_client(mock_user, _FailingAgent, monkeypatch)
+    resp = client.post(
+        "/marketing/campaigns",
+        json={"campaign_type": "email", "target_audience": {"segment": "all"}},
+    )
+    assert resp.status_code == 502, resp.text


### PR DESCRIPTION
Lane 1 (api/v1 agent wiring), starting with the prerequisite bug that blocked it.

## 1. fix: AgentResult built with wrong kwargs (3c5c01a8f)
`base_super_agent/agent.py` constructed `AgentResult(output=..., usage=...)` at 4
sites (router + round-table internal paths). Neither is a field; the required
`content`/`agent_name`/`agent_provider` were omitted -> pydantic `ValidationError`,
swallowed by the surrounding try/except -> silent fallback to basic `execute()`.
The intelligent-routing and round-table-judging paths computed a result then
discarded it on every call. Fixed to match the correct construction
(`marketing_agent.py:601`); usage payload folded into typed perf fields + metadata.
Regression test is **red-green verified**; agent + core suites green.

## 2. feat: wire /marketing/campaigns to MarketingAgent (d5abfe75a)
The endpoint returned hardcoded metrics (`estimated_revenue=5625.0`, fixed
`audience_size=2500`). It now calls `MarketingAgent.create_campaign` and returns
the real AI-generated campaign content. Response model reshaped (drop fabricated
`CampaignMetrics`; add `campaign_content` + `metadata`) — models used only in this
module, no consumers. Agent failure -> 502; unexpected -> generic 500.

## Verification
- `tests/agents/test_base_super_agent_result.py` (red-green proven)
- `tests/api/test_marketing_campaigns.py` (happy + 502; agent stubbed, no LLM)
- ruff + black clean on every touched file; agent + core suites green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a base-agent bug that broke routed and round-table results, and wires `/marketing/campaigns` to `MarketingAgent` to return real campaign content. Updates the response shape to be smaller and more accurate.

- **Bug Fixes**
  - Corrected `AgentResult` construction in router and round-table paths (now uses `content`/`agent_name`/`agent_provider`; usage moved to perf fields/metadata), restoring routed/round-table outputs.
  - Added a regression test to lock the fix.

- **New Features**
  - `/marketing/campaigns` now calls `MarketingAgent.create_campaign` and returns `campaign_content` plus `metadata`; response includes `channels` and drops fabricated mock metrics.
  - Builds a natural-language brief from the request and maps campaign type to channels; agent FAILED -> 502, unexpected -> 500.
  - Added endpoint tests for success and 502 paths.

<sup>Written for commit d5abfe75ab709d3bb72d8991c30a286b72240b0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

