### PR TITLE
feat(api): wire /ml/predict to MLCapabilitiesModule (real models, honest fallback)

### DIFF
--- a/api/v1/ml.py
+++ b/api/v1/ml.py
@@ -7,7 +7,6 @@ This module provides endpoints for:
 Version: 1.0.0
 """
 
-import asyncio
 import logging
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -17,6 +16,9 @@ from uuid import uuid4
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from agents.base_super_agent.ml_module import MLCapabilitiesModule
+from agents.base_super_agent.types import MLPrediction as AgentMLPrediction
+from agents.base_super_agent.types import SuperAgentType
 from core.task_status_store import TaskStatusStore, get_initialized_task_status_store
 from security.jwt_oauth2_auth import TokenPayload, get_current_user
 
@@ -40,6 +42,21 @@ class MLModelType(StrEnum):
     DEMAND_FORECASTING = "demand_forecasting"
     DYNAMIC_PRICING = "dynamic_pricing"
     SENTIMENT_ANALYSIS = "sentiment_analysis"
+
+
+# MLCapabilitiesModule carries no version string of its own; this identifies the
+# wiring/adapter version surfaced in the response.
+_AGENT_ML_VERSION = "agent-ml-1"
+
+# Map each public MLModelType to the (agent type, internal model name) that the
+# MLCapabilitiesModule registry actually exposes. Exhaustive over MLModelType.
+_MODEL_TYPE_MAP: dict[str, tuple[SuperAgentType, str]] = {
+    MLModelType.TREND_PREDICTION.value: (SuperAgentType.MARKETING, "trend_predictor"),
+    MLModelType.CUSTOMER_SEGMENTATION.value: (SuperAgentType.ANALYTICS, "clusterer"),
+    MLModelType.DEMAND_FORECASTING.value: (SuperAgentType.COMMERCE, "demand_forecaster"),
+    MLModelType.DYNAMIC_PRICING.value: (SuperAgentType.COMMERCE, "price_optimizer"),
+    MLModelType.SENTIMENT_ANALYSIS.value: (SuperAgentType.MARKETING, "sentiment_analyzer"),
+}
 
 
 class MLPredictionRequest(BaseModel):
@@ -118,158 +135,109 @@ async def _run_ml_prediction_background(
             },
         )
 
-        # Simulate ML computation time
-        await asyncio.sleep(0.5)
-
-        # TODO: Integrate with agents/ml_module.py MLModule
-        # Generate mock predictions based on model type
-        predictions, metrics = _generate_mock_predictions(model_type)
+        predictions, metrics, pred_status = await _compute_prediction(model_type, data)
 
         await store.set_status(
             prediction_id,
             {
-                "status": "completed",
+                "status": pred_status,
                 "model_type": model_type,
-                "model_version": "v2.1.0",
+                "model_version": _AGENT_ML_VERSION,
                 "started_at": started_at,
                 "completed_at": datetime.now(UTC).isoformat(),
-                "predictions": predictions,
+                "predictions": [p.model_dump() for p in predictions],
                 "metrics": metrics,
             },
         )
-        logger.info(f"Background ML task completed: {prediction_id}")
+        logger.info("Background ML task %s: %s", pred_status, prediction_id)
 
-    except Exception as e:
-        logger.error(f"Background ML task failed: {prediction_id}: {e}", exc_info=True)
+    except HTTPException as e:
+        logger.warning("Background ML task unavailable %s: %s", prediction_id, e.detail)
         await store.set_status(
             prediction_id,
             {
                 "status": "failed",
-                "error": str(e),
+                "model_type": model_type,
+                "started_at": started_at,
                 "completed_at": datetime.now(UTC).isoformat(),
+                "error": str(e.detail),
+            },
+        )
+
+    except Exception as e:
+        logger.error("Background ML task failed: %s: %s", prediction_id, e, exc_info=True)
+        await store.set_status(
+            prediction_id,
+            {
+                "status": "failed",
+                "model_type": model_type,
+                "started_at": started_at,
+                "completed_at": datetime.now(UTC).isoformat(),
+                "error": str(e),
             },
         )
 
 
-def _generate_mock_predictions(model_type: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    """Generate mock predictions for demonstration."""
-    if model_type == "trend_prediction":
-        predictions = [
-            {
-                "label": "oversized_blazers",
-                "confidence": 0.85,
-                "value": "trending_up",
-                "metadata": {
-                    "growth_rate": 0.45,
-                    "time_to_peak": "2_months",
-                    "similar_trends": ["wide_leg_pants", "structured_outerwear"],
-                },
-            },
-            {
-                "label": "cargo_pants",
-                "confidence": 0.72,
-                "value": "stable",
-                "metadata": {
-                    "growth_rate": 0.05,
-                    "time_to_peak": "current",
-                    "similar_trends": ["utility_wear", "tactical_fashion"],
-                },
-            },
-        ]
-        metrics = {
-            "model_accuracy": 0.89,
-            "prediction_horizon_days": 90,
-            "data_sources": ["social_media", "search_trends", "sales_data"],
-        }
-    elif model_type == "customer_segmentation":
-        predictions = [
-            {
-                "label": "high_value_loyalists",
-                "confidence": 0.91,
-                "value": 125,
-                "metadata": {
-                    "avg_order_value": 450.0,
-                    "purchase_frequency": "monthly",
-                    "lifetime_value": 5400.0,
-                },
-            },
-            {
-                "label": "occasional_shoppers",
-                "confidence": 0.88,
-                "value": 380,
-                "metadata": {
-                    "avg_order_value": 120.0,
-                    "purchase_frequency": "quarterly",
-                    "lifetime_value": 720.0,
-                },
-            },
-        ]
-        metrics = {
-            "num_segments": 5,
-            "silhouette_score": 0.72,
-            "customers_analyzed": 10000,
-        }
-    elif model_type == "demand_forecasting":
-        predictions = [
-            {
-                "label": "forecast_7_days",
-                "confidence": 0.94,
-                "value": 145,
-                "metadata": {"lower_bound": 120, "upper_bound": 170},
-            },
-            {
-                "label": "forecast_30_days",
-                "confidence": 0.78,
-                "value": 580,
-                "metadata": {"lower_bound": 450, "upper_bound": 710},
-            },
-        ]
-        metrics = {
-            "model_type": "lstm",
-            "mae": 12.5,
-            "rmse": 18.3,
-            "historical_days": 180,
-        }
-    elif model_type == "dynamic_pricing":
-        predictions = [
-            {
-                "label": "optimal_price",
-                "confidence": 0.86,
-                "value": 79.99,
-                "metadata": {
-                    "current_price": 89.99,
-                    "price_change": -10.0,
-                    "expected_revenue_lift": 0.15,
-                },
-            },
-        ]
-        metrics = {
-            "competitor_prices": [75.0, 85.0, 92.0],
-            "demand_elasticity": -1.2,
-            "margin_maintained": 0.35,
-        }
-    else:  # sentiment_analysis
-        predictions = [
-            {
-                "label": "overall_sentiment",
-                "confidence": 0.92,
-                "value": "positive",
-                "metadata": {"polarity": 0.75, "subjectivity": 0.6},
-            },
-            {
-                "label": "aspect_quality",
-                "confidence": 0.88,
-                "value": "positive",
-                "metadata": {"mentions": 3, "polarity": 0.8},
-            },
-        ]
-        metrics = {
-            "model": "transformer",
-            "language": "en",
-            "text_length": 150,
-        }
+def _reshape_agent_result(
+    result: AgentMLPrediction, model_name: str
+) -> tuple[list[MLPrediction], dict[str, Any]]:
+    """Adapt the agent-layer MLPrediction dataclass into the API response shape.
 
