### PR TITLE
fix(ci): unblind E2E — restore list reporter streaming + --max-failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,7 +555,13 @@ jobs:
         # job's continue-on-error) instead of running to the 30-min JOB timeout, which fires as
         # a cancellation that continue-on-error cannot absorb — that gated the pipeline.
         timeout-minutes: 15
-        run: ./node_modules/.bin/playwright test --reporter=html
+        # `--reporter=list,html`: the `list` reporter streams per-test results to the
+        # CI log (a bare `--reporter=html` overrode the config's list reporter, so the
+        # run produced ZERO output and the 15-min timeout was a black box — you could
+        # not tell which test hung). `html` is kept for the uploaded report artifact.
+        # `--max-failures=10`: bail fast instead of grinding 42 serial tests (workers=1,
+        # retries=2 = up to 90s each) past the 15-min cap with no signal.
+        run: ./node_modules/.bin/playwright test --reporter=list,html --max-failures=10
         working-directory: frontend
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:3000


### PR DESCRIPTION
## What
Stop the Playwright E2E step from running blind into its 15-min timeout.

## Root cause (investigated via the failing CI log)
The step ran `playwright test --reporter=html`. That CLI flag **overrides** `playwright.config.ts`'s `[html, list]` reporters, so in CI only the *html* reporter ran — silent (writes a file, streams nothing). The log showed `Running 42 tests using 1 worker` then **15 min of silence** → step timeout. Both servers booted fine (`/health` 200, frontend up at :3000); the suite itself doesn't finish in 15 min and, with `workers:1` + `retries:2`, a few timing-out tests grind serially past the cap **with zero visible output**.

## Fix
- `--reporter=list,html` → `list` streams per-test results to the CI log (next run reveals which test hangs); `html` kept for the report artifact.
- `--max-failures=10` → bail fast instead of grinding to the black-box cap.

## Follow-up
With streaming restored, the next run surfaces the actual slow/failing specs (`settings-page.spec` is the named un-hardened one) to fix or quarantine; then revisit `retries`. Job remains `continue-on-error` (non-gating) until hardened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores visible E2E test output in CI and adds a failure cap to avoid silent 15‑minute timeouts. Keeps the HTML report while making hung tests easy to spot.

- **Bug Fixes**
  - Run `playwright test` with `--reporter=list,html` so per-test results stream to CI logs; keep the HTML artifact.
  - Add `--max-failures=10` to stop early instead of grinding past the step timeout.

<sup>Written for commit fe5940cf46d79041b03a676eaf9e591c883f0e18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

