### PR TITLE
feat(api): wire /hf-spaces/{id}/refresh to HfApi.restart_space

### DIFF
--- a/api/v1/hf_spaces.py
+++ b/api/v1/hf_spaces.py
@@ -9,6 +9,7 @@ Routes:
 - POST /api/v1/hf-spaces/{space_id}/refresh - Refresh Space
 """
 
+import asyncio
 import logging
 import os
 import time
@@ -17,6 +18,7 @@ from typing import Literal
 
 import aiohttp
 from fastapi import APIRouter, HTTPException
+from huggingface_hub import HfApi
 from prometheus_client import Counter, Gauge, Histogram
 from pydantic import BaseModel, Field
 
@@ -326,16 +328,28 @@ async def refresh_space(space_id: str):
                 detail="HuggingFace token not configured. Set HF_TOKEN environment variable.",
             )
 
-        # TODO: Implement Space refresh via HuggingFace API
-        # This requires using the HuggingFace Hub API to trigger a rebuild
-        # For now, return success message
+        # repo_id is the "owner/space" segment of the canonical Space URL.
+        repo_id = space["url"].split("/spaces/", 1)[-1]
+        try:
+            runtime = await asyncio.to_thread(HfApi().restart_space, repo_id, token=HF_TOKEN)
+        except Exception as e:
+            logger.error("HF restart_space failed for %s: %s", repo_id, e, exc_info=True)
+            raise HTTPException(
+                status_code=502,
+                detail="Failed to trigger Space rebuild on HuggingFace",
+            ) from e
 
-        logger.info(f"Refresh initiated for Space: {space['name']} ({space_id})")
+        stage = getattr(runtime, "stage", None)
+        logger.info(
+            "Refresh initiated for Space: %s (%s), stage=%s", space["name"], space_id, stage
+        )
 
         return {
             "message": f"Refresh initiated for Space: {space['name']}",
             "space_id": space_id,
+            "repo_id": repo_id,
             "url": space["url"],
+            "stage": str(stage) if stage is not None else None,
         }
 
     except HTTPException:

--- a/tests/api/test_hf_spaces_refresh.py
+++ b/tests/api/test_hf_spaces_refresh.py
@@ -1,0 +1,73 @@
+"""Tests for POST /hf-spaces/{space_id}/refresh (api/v1/hf_spaces.py).
+
+The endpoint previously returned a fake success without touching HuggingFace.
+These tests lock the real wiring to HfApi.restart_space: the repo_id derived from
+the Space URL, 404 for unknown space, 500 when HF_TOKEN is unset, and 502 when the
+HuggingFace API call fails. HfApi is stubbed so no real Space is restarted.
+"""
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.v1 import hf_spaces as hf_module
+from api.v1.hf_spaces import hf_spaces_router
+
+# A real Space id from DEVSKYY_SPACES (url: .../spaces/damBruh/skyyrose-3d-converter).
+SPACE_ID = "skyyrose-3d-converter"
+EXPECTED_REPO_ID = "damBruh/skyyrose-3d-converter"
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(hf_spaces_router)
+    return TestClient(app)
+
+
+def test_refresh_success_calls_restart_space(monkeypatch):
+    captured = {}
+
+    class _StubHfApi:
+        def restart_space(self, repo_id, token=None, factory_reboot=False):
+            captured["repo_id"] = repo_id
+            captured["token"] = token
+            return SimpleNamespace(stage="BUILDING")
+
+    monkeypatch.setattr(hf_module, "HF_TOKEN", "fake-token")
+    monkeypatch.setattr(hf_module, "HfApi", _StubHfApi)
+
+    resp = _client().post(f"/hf-spaces/{SPACE_ID}/refresh")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["space_id"] == SPACE_ID
+    assert body["repo_id"] == EXPECTED_REPO_ID
+    assert body["stage"] == "BUILDING"
+    # repo_id derived from the Space URL is what HF was actually asked to restart.
+    assert captured["repo_id"] == EXPECTED_REPO_ID
+    assert captured["token"] == "fake-token"
+
+
+def test_refresh_unknown_space_returns_404(monkeypatch):
+    monkeypatch.setattr(hf_module, "HF_TOKEN", "fake-token")
+    resp = _client().post("/hf-spaces/not-a-real-space/refresh")
+    assert resp.status_code == 404, resp.text
+
+
+def test_refresh_without_token_returns_500(monkeypatch):
+    monkeypatch.setattr(hf_module, "HF_TOKEN", None)
+    resp = _client().post(f"/hf-spaces/{SPACE_ID}/refresh")
+    assert resp.status_code == 500, resp.text
+
+
+def test_refresh_hf_failure_returns_502(monkeypatch):
+    class _FailingHfApi:
+        def restart_space(self, repo_id, token=None, factory_reboot=False):
+            raise RuntimeError("hub 500")
+
+    monkeypatch.setattr(hf_module, "HF_TOKEN", "fake-token")
+    monkeypatch.setattr(hf_module, "HfApi", _FailingHfApi)
+
+    resp = _client().post(f"/hf-spaces/{SPACE_ID}/refresh")
+    assert resp.status_code == 502, resp.text


### PR DESCRIPTION
Lane 1 continued. `POST /hf-spaces/{space_id}/refresh` returned a fake success message without ever calling HuggingFace. It now triggers a real Space rebuild.

- `huggingface_hub.HfApi().restart_space(repo_id, token=HF_TOKEN)` via `asyncio.to_thread` (the SDK is sync; keep it off the event loop). `repo_id` is derived from the canonical Space URL (`.../spaces/<owner>/<space>`).
- HF API failure -> **502**; unknown space -> 404; missing `HF_TOKEN` -> 500 (both unchanged). Response now includes the resolved `repo_id` + the runtime `stage`.
- Signature verified against the **installed** `huggingface_hub 1.19.0` (`inspect.signature`) + Context7.

## Verification
- `tests/api/test_hf_spaces_refresh.py`: success (asserts the derived repo_id + token passed to HF), 404 unknown space, 500 no-token, 502 HF failure. **4/4 pass.** HfApi stubbed — no real Space restarted.

## ⚠️ Note (pre-existing, not introduced here)
`refresh_space` has **no auth dependency** — like every endpoint in `hf_spaces.py`. It now performs a real production action (Space rebuild) gated only by `HF_TOKEN` presence. Worth adding `Depends(get_current_user)` to the write endpoints in this file as a follow-up; left out of this PR to avoid a contract change beyond the wiring task.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
POST /hf-spaces/{space_id}/refresh now triggers a real Hugging Face Space rebuild by calling `huggingface_hub.HfApi.restart_space` off the event loop. The response now includes the resolved `repo_id` and the runtime `stage`.

- **New Features**
  - Calls `HfApi.restart_space(repo_id, token=HF_TOKEN)` via `asyncio.to_thread`; `repo_id` is parsed from the Space URL; returns `repo_id` and `stage` in the body.
  - Error handling: 404 for unknown space, 500 when `HF_TOKEN` is missing, 502 on HF API failure. Tests cover success and all error paths.

<sup>Written for commit e3d0e5a0b139b7ee9cad6d6cbfeffa00f0f05b85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Space refresh action now actually triggers a Hugging Face Space restart/rebuild instead of returning a placeholder success response.
  * Refresh responses now include the resolved Space repository and rebuild stage.
  * Improved error handling for refresh failures, including clear responses for unknown Spaces, missing configuration, and Hugging Face API errors.
* **Tests**
  * Added coverage for successful refreshes and error cases to verify the new refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->