### PR TITLE
test(elite-studio): fix 5 stale tests (canon re-correction + FLUX routing + retired overrides dir)

### DIFF
--- a/skyyrose/elite_studio/tests/test_compositor_stage_d.py
+++ b/skyyrose/elite_studio/tests/test_compositor_stage_d.py
@@ -213,12 +213,15 @@ class TestCompositeWithFluxBudgetThreading:
     code-review CRITICAL where the dispatcher dropped budget on the floor.
     """
 
-    def test_primary_hit_passes_budget_to_fal(self) -> None:
+    def test_primary_hit_passes_budget_to_kontext(self) -> None:
+        # kontext is the PRIMARY provider (flux_methods order: kontext → fal-fill
+        # → replicate; promoted in da951f494 because kontext conditions on the
+        # relit garment reference). When it succeeds, fal-fill/replicate never run.
         agent = _agent()
         budget = RunBudget(ceiling_usd=1.0)
         with (
-            patch.object(agent, "_flux_fill_fal", return_value=_FAKE_PNG) as fal,
-            patch.object(agent, "_flux_kontext") as kontext,
+            patch.object(agent, "_flux_kontext", return_value=_FAKE_PNG) as kontext,
+            patch.object(agent, "_flux_fill_fal") as fal,
             patch.object(agent, "_flux_fill_replicate") as replicate,
         ):
             out, provider = agent._composite_with_flux(
@@ -228,10 +231,10 @@ class TestCompositeWithFluxBudgetThreading:
                 prompt=_PROMPT,
                 budget=budget,
             )
-        assert provider == "fal-fill"
+        assert provider == "kontext"
         assert out == _FAKE_PNG
-        fal.assert_called_once_with(_SCENE, _MASK, _PROMPT, budget=budget)
-        kontext.assert_not_called()
+        kontext.assert_called_once_with(_SCENE, _MASK, _REF, _PROMPT, budget=budget)
+        fal.assert_not_called()
         replicate.assert_not_called()
 
     def test_fallback_chain_threads_budget_through_all_providers(self) -> None:

--- a/skyyrose/elite_studio/tests/test_config.py
+++ b/skyyrose/elite_studio/tests/test_config.py
@@ -33,8 +33,17 @@ class TestConstants:
 
 
 class TestPaths:
-    def test_overrides_dir_exists(self):
-        assert config.OVERRIDES_DIR.exists()
+    def test_overrides_dir_is_optional_path(self):
+        """OVERRIDES_DIR points at the retired per-SKU prompt-override location.
+
+        The directory was intentionally removed (overrides retired 2026-04-25,
+        commit 292ccc027); the constant remains as an OPTIONAL enrichment path
+        that consumers (utils.get_override, skyyrose_production_studio) tolerate
+        when absent. So we assert the constant is correctly located, not that the
+        directory exists on disk.
+        """
+        assert hasattr(config.OVERRIDES_DIR, "is_dir")
+        assert str(config.OVERRIDES_DIR).replace("\\", "/").endswith("prompts/overrides")
 
     def test_source_dir_is_path(self):
         """SOURCE_DIR is a Path object pointing to the expected location."""

--- a/skyyrose/elite_studio/tests/test_logo_registry.py
+++ b/skyyrose/elite_studio/tests/test_logo_registry.py
@@ -44,10 +44,13 @@ def test_black_roses_stays_centralized(registry: LogoRegistry) -> None:
     assert entry.collection == "black_rose"
 
 
-def test_signature_red_rose_is_signature_collection(registry: LogoRegistry) -> None:
-    """red-roses-cloud-cluster was misclassified pre-v4; must be Signature."""
+def test_red_rose_is_dual_collection(registry: LogoRegistry) -> None:
+    """red-roses-cloud-cluster is DUAL-collection (founder re-confirmed 2026-05-27):
+    used on BOTH Signature (sg-009) AND Love Hurts (lh-003, lh-004 inside-hood).
+    The 2026-05-25 'Signature only' reclassification was reverted in the registry.
+    """
     entry = registry.get_logo("red-roses-cloud-cluster")
-    assert entry.collection == "signature"
+    assert entry.collection == "shared_signature_love_hurts"
 
 
 def test_heart_rose_is_love_hurts(registry: LogoRegistry) -> None:
@@ -121,19 +124,23 @@ def test_four_mlb_jerseys_exactly(registry: LogoRegistry) -> None:
     assert sorted(mlb_users) == ["br-003", "br-012", "br-014", "br-015"]
 
 
-def test_lh003_uses_heart_rose_not_red_rose(registry: LogoRegistry) -> None:
-    """v4 correction: lh-003 must not reference red-roses (Signature LOGO)."""
+def test_lh003_uses_red_rose_not_heart_rose(registry: LogoRegistry) -> None:
+    """Founder re-confirmed 2026-05-27: lh-003 uses red-roses-cloud-cluster
+    (all_over + mesh_panels), NOT heart-rose-composite. The 2026-05-25 switch to
+    heart-rose was itself wrong and was reverted in the registry."""
     placements = registry.placements_for("lh-003")
     logo_ids = [p["logo_id"] for p in placements]
-    assert "red-roses-cloud-cluster" not in logo_ids
-    assert logo_ids.count("heart-rose-composite") >= 2  # all_over + mesh_panels
+    assert "heart-rose-composite" not in logo_ids
+    assert logo_ids.count("red-roses-cloud-cluster") >= 2  # all_over + mesh_panels
 
 
-def test_lh004_uses_heart_rose_not_red_rose(registry: LogoRegistry) -> None:
+def test_lh004_uses_both_red_rose_and_heart_rose(registry: LogoRegistry) -> None:
+    """Founder re-confirmed 2026-05-27: lh-004 carries BOTH —
+    red-roses-cloud-cluster (inside_hood) AND heart-rose-composite (back_center)."""
     placements = registry.placements_for("lh-004")
     logo_ids = [p["logo_id"] for p in placements]
-    assert "red-roses-cloud-cluster" not in logo_ids
-    assert "heart-rose-composite" in logo_ids
+    assert "red-roses-cloud-cluster" in logo_ids  # inside_hood
+    assert "heart-rose-composite" in logo_ids  # back_center
 
 
 def test_sg009_uses_red_rose(registry: LogoRegistry) -> None:


### PR DESCRIPTION
Five `elite_studio` tests were failing on `main` because they encode expectations that were **deliberately changed** since the tests were written. Each fix is test-only — aligning the assertion to verified-correct current behavior. No production, canon-data, or config-constant changes.

## Fixes
| Test | Why stale | Verified against |
|---|---|---|
| `test_logo_registry` ×3 | Registry re-corrected to **founder canon** (2026-05-27, `90fee8ee4`): `red-roses-cloud-cluster` is dual-collection; lh-003 uses red-roses (not heart-rose); lh-004 carries **both** | Read `logo-registry.json` v5/v6 entries + changelog directly |
| `test_config::test_overrides_dir_exists` | `OVERRIDES_DIR` dir intentionally retired (`292ccc027`); **constant stays** (census: 5 live consumers) — only the existence-assert was stale | `git`/grep census of `OVERRIDES_DIR` |
| `test_compositor_stage_d::test_primary_hit` | FLUX order intentionally changed to `kontext → fal-fill → replicate` (`da951f494`) | `flux_methods.py:57-67` |

All 3 files: **44/44 pass**, ruff + black clean. All 5 predate and are disjoint from the scene-OAI change (`22245a934`).

## Flagged separately (NOT in this PR, NOT skipped)
2 `test_compositor_agent` failures are a **real CLIP bug**: `skyyrose/core/embeddings/config.py` pins `clip_revision=3d74acf9…`, which has **no `model.safetensors` on HF (HTTP 404)**, while `embeddings/clip.py:48` forces `use_safetensors=True`. Breaks core CLIP embeddings everywhere (CI included). Needs a founder decision (repin to a safetensors revision vs drop the flag) — tracked, not patched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG6kqt4UojivQPWLXhzFgR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 5 stale `elite_studio` tests to match current logo canon, optional `OVERRIDES_DIR` handling, and updated `FLUX` provider order. Test-only changes; no production, data, or config behavior changes.

- **Bug Fixes**
  - `test_logo_registry` ×3: red-roses-cloud-cluster is dual-collection; `lh-003` uses red-roses; `lh-004` uses both red-roses and heart-rose.
  - `test_config::test_overrides_dir_*`: treat `OVERRIDES_DIR` as an optional path; stop asserting the directory exists on disk.
  - `test_compositor_stage_d::test_primary_hit_*`: reflect `FLUX` routing now prefers `kontext` → `fal-fill` → `replicate`.

<sup>Written for commit c76586a5939a4249b146eff40df26af239321b04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

