### PR TITLE
fix(deps): realign torch trio to 2.9.1 so [all] resolves — unbreak Docker build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,9 +227,14 @@ mcp = [
 ]
 
 ml = [
-    "torch==2.12.1",
+    # Keep the torch/torchvision/torchaudio trio version-consistent: torchvision
+    # 0.24.1 requires torch 2.9.1, so torch must stay 2.9.1 (and torchaudio 2.9.1).
+    # A Dependabot bump of torch alone (2.9.1 -> 2.12.1) made the [all] extra
+    # unresolvable and broke the Docker build; this is the locally-installed,
+    # test-validated set. Bump all three together (and re-validate) if upgrading.
+    "torch==2.9.1",
     "torchvision==0.24.1",
-    "torchaudio==2.11.0",
+    "torchaudio==2.9.1",
     "transformers>=4.53.0",
     "huggingface-hub>=0.27.0",
     "numpy>=2.1.3",


### PR DESCRIPTION
## What
Realign the `torch` trio so the `[all]` extra resolves and the **Docker Build** CI job passes again.

## Root cause
Dependabot bumped `torch` 2.9.1 → 2.12.1 **alone** (`17bac906a`) without co-bumping `torchvision`/`torchaudio`. `torchvision==0.24.1` requires `torch==2.9.1`, so `uv pip install ".[all]"` became unresolvable:
```
Because torchvision==0.24.1 depends on torch==2.9.1 and devskyy[all] depends on
torch==2.12.1, torchvision==0.24.1 and devskyy[all] are incompatible → [all] cannot be used.
```

## Fix
Pin the version-consistent, locally-installed, **test-validated** trio:
`torch==2.9.1` · `torchvision==0.24.1` · `torchaudio==2.9.1` (+ a comment to bump all three together next time).

## Verification
- `uv pip compile pyproject.toml --extra all` resolves cleanly with the new pins (no torch conflict).
- The trio is the exact set in `.venv` — the embeddings + elite_studio suites pass on it.
- The 2.12.1 pin provided no benefit: it was uninstallable.

## Scope
Test-only / deps-only; no source change. Unrelated to the embeddings work (PR #633/#634).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Realigns `torch`, `torchvision`, and `torchaudio` to compatible versions so `.[all]` resolves and the Docker build passes again. Fixes the mismatch introduced by a solo `torch` bump.

- **Dependencies**
  - Pin `torch==2.9.1`, `torchvision==0.24.1`, `torchaudio==2.9.1`.
  - Add a note to bump all three together on future upgrades.

<sup>Written for commit 27b5a8fb8f22ab0e7d621b7040c665ccfb90e3a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

