### PR TITLE
feat(observability): Phase 3 Track OBS — embedding encode telemetry + gate PSI-drift observer

### DIFF
--- a/core/token_tracker.py
+++ b/core/token_tracker.py
@@ -36,6 +36,7 @@ class TaskType(StrEnum):
     EXTRACT = "extract"
     TRANSLATE = "translate"
     CODE = "code"
+    EMBED = "embed"  # OBS-wire: server-side image/text embedding encode
 
 
 # Provider cost per 1M tokens (as of 2026-01-08)
@@ -61,6 +62,10 @@ PROVIDER_COSTS = {
     # Groq
     "llama-3.3-70b-versatile": {"input": 0.59, "output": 0.79},
     "mixtral-8x7b-32768": {"input": 0.24, "output": 0.24},
+    # Embeddings (local weights — no per-token API cost; listed so EMBED rows
+    # don't log a spurious unknown_model_cost warning on every encode).
+    "openai/clip-vit-base-patch32": {"input": 0.0, "output": 0.0},
+    "facebook/dinov2-base": {"input": 0.0, "output": 0.0},
 }
 
 
@@ -363,3 +368,45 @@ def record_llm_usage(
         )
     except Exception:  # noqa: BLE001 — telemetry must never break the call path
         logger.warning("record_llm_usage_failed", exc_info=True)