-    return predictions, metrics
+    ``predict()`` never raises; it signals failure with ``prediction is None`` or
+    ``confidence == 0.0``. In that case return an empty prediction list so the
+    endpoint reports ``status="failed"`` honestly instead of fabricating output.
+    """
+    metrics: dict[str, Any] = {
+        "latency_ms": result.latency_ms,
+        "model_used": result.model_used,
+    }
+    if result.prediction is None or result.confidence == 0.0:
+        metrics["error"] = (result.metadata or {}).get("error", "prediction unavailable")
+        return [], metrics
+
+    # predict() returns model_used="none" on the not-found path (a truthy string),
+    # so fall back to the requested model_name only when it is that sentinel.
+    label = result.model_used if result.model_used != "none" else model_name
+    prediction = MLPrediction(
+        label=label,
+        confidence=result.confidence,
+        value=result.prediction,
+        metadata=result.metadata,
+    )
+    return [prediction], metrics
+
+
+async def _compute_prediction(
+    model_type: str, data: dict[str, Any]
+) -> tuple[list[MLPrediction], dict[str, Any], str]:
+    """Run a real ML prediction for ``model_type`` via MLCapabilitiesModule.
+
+    Returns ``(predictions, metrics, status)`` where status is ``"completed"`` or
+    ``"failed"`` (degraded/unfitted model). Raises ``HTTPException(503)`` when the
+    ML module cannot initialize or the model is not available for its agent type;
+    the sync endpoint surfaces that as 503 and the background task stores it as a
+    failed status.
+    """
+    agent_type, model_name = _MODEL_TYPE_MAP[model_type]
+    module = MLCapabilitiesModule(agent_type)
+    try:
+        await module.initialize()
+    except Exception as e:
+        logger.exception("ML module init failed for %s", model_type)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="ML module is unavailable",
+        ) from e
+
+    if model_name not in module.list_available_models():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Model for '{model_type}' is unavailable",
+        )
+
+    result = await module.predict(model_name, data)
+    predictions, metrics = _reshape_agent_result(result, model_name)
+    return predictions, metrics, "completed" if predictions else "failed"
 
 
 # =============================================================================
@@ -362,36 +330,19 @@ async def predict(
             metrics={"message": "Task running in background. Poll status endpoint for results."},
         )
 
-    try:
-        # Process synchronously for lighter models
-        predictions_data, metrics = _generate_mock_predictions(request.model_type.value)
+    predictions, metrics, pred_status = await _compute_prediction(
+        request.model_type.value, request.data
+    )
 
-        predictions = [
-            MLPrediction(
-                label=p["label"],
-                confidence=p["confidence"],
-                value=p["value"],
-                metadata=p.get("metadata"),
-            )
-            for p in predictions_data
-        ]
-
-        return MLPredictionResponse(
-            prediction_id=prediction_id,
-            status="completed",
-            timestamp=datetime.now(UTC).isoformat(),
-            model_type=request.model_type.value,
-            model_version="v2.1.0",
-            predictions=predictions,
-            metrics=metrics,
-        )
-
-    except Exception as e:
-        logger.error(f"ML prediction failed: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"ML prediction failed: {str(e)}",
-        )
+    return MLPredictionResponse(
+        prediction_id=prediction_id,
+        status=pred_status,
+        timestamp=datetime.now(UTC).isoformat(),
+        model_type=request.model_type.value,
+        model_version=_AGENT_ML_VERSION,
+        predictions=predictions,
+        metrics=metrics,
+    )
 
 
 @router.get(

--- a/tests/api/test_ml_predict.py
+++ b/tests/api/test_ml_predict.py
@@ -1,0 +1,162 @@
+"""Tests for POST /ml/predict (api/v1/ml.py) wired to MLCapabilitiesModule.
+
+The endpoint previously returned hardcoded mock predictions. These tests lock the
+real wiring: MLModelType -> (SuperAgentType, model_name) routing, the single->list
+reshape, honest status="failed" for degraded/unfitted models, and 503 for an
+unavailable model or a failed module init. The ML module is stubbed so no model
+loads and no HuggingFace download happens.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agents.base_super_agent.types import MLPrediction as AgentMLPrediction
+from agents.base_super_agent.types import SuperAgentType
+from api.v1 import ml as ml_module
+from api.v1.ml import router
+
+
+@pytest.fixture
+def mock_user():
+    from security.jwt_oauth2_auth import TokenPayload, TokenType
+
+    return TokenPayload(
+        sub="u1",
+        jti="j1",
+        type=TokenType.ACCESS,
+        roles=["user"],
+        exp=datetime.now(UTC),
+        iat=datetime.now(UTC),
+    )
+
+
+def _client(mock_user, module_cls, monkeypatch) -> TestClient:
+    from security.jwt_oauth2_auth import get_current_user
+
+    monkeypatch.setattr(ml_module, "MLCapabilitiesModule", module_cls)
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    return TestClient(app)
+
+
+def _ok_module(captured=None, available=None):
+    avail = (
+        available
+        if available is not None
+        else [
+            "trend_predictor",
+            "sentiment_analyzer",
+            "price_optimizer",
+            "demand_forecaster",
+            "clusterer",
+        ]
+    )
+
+    class _Mod:
+        def __init__(self, agent_type):
+            if captured is not None:
+                captured["agent_type"] = agent_type
+
+        async def initialize(self):
+            return None
+
+        def list_available_models(self):
+            return avail
+
+        async def predict(self, model_name, input_data, **kwargs):
+            if captured is not None:
+                captured["model_name"] = model_name
+            return AgentMLPrediction(
+                task=model_name,
+                prediction={"score": 0.9},
+                confidence=0.85,
+                model_used=model_name,
+                latency_ms=12.3,
+                metadata={},
+            )
+
+    return _Mod
+
+
+def test_sync_predict_success_and_routing(mock_user, monkeypatch):
+    captured = {}
+    client = _client(mock_user, _ok_module(captured), monkeypatch)
+    resp = client.post("/ml/predict", json={"model_type": "trend_prediction", "data": {"x": 1}})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "completed"
+    assert body["model_version"] == "agent-ml-1"
+    assert len(body["predictions"]) == 1
+    assert body["predictions"][0]["label"] == "trend_predictor"
+    assert body["predictions"][0]["value"] == {"score": 0.9}
+    assert body["predictions"][0]["confidence"] == 0.85
+    # routing: trend_prediction -> (MARKETING, trend_predictor)
+    assert captured["agent_type"] == SuperAgentType.MARKETING
+    assert captured["model_name"] == "trend_predictor"
+
+
+def test_sync_predict_degraded_returns_failed(mock_user, monkeypatch):
+    class _Mod:
+        def __init__(self, agent_type):
+            pass
+
+        async def initialize(self):
+            return None
+
+        def list_available_models(self):
+            return ["price_optimizer"]
+
+        async def predict(self, model_name, input_data, **kwargs):
+            return AgentMLPrediction(
+                task=model_name,
+                prediction=None,
+                confidence=0.0,
+                model_used=model_name,
+                latency_ms=1.0,
+                metadata={"error": "model not fitted"},
+            )
+
+    client = _client(mock_user, _Mod, monkeypatch)
+    resp = client.post("/ml/predict", json={"model_type": "dynamic_pricing", "data": {}})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "failed"
+    assert body["predictions"] == []
+    assert "error" in body["metrics"]
+
+
+def test_model_unavailable_returns_503(mock_user, monkeypatch):
+    client = _client(mock_user, _ok_module(available=[]), monkeypatch)
+    resp = client.post("/ml/predict", json={"model_type": "sentiment_analysis", "data": {}})
+    assert resp.status_code == 503, resp.text
+
+
+def test_init_failure_returns_503(mock_user, monkeypatch):
+    class _Mod:
+        def __init__(self, agent_type):
+            pass
+
+        async def initialize(self):
+            raise RuntimeError("no sklearn")
+
+        def list_available_models(self):
+            return []
+
+        async def predict(self, *args, **kwargs):
+            raise AssertionError("predict should not be reached after init failure")
+
+    client = _client(mock_user, _Mod, monkeypatch)
+    resp = client.post("/ml/predict", json={"model_type": "sentiment_analysis", "data": {}})
+    assert resp.status_code == 503, resp.text
+
+
+def test_invalid_model_type_returns_422(mock_user, monkeypatch):
+    client = _client(mock_user, _ok_module(), monkeypatch)
+    resp = client.post("/ml/predict", json={"model_type": "not_a_real_type", "data": {}})
+    assert resp.status_code == 422, resp.text


