### PR TITLE
feat(api): wire /commerce/pricing/optimize to CommerceAgent + catalog SOT

### DIFF
--- a/api/v1/commerce.py
+++ b/api/v1/commerce.py
@@ -17,8 +17,10 @@ from uuid import uuid4
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from agents.commerce_agent import CommerceAgent
 from core.task_status_store import TaskStatusStore, get_initialized_task_status_store
 from security.jwt_oauth2_auth import TokenPayload, get_current_user
+from skyyrose.core.catalog_loader import read_catalog_rows
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -92,7 +94,7 @@ class PriceOptimization(BaseModel):
     optimized_price: float
     price_change: float
     price_change_pct: float
-    estimated_revenue_impact: float
+    estimated_revenue_impact: float | None = None
     confidence: float
 
 
@@ -398,6 +400,27 @@ async def get_bulk_operation_status(
     )
 
 
+def _coerce_price(value: Any) -> float | None:
+    """Best-effort float coercion for a price; None if missing or not positive."""
+    if value is None or value == "":
+        return None
+    try:
+        price = float(value)
+    except (TypeError, ValueError):
+        return None
+    return price if price > 0 else None
+
+
+def _catalog_price_map() -> dict[str, float]:
+    """Map SKU -> current price from the canonical catalog CSV (the SOT)."""
+    prices: dict[str, float] = {}
+    for row in read_catalog_rows():
+        price = _coerce_price(row.get("price"))
+        if price is not None:
+            prices[row["sku"]] = price
+    return prices
+
+
 @router.post(
     "/pricing/optimize",
     response_model=DynamicPricingResponse,
@@ -439,54 +462,75 @@ async def optimize_pricing(
         f"{request.strategy} ({len(request.product_ids)} products)"
     )
 
+    price_by_sku = _catalog_price_map()
+
+    agent = CommerceAgent()
     try:
-        # TODO: Integrate with agents/commerce_agent.py CommerceAgent
-        # For now, return mock data demonstrating the structure
-
-        optimizations = []
-        total_revenue_impact = 0.0
-
-        for product_id in request.product_ids:
-            current_price = 89.99  # Mock current price
-            optimized_price = 79.99  # Mock optimized price
-            price_change = optimized_price - current_price
-            price_change_pct = (price_change / current_price) * 100
-            revenue_impact = 450.0  # Mock estimated impact
-
-            optimizations.append(
-                PriceOptimization(
-                    product_id=product_id,
-                    current_price=current_price,
-                    optimized_price=optimized_price,
-                    price_change=price_change,
-                    price_change_pct=price_change_pct,
-                    estimated_revenue_impact=revenue_impact,
-                    confidence=0.85,
-                )
-            )
-            total_revenue_impact += revenue_impact
-
-        aggregate_metrics = {
-            "total_revenue_impact": total_revenue_impact,
-            "avg_price_change_pct": -11.1,
-            "products_with_price_increase": 2,
-            "products_with_price_decrease": len(request.product_ids) - 2,
-            "estimated_conversion_lift": 0.15,
-        }
-
-        return DynamicPricingResponse(
-            optimization_id=optimization_id,
-            status="completed",
-            timestamp=datetime.now(UTC).isoformat(),
-            strategy=request.strategy,
-            total_products=len(request.product_ids),
-            optimizations=optimizations,
-            aggregate_metrics=aggregate_metrics,
-        )
-
+        await agent.initialize()
     except Exception as e:
-        logger.error(f"Price optimization failed: {e}", exc_info=True)
+        logger.exception("Pricing agent initialization failed for %s", optimization_id)
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Price optimization failed: {str(e)}",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Pricing engine is unavailable",
+        ) from e
+
+    optimizations: list[PriceOptimization] = []
+    skipped: list[dict[str, str]] = []
+
+    for product_id in request.product_ids:
+        current_price = price_by_sku.get(product_id)
+        if current_price is None:
+            skipped.append({"product_id": product_id, "reason": "not in catalog"})
+            continue
+
+        try:
+            result = await agent.optimize_price(product_id, factors=request.constraints)
+        except Exception:
+            logger.exception("optimize_price failed for %s", product_id)
+            skipped.append({"product_id": product_id, "reason": "optimization error"})
+            continue
+
+        optimized_price = _coerce_price(result.get("recommended_price"))
+        if optimized_price is None:
+            skipped.append(
+                {"product_id": product_id, "reason": result.get("error", "no recommendation")}
+            )
+            continue
+
+        price_change = optimized_price - current_price
+        price_change_pct = (price_change / current_price * 100.0) if current_price else 0.0
+        optimizations.append(
+            PriceOptimization(
+                product_id=product_id,
+                current_price=round(current_price, 2),
+                optimized_price=round(optimized_price, 2),
+                price_change=round(price_change, 2),
+                price_change_pct=round(price_change_pct, 2),
+                estimated_revenue_impact=None,
+                confidence=float(result.get("confidence") or 0.0),
+            )
         )