+
+
+def record_embedding_usage(
+    *,
+    model: str,
+    latency_ms: float = 0.0,
+    success: bool = True,
+    cache_hit: bool = False,
+    dim: int | None = None,
+    count: int = 1,
+    agent_id: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Record one embedding encode (or cache hit) into the global tracker.
+
+    OBS-wire: the embedding encode path emitted zero telemetry, so FleetObserver
+    was blind to its cost/latency/errors. One row per encode (``task_type=EMBED``)
+    with latency, cache-hit, success. Embeddings are token-free (local weights), so
+    token counts are 0 and cost resolves to 0. ``agent_id`` falls back to the
+    ``current_agent_id`` ContextVar. NEVER raises — telemetry must not break the
+    encode path.
+    """
+    try:
+        meta: dict[str, Any] = {"cache_hit": cache_hit, "count": count}
+        if dim is not None:
+            meta["dim"] = dim
+        get_token_tracker().record(
+            TokenUsage(
+                provider="embeddings",
+                model=model,
+                task_type=TaskType.EMBED,
+                agent_id=agent_id if agent_id is not None else current_agent_id.get(),
+                input_tokens=0,
+                output_tokens=0,
+                latency_ms=latency_ms,
+                success=success,
+                error=error,
+                metadata=meta,
+            )
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break the encode path
+        logger.warning("record_embedding_usage_failed", exc_info=True)

--- a/monitoring/embedding_observer.py
+++ b/monitoring/embedding_observer.py
@@ -1,0 +1,223 @@
+"""Embedding-gate observability + PSI drift — ALERT-ONLY, pure-read.
+
+Mirrors ``monitoring/fleet_observer.py``: ``evaluate()`` computes alerts and
+NEVER mutates the gate threshold, the PSI reference, or any other state. All
+remediation (recalibrating the centroid threshold) is human-initiated.
+
+The brand-centroid gate freezes its accept threshold at build time against the
+score distribution it was calibrated on. If the live cosine-score distribution
+drifts off that reference, the threshold silently stops meaning what it did.
+Population Stability Index (PSI) over the score distribution is the standard
+drift signal: <0.1 stable, 0.1-0.2 minor, >0.2 significant. We TICKET at
+PSI > 0.2 and PAGE at PSI > 0.25 — and only alert; we never auto-retune.
+
+``AlertSeverity`` is reused from ``fleet_observer`` (same package) rather than the
+``evaluation`` package's ``Severity``, keeping ``monitoring/`` free of a QC-package
+dependency — the same decoupling rationale documented in ``fleet_observer``.
+
+@package SkyyRose
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from monitoring.fleet_observer import AlertSeverity
+
+# Industry-standard PSI bands. Recalibration is human-initiated; these only route.
+PSI_TICKET = 0.2
+PSI_PAGE = 0.25
+# Laplace smoothing so an empty bucket can't drive a term to ±inf.
+_EPS = 1e-6
+_DEFAULT_BUCKETS = 10
+
+
+def _bucket_index(score: float, edges: tuple[float, ...]) -> int:
+    """Index of the half-open bucket [edges[i], edges[i+1]) holding ``score``.
+
+    Scores at or below the first edge land in bucket 0; at or above the last edge
+    in the final bucket — so out-of-range live scores are clamped, not dropped.
+    """
+    n = len(edges) - 1
+    if score <= edges[0]:
+        return 0
+    if score >= edges[-1]:
+        return n - 1
+    for i in range(n):
+        if edges[i] <= score < edges[i + 1]:
+            return i
+    return n - 1  # unreachable given the guards above
+
+
+def _proportions(scores: list[float], edges: tuple[float, ...]) -> tuple[float, ...]:
+    """Fraction of ``scores`` in each bucket defined by ``edges`` (binned with edges)."""
+    n = len(edges) - 1
+    counts = [0] * n
+    for s in scores:
+        counts[_bucket_index(s, edges)] += 1
+    total = len(scores) or 1
+    return tuple(c / total for c in counts)
+
+
+@dataclass(frozen=True)
+class PSIReference:
+    """Frozen build-time score distribution: bucket EDGES + reference proportions.
+
+    Edges are fixed at build time; live scores are always binned with THESE edges
+    (never re-binned independently) so the PSI comparison is apples-to-apples.
+    """
+
+    edges: tuple[float, ...]  # len == n_buckets + 1, ascending
+    proportions: tuple[float, ...]  # len == n_buckets, sums to ~1.0
+
+    @staticmethod
+    def from_scores(
+        scores: list[float], *, n_buckets: int = _DEFAULT_BUCKETS, lo: float = 0.0, hi: float = 1.0
+    ) -> PSIReference:
+        if n_buckets < 1:
+            raise ValueError(f"n_buckets must be >= 1, got {n_buckets}")
+        if hi <= lo:
+            raise ValueError(f"hi ({hi}) must be > lo ({lo})")
+        edges = tuple(lo + (hi - lo) * i / n_buckets for i in range(n_buckets + 1))
+        return PSIReference(edges=edges, proportions=_proportions(scores, edges))
+
+
+def psi(reference: PSIReference, live_scores: list[float]) -> float:
+    """Population Stability Index of ``live_scores`` vs the reference.
+
+    Live scores are binned with the reference's own edges. Returns 0.0 on an
+    identical distribution and grows as the live distribution shifts. Empty-bucket
+    terms are Laplace-smoothed by ``_EPS``.
+    """
+    live = _proportions(live_scores, reference.edges)
+    total = 0.0
+    for ref_p, live_p in zip(reference.proportions, live, strict=True):
+        r = ref_p + _EPS
+        live_p_eps = live_p + _EPS
+        total += (live_p_eps - r) * math.log(live_p_eps / r)
+    return total
+
+
+@dataclass(frozen=True)
+class GateAlert:
+    rule: str
+    severity: AlertSeverity
+    message: str
+    value: float
+    threshold: float
+
+
+@dataclass(frozen=True)
+class GateReport:
+    n_scores: int
+    accept_ratio: float | None  # None when no accept/reject labels were supplied
+    psi: float | None  # None when no reference was configured (or no live scores)
+    alerts: tuple[GateAlert, ...]
+
+
+class EmbeddingObserver:
+    """Read-only embedding-gate health observer. Never mutates the gate threshold.
+
+    ``evaluate()`` is pure: given the live gate scores (and optional accept/reject
+    labels) it returns a :class:`GateReport`. It reads the configured PSI reference
+    but never writes it or any gate state — recalibration stays human-initiated.
+    """
+
+    def __init__(
+        self,
+        *,
+        reference: PSIReference | None = None,
+        psi_ticket: float = PSI_TICKET,
+        psi_page: float = PSI_PAGE,
+        min_accept_ratio: float | None = None,
+    ) -> None:
+        self._reference = reference
+        self._psi_ticket = psi_ticket
+        self._psi_page = psi_page
+        self._min_accept_ratio = min_accept_ratio
+
+    def evaluate(
+        self, live_scores: list[float], *, accepted: list[bool] | None = None
+    ) -> GateReport:
+        alerts: list[GateAlert] = []
+
+        psi_value: float | None = None
+        if self._reference is not None and live_scores:
+            psi_value = psi(self._reference, live_scores)
+            if psi_value > self._psi_page:
+                alerts.append(
+                    GateAlert(
+                        "psi_drift",
+                        AlertSeverity.PAGE,
+                        f"gate score PSI {psi_value:.3f} exceeds PAGE {self._psi_page:.2f} "
+                        f"— live distribution has drifted off the calibrated reference",
+                        psi_value,
+                        self._psi_page,
+                    )
+                )
+            elif psi_value > self._psi_ticket:
+                alerts.append(
+                    GateAlert(
+                        "psi_drift",
+                        AlertSeverity.TICKET,
+                        f"gate score PSI {psi_value:.3f} exceeds TICKET {self._psi_ticket:.2f}",
+                        psi_value,
+                        self._psi_ticket,
+                    )
+                )
+
+        accept_ratio: float | None = None
+        if accepted:
+            accept_ratio = sum(1 for a in accepted if a) / len(accepted)
+            if self._min_accept_ratio is not None and accept_ratio < self._min_accept_ratio:
+                alerts.append(
+                    GateAlert(
+                        "low_accept_ratio",
+                        AlertSeverity.TICKET,
+                        f"accept ratio {accept_ratio:.2%} below floor {self._min_accept_ratio:.2%}",
+                        accept_ratio,
+                        self._min_accept_ratio,
+                    )
+                )
+
+        return GateReport(
+            n_scores=len(live_scores),
+            accept_ratio=accept_ratio,
+            psi=psi_value,
+            alerts=tuple(alerts),
+        )
+
+
+def format_gate_report(report: GateReport) -> str:
+    """Render a :class:`GateReport` as a markdown summary (for an MCP tool / cron)."""
+    ratio = "n/a" if report.accept_ratio is None else f"{report.accept_ratio:.2%}"
+    psi_str = "n/a" if report.psi is None else f"{report.psi:.3f}"
+    lines = [
+        "## Embedding Gate Health",
+        f"Scores: {report.n_scores} | Accept ratio: {ratio} | PSI: {psi_str}",
+        "",
+    ]
+    if not report.alerts:
+        lines.append("**No alerts. Gate within thresholds.**")
+        return "\n".join(lines)
+    lines.append("| Severity | Rule | Value | Threshold | Message |")
+    lines.append("|----------|------|-------|-----------|---------|")
+    for alert in sorted(report.alerts, key=lambda a: -int(a.severity)):
+        lines.append(
+            f"| {alert.severity.name} | {alert.rule} | {alert.value:.3f} | "
+            f"{alert.threshold:.3f} | {alert.message} |"
+        )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "PSI_TICKET",
+    "PSI_PAGE",
+    "PSIReference",
+    "psi",
+    "GateAlert",
+    "GateReport",
+    "EmbeddingObserver",
+    "format_gate_report",
+]

