### PR TITLE
test(embeddings): fix dtype-kwarg assertion for transformers 4.x

### DIFF
--- a/tests/core/embeddings/test_clip.py
+++ b/tests/core/embeddings/test_clip.py
@@ -11,6 +11,7 @@ import torch
 from skyyrose.core.embeddings import clip as clip_mod
 from skyyrose.core.embeddings.clip import ClipEncoder
 from skyyrose.core.embeddings.config import EmbeddingConfig
+from skyyrose.core.embeddings.device import dtype_load_kwargs
 from skyyrose.core.embeddings.errors import EmbedError
 
 
@@ -78,7 +79,11 @@ def test_load_passes_pinned_revision_safetensors_dtype(patched):
     assert model_call["revision"] == "3d74acf9a28c67741b2f4f2ea7635f0aaf6f0268"
     # CLIP ships only pytorch_model.bin at the pinned SHA -> cannot force safetensors.
     assert model_call["use_safetensors"] is False
-    assert model_call["dtype"] == torch.float32  # E-determinism (transformers 5 kwarg)
+    # E-determinism: the dtype kwarg is passed; its NAME is version-dependent
+    # ("dtype" on transformers >=5, "torch_dtype" on 4.x), so derive it from the
+    # same helper the loader uses instead of hardcoding the v5 name.
+    dtype_key = next(iter(dtype_load_kwargs(torch.float32)))
+    assert model_call[dtype_key] == torch.float32
     # Processor is pinned to the same revision.
     assert patched["proc"]["revision"] == "3d74acf9a28c67741b2f4f2ea7635f0aaf6f0268"
 

--- a/tests/core/embeddings/test_dino.py
+++ b/tests/core/embeddings/test_dino.py
@@ -9,6 +9,7 @@ from PIL import Image
 
 from skyyrose.core.embeddings import dino as dino_mod
 from skyyrose.core.embeddings.config import EmbeddingConfig
+from skyyrose.core.embeddings.device import dtype_load_kwargs
 from skyyrose.core.embeddings.dino import DinoEncoder
 
 
@@ -76,7 +77,8 @@ def test_load_passes_pinned_revision_safetensors_dtype(patched):
     enc.embed_image(_img())
     assert patched["model"]["revision"] == "f9e44c814b77203eaa57a6bdbbd535f21ede1415"
     assert patched["model"]["use_safetensors"] is True
-    assert patched["model"]["dtype"] == torch.float32
+    dtype_key = next(iter(dtype_load_kwargs(torch.float32)))
+    assert patched["model"][dtype_key] == torch.float32
     assert patched["proc"]["revision"] == "f9e44c814b77203eaa57a6bdbbd535f21ede1415"
 
 


### PR DESCRIPTION
The Phase 2 embeddings merge (#633) landed `tests/core/embeddings/test_clip.py` and `test_dino.py` with `test_load_passes_pinned_revision_safetensors_dtype` asserting the loader kwarg name **`dtype`** (transformers 5.x). The runtime here is **transformers 4.57.6**, where `device.dtype_load_kwargs` correctly emits **`torch_dtype`** — so the assertion hit `KeyError` and both tests were red on main.

Fix derives the expected key from the loader's own `dtype_load_kwargs` helper, so the assertion is correct on both transformers 4.x and 5.x. **Implementation unchanged** — this is a test-only version-skew fix.

## Verification
- `tests/core/embeddings/` → **54/54** (was 52/54)
- elite_studio embedding + facade tests → 23/23
- `test_compositor_agent` full-pipeline + checkpoint-resume → pass
- ruff + black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG6kqt4UojivQPWLXhzFgR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix embeddings tests to derive the dtype kwarg key from `dtype_load_kwargs` instead of hardcoding it, so they work with both `transformers` 4.x (`torch_dtype`) and 5.x (`dtype`). This removes the KeyError and restores all embeddings tests to passing; production code is unchanged.

<sup>Written for commit c092beb7217f3d7be1356a2690728483033fcb22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