+
+    if not optimizations:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="No prices could be optimized (pricing model unavailable or unknown SKUs)",
+        )
+
+    avg_change = sum(o.price_change_pct for o in optimizations) / len(optimizations)
+    aggregate_metrics = {
+        "optimized_count": len(optimizations),
+        "skipped_count": len(skipped),
+        "skipped": skipped,
+        "avg_price_change_pct": round(avg_change, 2),
+    }
+
+    return DynamicPricingResponse(
+        optimization_id=optimization_id,
+        status="completed",
+        timestamp=datetime.now(UTC).isoformat(),
+        strategy=request.strategy,
+        total_products=len(request.product_ids),
+        optimizations=optimizations,
+        aggregate_metrics=aggregate_metrics,
+    )

--- a/tests/api/test_commerce_pricing.py
+++ b/tests/api/test_commerce_pricing.py
@@ -1,0 +1,112 @@
+"""Tests for the dynamic pricing endpoint (``api/v1/commerce.py``).
+
+Verifies ``/commerce/pricing/optimize`` is wired to ``CommerceAgent`` with the
+canonical catalog as the ``current_price`` source. The prior implementation
+returned hardcoded values (``current_price=89.99``, ``optimized_price=79.99``,
+``revenue_impact=450.0``). These tests lock the real wiring, the honest
+``estimated_revenue_impact=None`` (the agent does not model it), and the
+graceful skip / 503 paths when the pricing model is unavailable or a SKU is
+unknown.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.v1 import commerce as commerce_module
+from api.v1.commerce import router
+
+
+@pytest.fixture
+def mock_user():
+    from security.jwt_oauth2_auth import TokenPayload, TokenType
+
+    return TokenPayload(
+        sub="user_123",
+        jti="jti_123",
+        type=TokenType.ACCESS,
+        roles=["user"],
+        exp=datetime.now(UTC),
+        iat=datetime.now(UTC),
+    )
+
+
+def _make_client(mock_user, agent_cls, price_map, monkeypatch) -> TestClient:
+    from security.jwt_oauth2_auth import get_current_user
+
+    # Replace the real agent (no heavy initialize / no ml model) and pin the
+    # catalog price map so the test is independent of catalog data drift.
+    monkeypatch.setattr(commerce_module, "CommerceAgent", agent_cls)
+    monkeypatch.setattr(commerce_module, "_catalog_price_map", lambda: price_map)
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    return TestClient(app)
+
+
+def test_optimize_pricing_returns_real_optimization(mock_user, monkeypatch):
+    class _StubAgent:
+        async def initialize(self):
+            return None
+
+        async def optimize_price(self, sku, factors=None):
+            return {"sku": sku, "recommended_price": 30.0, "confidence": 0.9}
+
+    client = _make_client(mock_user, _StubAgent, {"br-001": 50.0}, monkeypatch)
+    resp = client.post(
+        "/commerce/pricing/optimize",
+        json={"product_ids": ["br-001"], "strategy": "ml_optimized"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total_products"] == 1
+    opt = body["optimizations"][0]
+    assert opt["product_id"] == "br-001"
+    assert opt["current_price"] == 50.0  # from the catalog SOT, not hardcoded
+    assert opt["optimized_price"] == 30.0  # from the agent
+    assert opt["price_change"] == -20.0
+    assert opt["price_change_pct"] == -40.0
+    assert opt["estimated_revenue_impact"] is None  # honest: agent does not model it
+    assert opt["confidence"] == 0.9
+
+
+def test_optimize_pricing_ml_unavailable_returns_503(mock_user, monkeypatch):
+    class _NoMLAgent:
+        async def initialize(self):
+            return None
+
+        async def optimize_price(self, sku, factors=None):
+            return {"sku": sku, "error": "ML module not available"}
+
+    client = _make_client(mock_user, _NoMLAgent, {"br-001": 50.0}, monkeypatch)
+    resp = client.post(
+        "/commerce/pricing/optimize",
+        json={"product_ids": ["br-001"]},
+    )
+    assert resp.status_code == 503, resp.text
+
+
+def test_optimize_pricing_skips_unknown_sku(mock_user, monkeypatch):
+    class _StubAgent:
+        async def initialize(self):
+            return None
+
+        async def optimize_price(self, sku, factors=None):
+            return {"recommended_price": 30.0, "confidence": 0.8}
+
+    client = _make_client(mock_user, _StubAgent, {"br-001": 50.0}, monkeypatch)
+    resp = client.post(
+        "/commerce/pricing/optimize",
+        json={"product_ids": ["zz-999", "br-001"]},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body["optimizations"]) == 1
+    assert body["optimizations"][0]["product_id"] == "br-001"
+    assert body["aggregate_metrics"]["skipped_count"] == 1
+    assert body["aggregate_metrics"]["skipped"][0]["product_id"] == "zz-999"


### PR DESCRIPTION
Lane 1 (api/v1 agent wiring), continued. Wires the dynamic-pricing endpoint.

`/commerce/pricing/optimize` returned hardcoded prices (`current=89.99`,
`optimized=79.99`, `revenue_impact=450.0`). Now:
- **current_price** from the canonical catalog CSV (`skyyrose.core.catalog_loader.read_catalog_rows`) — the SOT, not a guess.
- **optimized_price + confidence** from `CommerceAgent.optimize_price`, which needs `await agent.initialize()` to load the `ml_module` (a fresh agent has `ml_module=None`).
- **estimated_revenue_impact -> None** (Optional): the agent does not model revenue impact, so it's reported honestly instead of fabricated. Models used only in this module; no consumers, no frontend caller (verified).
- unknown SKU / no recommendation -> skipped (in `aggregate_metrics`); nothing optimizable or init failure -> **503**.
- `bulk_product_operations` (WooCommerce writes) intentionally left — STOP-AND-SHOW gated, not wired autonomously.

## Verification
- `tests/api/test_commerce_pricing.py`: happy path, ml-unavailable -> 503, unknown-sku skip (agent + catalog map stubbed; no ml, no live catalog dependency).
- ruff + black clean; `_catalog_price_map()` resolves 33 real SKUs (br-001=35.0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired `/commerce/pricing/optimize` to the real pricing engine and the catalog source of truth. The endpoint now returns catalog-backed current prices and model-recommended optimized prices, and removes fabricated revenue impact.

- **New Features**
  - Uses `CommerceAgent` (with `await agent.initialize()`) for `optimized_price` and `confidence`.
  - Reads `current_price` from the canonical catalog via `skyyrose.core.catalog_loader.read_catalog_rows` (`_catalog_price_map` with safe `_coerce_price`).
  - Sets `estimated_revenue_impact` to `None` (not modeled).
  - Skips unknown SKUs or no-recommendation cases; returns 503 if nothing can be optimized or agent init fails.
  - Returns lean aggregate metrics: `optimized_count`, `skipped_count`, `skipped`, and `avg_price_change_pct`.
  - Leaves `bulk_product_operations` unchanged (STOP-AND-SHOW gated).
  - Adds tests covering happy path, ML-unavailable (503), and unknown SKU skip.

<sup>Written for commit 8d9da55a02dd3d17119086577f825cc97d380c00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