--- a/skyyrose/core/embeddings/base.py
+++ b/skyyrose/core/embeddings/base.py
@@ -20,6 +20,7 @@ lives here.
 from __future__ import annotations
 
 import logging
+import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 from threading import Lock
@@ -104,13 +105,40 @@ class BaseEncoder(ABC):
         if batch_size < 1:
             raise EmbedError(f"batch_size must be >= 1, got {batch_size}")
         self._ensure_loaded()
-        out: list[np.ndarray] = []
-        for start in range(0, len(sources), batch_size):
-            chunk = sources[start : start + batch_size]
-            images = [self._open(s) for s in chunk]
-            raw = self._encode_pils(images)
-            out.extend(self._l2_normalize(row) for row in raw)
-        return np.stack(out)
+        # OBS-wire: one telemetry row per encode (latency, success, count). Imported
+        # lazily so the package still imports without core/ side effects; the helper
+        # never raises, so telemetry cannot break the encode path.
+        from core.token_tracker import record_embedding_usage
+
+        started = time.perf_counter()
+        try:
+            out: list[np.ndarray] = []
+            for start in range(0, len(sources), batch_size):
+                chunk = sources[start : start + batch_size]
+                images = [self._open(s) for s in chunk]
+                raw = self._encode_pils(images)
+                out.extend(self._l2_normalize(row) for row in raw)
+            result = np.stack(out)
+        except Exception as exc:
+            record_embedding_usage(
+                model=self.space.model_id,
+                latency_ms=(time.perf_counter() - started) * 1000.0,
+                success=False,
+                cache_hit=False,
+                dim=self.space.dim,
+                count=len(sources),
+                error=str(exc),
+            )
+            raise
+        record_embedding_usage(
+            model=self.space.model_id,
+            latency_ms=(time.perf_counter() - started) * 1000.0,
+            success=True,
+            cache_hit=False,
+            dim=self.space.dim,
+            count=len(sources),
+        )
+        return result
 
     def cosine_similarity(self, a: np.ndarray, b: np.ndarray) -> float:
         """Dot product of two same-shape L2-normalized vectors."""