### PR DESCRIPTION
Lane 1 continued. Wires POST /ml/predict (sync + background paths) to the real ML module; removes _generate_mock_predictions entirely. Planned via a 7-agent investigate→synthesize→**adversarial-verify** workflow whose verdicts caught two must-fix bugs (below).

- `_MODEL_TYPE_MAP` routes each `MLModelType` → `(SuperAgentType, internal model_name)` — the endpoint taxonomy and the module's per-agent-type model registry don't match, so a mapping is required.
- construct `MLCapabilitiesModule(agent_type)` → `await initialize()` → `predict()` (mirrors the commerce wiring; `ml_module` only loads in `initialize()`, not `__init__`).
- single agent-layer `MLPrediction` dataclass adapted into the response list. Degraded/unfitted model (`predict()` returns `prediction=None`/`confidence=0.0` — it never raises) → `status="failed"` + empty predictions (**honest, not fabricated**). Module init failure or model-not-available-for-its-type → **503**. Invalid enum → 422 (Pydantic).

**Adversarial-review fixes (would have shipped broken otherwise):**
1. `model_version` is a required response field but the module has no version → would `ValidationError` on every call. Fixed with an `_AGENT_ML_VERSION` sentinel.
2. Background task stored `list[MLPrediction]` pydantic objects into the JSON task store → `TypeError`. Fixed: `.model_dump()` before store.

