### PR TITLE
feat(evaluation): Phase 3 Track Q — gate() cost-cap + judge model/temperature pin

### DIFF
--- a/evaluation/budget.py
+++ b/evaluation/budget.py
@@ -1,0 +1,51 @@
+"""Cost budget + STOP-AND-SHOW ceiling for evaluation judge calls.
+
+``EvaluationCore.gate()`` runs a producer→judge→revise loop (up to ``cap``
+revisions) — used by the batch/calibration paths, not the single-shot live
+``evaluate()`` path. Before promoting ``gate()`` to production it needs a spend
+ceiling so a batch can never loop past a budget.
+
+``EvalBudget`` mirrors ``scripts/oai_render/cost.py`` ``SpendTracker`` but is kept
+local to ``evaluation/`` on purpose: the domain-agnostic QC package must not
+depend on the ``scripts/oai_render`` render domain (same decoupling rationale as
+``monitoring/fleet_observer.py``'s local ``AlertSeverity`` copy — a few lines is
+cheaper than an inverted dependency).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Conservative per-judge-call estimate for the pre-call budget guard. A verdict is
+# ~1.5k output tokens at Sonnet ($15/1M out) ≈ $0.03; rounded up for headroom. The
+# guard uses this ESTIMATE to block a call BEFORE it fires; ``add()`` records the
+# ACTUAL cost the judge returns afterward.
+DEFAULT_EST_JUDGE_COST_USD = 0.05
+
+
+class CostCapExceeded(RuntimeError):
+    """Raised before a paid judge call when it would exceed the budget ceiling."""
+
+
+@dataclass
+class EvalBudget:
+    """Runtime accumulator that hard-stops paid judge calls at a cap.
+
+    Check ``can_afford(next_est)`` BEFORE each judge call; ``add(actual)`` after it
+    fires. A single ``EvalBudget`` shared across a batch of ``gate()`` calls caps
+    the whole batch (the spec's "a batch over max_cost_usd is blocked before any
+    paid call").
+    """
+
+    cap_usd: float
+    spent_usd: float = 0.0
+
+    def can_afford(self, next_cost_usd: float) -> bool:
+        return (self.spent_usd + next_cost_usd) <= self.cap_usd
+
+    def add(self, cost_usd: float) -> None:
+        self.spent_usd = round(self.spent_usd + cost_usd, 6)
+
+    @property
+    def remaining_usd(self) -> float:
+        return max(0.0, round(self.cap_usd - self.spent_usd, 6))

--- a/evaluation/core.py
+++ b/evaluation/core.py
@@ -17,6 +17,7 @@ from dataclasses import replace
 from typing import Any
 
 from evaluation.adapter import DomainAdapter
+from evaluation.budget import DEFAULT_EST_JUDGE_COST_USD, CostCapExceeded, EvalBudget
 from evaluation.contracts import Verdict
 
 # wrap ClaudeJudge as: lambda req: judge.run(**req)
@@ -52,11 +53,28 @@ class EvaluationCore:
         ref: Any,
         producer: Callable[[Any], Awaitable[Any]],
         cap: int = 2,
+        *,
+        budget: EvalBudget | None = None,
+        est_call_cost_usd: float = DEFAULT_EST_JUDGE_COST_USD,
     ) -> Verdict:
+        """producer -> judge -> revise loop, capped at ``cap`` revisions.
+
+        When ``budget`` is supplied, the per-call estimate is checked BEFORE every
+        paid judge call (the initial score and each revision); if the next call
+        would exceed the cap, ``CostCapExceeded`` is raised before producing or
+        judging — so a batch never loops past its ceiling. Actual per-call cost is
+        accumulated into ``budget`` and reported as the returned verdict's
+        ``cost_usd`` (the loop total, not just the last call).
+        """
+        self._ensure_affordable(budget, est_call_cost_usd)
         subject = await producer(ref)
         verdict = await self.score(adapter, subject, ref)
+        total_cost = verdict.cost_usd
+        if budget is not None:
+            budget.add(verdict.cost_usd)
         attempts = 0
         while not verdict.passed and attempts < cap:
+            self._ensure_affordable(budget, est_call_cost_usd)
             attempts += 1
             critique = {
                 "failure_tags": verdict.failure_tags,
@@ -65,6 +83,19 @@ class EvaluationCore:
             }
             subject = await adapter.revise(ref, critique)
             verdict = await self.score(adapter, subject, ref)
+            total_cost += verdict.cost_usd
+            if budget is not None:
+                budget.add(verdict.cost_usd)
             if verdict.passed:
                 break
-        return replace(verdict, attempts=attempts)
+        return replace(verdict, attempts=attempts, cost_usd=total_cost)
+
+    @staticmethod
+    def _ensure_affordable(budget: EvalBudget | None, est_call_cost_usd: float) -> None:
+        """Raise ``CostCapExceeded`` before a paid judge call that would exceed the cap."""
+        if budget is not None and not budget.can_afford(est_call_cost_usd):
+            raise CostCapExceeded(
+                f"Eval budget exhausted: spent ${budget.spent_usd:.4f} of "
+                f"${budget.cap_usd:.4f}; next judge call (est ${est_call_cost_usd:.4f}) "
+                f"would exceed the cap. No paid call made."
+            )

--- a/evaluation/judge.py
+++ b/evaluation/judge.py
@@ -12,6 +12,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Default judge model: Sonnet, not Opus. Q-modelpin — a caller-supplied model with
+# no default risks an accidental Opus (5x cost). Sonnet is the calibrated QC judge.
+DEFAULT_JUDGE_MODEL = "claude-sonnet-4-6"
+
 # USD per 1M tokens (input, output). Keep in sync with model-routing doc.
 _PRICING: dict[str, tuple[float, float]] = {
     "claude-sonnet-4-6": (3.0, 15.0),
@@ -56,18 +60,21 @@ class ClaudeJudge:
     def __init__(
         self,
         client: Any,
-        model: str,
+        model: str = DEFAULT_JUDGE_MODEL,
         max_tokens: int = 1500,  # generous for a verdict JSON; bump if adapters request large free-text fields
+        temperature: float = 0.0,  # Q-modelpin — 0 = deterministic, reproducible verdicts
     ) -> None:
         self._client = client
         self._model = model
         self._max_tokens = max_tokens
+        self._temperature = temperature
 
     def run(self, *, messages: list[dict], tool: dict) -> tuple[dict, float]:
         """Force one call to `tool` and return (tool_input, cost_usd)."""
         resp = self._client.messages.create(
             model=self._model,
             max_tokens=self._max_tokens,
+            temperature=self._temperature,
             messages=messages,
             tools=[tool],
             tool_choice={"type": "tool", "name": tool["name"], "disable_parallel_tool_use": True},

--- a/tests/quality/test_eval_cost_cap.py
+++ b/tests/quality/test_eval_cost_cap.py
@@ -1,0 +1,140 @@
+"""EvaluationCore.gate() cost-cap (Q-costcap) — model-free.
+
+The discriminating assertion for "blocked before any paid call" is that the
+judge_fn call-count is 0 when the budget is exhausted: a raise that happens
+AFTER the call would still satisfy a naive ``pytest.raises`` check, so we assert
+the paid call never fired (mirrors the flux_lora ``mock_post.assert_not_called()``
+pattern). No Anthropic client, no network — judge_fn is a plain counter.
+"""
+
+import pytest
+
+from evaluation.budget import CostCapExceeded, EvalBudget
+from evaluation.contracts import Verdict
+from evaluation.core import EvaluationCore
+
+
+class _Adapter:
+    domain = "test"
+
+    def __init__(self, det, verdicts):
+        self._det = det
+        self._v = list(verdicts)
+        self.calls = 0
+
+    def deterministic_checks(self, subject, ref):
+        return list(self._det)
+
+    def build_judge_request(self, subject, ref):
+        return {"judge": True}
+
+    def parse_verdict(self, judge_output, det_failures):
+        v = self._v[min(self.calls, len(self._v) - 1)]
+        self.calls += 1
+        return v
+
+    async def revise(self, ref, critique):
+        return "revised"
+
+
+def _v(passed, cost=0.01):
+    return Verdict(
+        domain="test",
+        passed=passed,
+        score=1.0 if passed else 0.0,
+        gate_results={},
+        failure_tags=() if passed else ("x",),
+        reason="",
+        cost_usd=cost,
+    )
+
+
+class _CountingJudge:
+    """judge_fn that counts invocations so we can assert it was never called."""
+
+    def __init__(self, cost=0.01):
+        self.calls = 0
+        self._cost = cost
+
+    def __call__(self, request):
+        self.calls += 1
+        return ({"ok": True}, self._cost)
+
+
+async def _producer(ref):
+    return "subject"
+
+
+# ── EvalBudget unit ────────────────────────────────────────────────────────
+
+
+def test_budget_can_afford_and_accumulates():
+    b = EvalBudget(cap_usd=1.0)
+    assert b.can_afford(0.4) and b.remaining_usd == 1.0
+    b.add(0.4)
+    assert b.remaining_usd == pytest.approx(0.6)
+    b.add(0.4)
+    assert not b.can_afford(0.4)  # 0.8 + 0.4 > 1.0
+    assert b.remaining_usd == pytest.approx(0.2)
+
+
+# ── gate() cost-cap ────────────────────────────────────────────────────────
+
+
+async def test_gate_raises_before_any_paid_call_when_budget_exhausted():
+    judge = _CountingJudge()
+    core = EvaluationCore(judge_fn=judge)
+    ad = _Adapter(det=[], verdicts=[_v(True)])
+    budget = EvalBudget(cap_usd=0.0)  # cannot afford even one call
+
+    with pytest.raises(CostCapExceeded):
+        await core.gate(
+            ad, ref={}, producer=_producer, cap=2, budget=budget, est_call_cost_usd=0.05
+        )
+
+    assert judge.calls == 0  # the paid call never fired
+    assert ad.calls == 0  # producer/score never reached
+    assert budget.spent_usd == 0.0
+
+
+async def test_gate_stops_mid_loop_when_budget_runs_out():
+    # cap affords the initial call (est 0.05) but not a revision: after the initial
+    # call spends 0.01 actual, remaining 0.04 < est 0.05 -> the revision is blocked.
+    judge = _CountingJudge(cost=0.01)
+    core = EvaluationCore(judge_fn=judge)
+    ad = _Adapter(det=[], verdicts=[_v(False), _v(True)])
+    budget = EvalBudget(cap_usd=0.05)
+
+    with pytest.raises(CostCapExceeded):
+        await core.gate(
+            ad, ref={}, producer=_producer, cap=2, budget=budget, est_call_cost_usd=0.05
+        )
+
+    assert judge.calls == 1  # only the initial judge call fired; revision blocked pre-call
+    assert budget.spent_usd == pytest.approx(0.01)
+
+
+async def test_gate_without_budget_is_unbounded_back_compat():
+    judge = _CountingJudge()
+    core = EvaluationCore(judge_fn=judge)
+    ad = _Adapter(det=[], verdicts=[_v(False), _v(False), _v(False)])
+
+    v = await core.gate(ad, ref={}, producer=_producer, cap=2)  # budget=None
+
+    assert v.attempts == 2 and judge.calls == 3  # current behavior preserved
+
+
+async def test_gate_accumulates_total_cost_into_budget_and_verdict():
+    # score() sets verdict.cost_usd from the judge_fn's returned cost (not the
+    # adapter verdict), so 2 judge calls at 0.01 each accumulate to 0.02.
+    judge = _CountingJudge(cost=0.01)
+    core = EvaluationCore(judge_fn=judge)
+    ad = _Adapter(det=[], verdicts=[_v(False), _v(True)])
+    budget = EvalBudget(cap_usd=1.0)
+
+    v = await core.gate(ad, ref={}, producer=_producer, cap=2, budget=budget)
+
+    assert judge.calls == 2
+    assert budget.spent_usd == pytest.approx(0.02)  # 2 judge calls x 0.01 accumulated
+    assert v.cost_usd == pytest.approx(0.02)  # verdict reports the loop total
+    assert v.attempts == 1

--- a/tests/quality/test_eval_judge.py
+++ b/tests/quality/test_eval_judge.py
@@ -1,6 +1,6 @@
 import pytest
 
-from evaluation.judge import ClaudeJudge, anthropic_cost_usd, image_block
+from evaluation.judge import DEFAULT_JUDGE_MODEL, ClaudeJudge, anthropic_cost_usd, image_block
 
 
 class _Block:
@@ -60,6 +60,19 @@ def test_judge_returns_tool_input_and_cost():
         "name": "render_qc_verdict",
         "disable_parallel_tool_use": True,
     }
+
+
+def test_judge_pins_default_model_and_temperature_zero():
+    """Q-modelpin: model defaults to Sonnet (not Opus) + temperature=0 (deterministic)."""
+    client = _Client({"ok": True})
+    judge = ClaudeJudge(client=client)  # no model passed -> default
+    judge.run(
+        messages=[{"role": "user", "content": [{"type": "text", "text": "x"}]}],
+        tool={"name": "render_qc_verdict", "input_schema": {"type": "object"}},
+    )
+    sent = client.messages.calls[0]
+    assert sent["model"] == DEFAULT_JUDGE_MODEL == "claude-sonnet-4-6"
+    assert sent["temperature"] == 0.0
 
 
 def test_cost_formula():


### PR DESCRIPTION
Phase 3 **Track Q (eval safety)**: hardens `evaluation.gate()` before it's promoted to production.

**Framing (honest):** `gate()`'s producer→judge→revise loop is **not** on the live path today (the content agent uses single-shot `evaluate()`); `gate()` runs in batch/calibration. A single `gate()` call is ~$0.07 — the spec's "$15" was stale (assumed Opus/batch). This adds the budget ceiling + determinism so the loop is safe **when** promoted, not to stop a live leak.

## Changes
- **`evaluation/budget.py` (NEW)** — `EvalBudget(cap_usd, can_afford, add, remaining)` + `CostCapExceeded`. Kept local to `evaluation/` (no `scripts/oai_render` coupling — same house style as `monitoring/fleet_observer`'s local `AlertSeverity`).
- **`evaluation/core.gate()`** — optional `budget=` + `est_call_cost_usd=`. Checks `can_afford` **before every paid judge call** (initial + each revision) and raises `CostCapExceeded` before producing/judging when the next call would exceed the cap. Accumulates actual cost into the budget; reports the **loop total** as `verdict.cost_usd` (was last-call only). `budget=None` = unbounded (back-compat; existing 5 gate tests unchanged).
- **`evaluation/judge.ClaudeJudge`** — model defaults to `claude-sonnet-4-6` (not Opus) + `temperature=0` (reproducible verdicts; compatibility with forced `tool_choice` verified via Context7).

## Verification
- `tests/quality/` **69/69** (model-free). Discriminating test: budget-exhausted `gate()` raises with **judge_fn call-count 0** (no paid call), mirroring `flux_lora`'s `assert_not_called()`.
- ruff + black clean.

## Deferred — named, still-pending Track Q (NOT in this PR)
Q-unavail (HIGH — mandatory review queue on judge-unavailable), Q-mode (HIGH — wire `decide_mode` into the gate action), Q-data (HIGH — curated centroid allowlist), Q-fusion, Q-kappa; **Q-calib DEFER** (blocked on render rebuild). Track OBS (observability + PSI drift) ships as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG6kqt4UojivQPWLXhzFgR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hard cost cap to the evaluation `gate()` loop and pins the judge to `claude-sonnet-4-6` with `temperature=0` to prevent overspend and produce deterministic verdicts before promoting Track Q.

- **New Features**
  - New `EvalBudget` with `cap_usd`, `can_afford`, `add`, and `remaining_usd`; raises `CostCapExceeded` before any paid judge call that would exceed the cap.
  - `evaluation.core.gate()` accepts `budget` and `est_call_cost_usd`; checks affordability before the initial score and each revision, accumulates actual costs, and returns the loop total in `verdict.cost_usd`. `budget=None` keeps prior unbounded behavior.
  - `ClaudeJudge` defaults to model `claude-sonnet-4-6` and `temperature=0`, keeping costs reasonable and verdicts reproducible (compatible with forced `tool_choice`).

<sup>Written for commit b2c5ff61088414b0824b9a4741ff593bb1f86150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added budget-aware evaluation gating with a configurable cost cap.
  * Judge calls now track accumulated cost and can stop before exceeding budget.
  * Default judge settings now include a pinned model and zero-temperature output.

* **Bug Fixes**
  * Prevents paid evaluation calls from running once the budget is exhausted.
  * Keeps budget totals and returned verdict cost consistent across retries and revisions.

* **Tests**
  * Added coverage for budget limits, cost tracking, and default judge settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->