--- a/skyyrose/core/embeddings/cache.py
+++ b/skyyrose/core/embeddings/cache.py
@@ -103,16 +103,34 @@ class EmbeddingCache:
 
         key = self._key(self._hash_bytes(data))
 
+        # OBS-wire: record cache HITS here (latency ~0, cache_hit=True). MISSES fall
+        # through to encoder.embed_image -> BaseEncoder.embed_images, which records
+        # its own cache_hit=False row — so each encode is counted exactly once.
         cached = self._mem.get(key)
         if cached is not None:
+            self._record_hit()
             return cached
 
         disk = self._load_disk(key)
         if disk is not None:
             self._mem[key] = disk
+            self._record_hit()
             return disk
 
         vector = self._encoder.embed_image(source)
         self._mem[key] = vector
         self._store_disk(key, vector)
         return vector
+
+    def _record_hit(self) -> None:
+        """Emit one cache-hit telemetry row (lazy import; never raises)."""
+        from core.token_tracker import record_embedding_usage
+
+        record_embedding_usage(
+            model=self._encoder.space.model_id,
+            latency_ms=0.0,
+            success=True,
+            cache_hit=True,
+            dim=self._encoder.space.dim,
+            count=1,
+        )

--- a/tests/core/test_token_tracker_embed.py
+++ b/tests/core/test_token_tracker_embed.py
@@ -1,0 +1,59 @@
+"""OBS-wire: TaskType.EMBED + record_embedding_usage() — model-free."""
+
+from core.token_tracker import (
+    TaskType,
+    TokenUsage,
+    get_token_tracker,
+    record_embedding_usage,
+)
+
+
+def test_task_type_embed_exists():
+    assert TaskType.EMBED.value == "embed"
+
+
+def test_embedding_model_cost_is_zero_no_warning():
+    # Embedding model ids are registered with 0 cost so EMBED rows don't log a
+    # spurious unknown_model_cost warning on every encode.
+    for model in ("openai/clip-vit-base-patch32", "facebook/dinov2-base"):
+        u = TokenUsage(provider="embeddings", model=model, task_type=TaskType.EMBED)
+        assert u.calculate_cost() == 0.0
+
+
+def test_record_embedding_usage_records_one_row():
+    tracker = get_token_tracker()
+    tracker.clear()
+    try:
+        record_embedding_usage(
+            model="facebook/dinov2-base",
+            latency_ms=12.5,
+            success=True,
+            cache_hit=True,
+            dim=768,
+            count=1,
+        )
+        recs = tracker.records()
+        assert len(recs) == 1
+        r = recs[0]
+        assert r.task_type == TaskType.EMBED
+        assert r.provider == "embeddings"
+        assert r.model == "facebook/dinov2-base"
+        assert r.latency_ms == 12.5
+        assert r.success is True
+        assert r.metadata["cache_hit"] is True
+        assert r.metadata["dim"] == 768
+        assert r.calculate_cost() == 0.0  # token-free, registered at 0
+    finally:
+        tracker.clear()
+
+
+def test_record_embedding_usage_never_raises_on_bad_input():
+    # Telemetry must not break the encode path even if something is off.
+    tracker = get_token_tracker()
+    tracker.clear()
+    try:
+        record_embedding_usage(model="facebook/dinov2-base", success=False, error="boom")
+        recs = tracker.records()
+        assert len(recs) == 1 and recs[0].success is False
+    finally:
+        tracker.clear()