Known follow-on (out of scope, flagged): the sklearn/prophet models are untrained and per-model input adapters don't exist, so most types return `status="failed"` until a fit/ingest phase — but the endpoint no longer lies.

## Verification
- `tests/api/test_ml_predict.py`: success+routing, degraded→failed, model-unavailable→503, init-failure→503, invalid-type→422 (module stubbed; no model load / no HF download). **5/5 pass.**
- ruff + black clean; `_generate_mock_predictions` fully removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired POST /ml/predict to the real `MLCapabilitiesModule`, replacing mock data with actual model calls and honest failure handling. Adds routing, clear status semantics, and tests.

- New Features
  - Replaced `_generate_mock_predictions` with `MLCapabilitiesModule.initialize() -> predict()` in sync and background paths.
  - Added `_MODEL_TYPE_MAP` to route each `MLModelType` to `(SuperAgentType, model_name)`.
  - Adapted single agent `MLPrediction` into the API list; degraded/unfitted models return `status="failed"` with empty predictions.
  - Return 503 when the module fails to init or the model isn’t available; Pydantic still returns 422 for invalid types.
  - Tests added for routing, degraded→failed, model-unavailable→503, init-failure→503, and invalid-type→422.

- Bug Fixes
  - Provided `_AGENT_ML_VERSION` to populate the required `model_version` field.
  - Background task now stores serialized predictions via `.model_dump()` to avoid TypeError in the JSON task store.

<sup>Written for commit ede2526ccfc0506eab22a84a0056a973a3a9cccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