--- a/tests/monitoring/test_embedding_observer.py
+++ b/tests/monitoring/test_embedding_observer.py
@@ -1,0 +1,86 @@
+"""EmbeddingObserver + PSI drift (OBS-gate / OBS-psi) — pure, model-free.
+
+Acceptance (spec §9): PSI == 0 on identical distributions and rises on a shift;
+the observer is pure-read (never mutates the threshold).
+"""
+
+import pytest
+
+from monitoring.embedding_observer import (
+    PSI_PAGE,
+    EmbeddingObserver,
+    PSIReference,
+    format_gate_report,
+    psi,
+)
+from monitoring.fleet_observer import AlertSeverity
+
+
+def test_psi_zero_on_identical_distribution():
+    scores = [0.1, 0.3, 0.5, 0.7, 0.9, 0.5, 0.5, 0.6]
+    ref = PSIReference.from_scores(scores)
+    assert psi(ref, scores) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_psi_rises_on_shift():
+    ref = PSIReference.from_scores([0.9, 0.92, 0.88, 0.95, 0.9, 0.91])
+    drifted = [0.1, 0.15, 0.2, 0.12, 0.18, 0.1]
+    assert psi(ref, drifted) > psi(ref, [0.9, 0.92, 0.88, 0.95, 0.9, 0.91])
+    assert psi(ref, drifted) > PSI_PAGE  # a gross shift clears the PAGE band
+
+
+def test_psi_bins_live_with_reference_edges_not_rebinned():
+    # Two disjoint clusters would look "identical" if each were re-binned on its
+    # own range. Binning live with the REFERENCE edges keeps them apart -> PSI > 0.
+    ref = PSIReference.from_scores([0.1, 0.1, 0.1, 0.1])  # all in the low bucket
+    live = [0.9, 0.9, 0.9, 0.9]  # all in the high bucket
+    assert psi(ref, live) > 0.0
+
+
+def test_observer_clean_distribution_has_no_alert():
+    ref = PSIReference.from_scores([0.9, 0.91, 0.92, 0.9, 0.93, 0.9])
+    rep = EmbeddingObserver(reference=ref).evaluate([0.9, 0.91, 0.9, 0.92])
+    assert rep.alerts == ()
+    assert rep.psi == pytest.approx(0.0, abs=1e-9)
+
+
+def test_observer_pages_on_gross_drift():
+    ref = PSIReference.from_scores([0.9, 0.91, 0.92, 0.9, 0.93, 0.9])
+    rep = EmbeddingObserver(reference=ref).evaluate([0.1, 0.05, 0.12, 0.08])
+    assert any(a.rule == "psi_drift" and a.severity == AlertSeverity.PAGE for a in rep.alerts)
+
+
+def test_observer_is_pure_read_never_mutates():
+    ref = PSIReference.from_scores([0.5, 0.6, 0.7, 0.4])
+    obs = EmbeddingObserver(reference=ref)
+    before_props, before_edges = ref.proportions, ref.edges
+    before_thresholds = (obs._psi_ticket, obs._psi_page)
+    live = [0.1, 0.2, 0.9, 0.95]
+
+    r1 = obs.evaluate(live)
+    r2 = obs.evaluate(live)
+
+    assert ref.proportions == before_props and ref.edges == before_edges  # reference frozen
+    assert (obs._psi_ticket, obs._psi_page) == before_thresholds  # thresholds untouched
+    assert live == [0.1, 0.2, 0.9, 0.95]  # input not mutated
+    assert r1 == r2  # idempotent — no hidden state
+
+
+def test_observer_accept_ratio_and_low_accept_alert():
+    obs = EmbeddingObserver(min_accept_ratio=0.5)
+    rep = obs.evaluate([0.9, 0.2, 0.1, 0.1], accepted=[True, False, False, False])
+    assert rep.accept_ratio == pytest.approx(0.25)
+    assert any(a.rule == "low_accept_ratio" for a in rep.alerts)
+
+
+def test_observer_without_reference_reports_no_psi():
+    rep = EmbeddingObserver().evaluate([0.5, 0.6])
+    assert rep.psi is None and rep.alerts == ()
+
+
+def test_format_gate_report_renders_markdown():
+    ref = PSIReference.from_scores([0.9, 0.9, 0.9])
+    rep = EmbeddingObserver(reference=ref).evaluate([0.1, 0.1, 0.1])
+    out = format_gate_report(rep)
+    assert "Embedding Gate Health" in out
+    assert "psi_drift" in out  # the drift alert is rendered


### PR DESCRIPTION
Phase 3 **Track OBS (observability)**: the embedding encode path emitted zero telemetry and the gate had no drift signal. Adds both — ALERT-ONLY, pure-read (never auto-retunes, never mutates the gate threshold).

## OBS-wire — encode telemetry
- **`core/token_tracker.py`**: `TaskType.EMBED` + `record_embedding_usage()` (latency, cache-hit, success; never raises). CLIP/DINO model ids registered at 0 cost so EMBED rows don't log a spurious `unknown_model_cost` warning. `FleetObserver` already reads `token_tracker`, so embedding encodes now surface in fleet health for free.
- **`skyyrose/core/embeddings/base.py`**: one telemetry row per encode in `embed_images` (the single funnel). Lazy import; failures recorded then re-raised.
- **`skyyrose/core/embeddings/cache.py`**: records cache **hits**; misses fall through to the encoder which records its own miss — each encode counted exactly once.

## OBS-gate + OBS-psi — drift observer
- **`monitoring/embedding_observer.py` (NEW)**: `psi()` + `PSIReference` (build-time score histogram; live scores binned with the **reference's** edges, +epsilon smoothing) + `EmbeddingObserver` (pure-read; **TICKET at PSI>0.2, PAGE at PSI>0.25**; optional accept-ratio floor) + `format_gate_report`. Reuses `fleet_observer.AlertSeverity` (keeps `monitoring/` free of an `evaluation/` dependency, per house style).

## Verification (acceptance spec §9)
- PSI **== 0 on identical** distributions, **rises on a shift**, bins live with the reference edges (not re-binned). Observer **pages on gross drift** and is **pure-read** (idempotent; never mutates reference/thresholds/input). 
- **93 unit + 9 integration** (real encode path) pass; ruff + black clean.

## Deferred — named (NOT in this PR)
- Gate-**verdict** emission at the `embedding_gate.evaluate()` call sites — those live in the dual-copy compositor (`stage_g_visual_qa` / `orchestrator` / `compositor_agent`, the Phase-1 two-copies hazard). The observer's `evaluate(scores, reference)` is pure, so wiring the live feed is a bounded follow-up.
- OBS-struct (`logging`→`structlog`) — target `embedding_engine.py` unconfirmed; left as remaining LOW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG6kqt4UojivQPWLXhzFgR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds embedding encode telemetry and a read-only PSI drift observer for the embedding gate. This surfaces latency/cache hits in fleet health and alerts on distribution drift without changing thresholds.

- **New Features**
  - Telemetry: `TaskType.EMBED` + `record_embedding_usage()` (latency, success, cache-hit, dim, count). Wired into `embed_images`; cache records hits. `openai/clip-vit-base-patch32` and `facebook/dinov2-base` set to 0 cost. Never raises.
  - Drift observer: `PSIReference`, `psi()`, `EmbeddingObserver`, `format_gate_report`. Bins live scores with reference edges; TICKET at PSI > 0.2, PAGE at PSI > 0.25; optional accept-ratio floor. Pure read-only (no auto-retune).

<sup>Written for commit 18a8c58f84ab3f2fcd33aa3a4eefc96edd84e42f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

