### PR TITLE
docs: add product-image fidelity gate to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,11 @@ The diligence spine. These are the standard for every task — not aspirational,
 | Recent web facts (prices, events, status) | **WebSearch** | Only when the answer depends on current state. |
 | Existing implementation to reuse | `gh search code` / `gh search repos` | Search before writing net-new. |
 | What a render / image actually shows | **Read the image** (vision); `identify` for metadata | One-shot batch quota — batch reads, never retry (all fail once exceeded). |
+| Product image about to touch the site (render / content / skyyrose.co edit) | **Read the actual pixels (vision)** → confirm correct garment for that SKU vs catalog/dossier | **MANDATORY.** Filename/manifest can lie; wrong-garment is the #1 recurring defect. Eyes-on or don't ship. |
 
 **Rule of thumb:** the verification must be able to *fail*. A check that can't return "no" isn't verification — it's a guess with a citation.
+
+> **MANDATORY — Product-image fidelity gate.** Before you **render anything, create content, or edit skyyrose.co**, every product image about to touch the site MUST be eyes-on verified as the *correct garment for that SKU* — read the actual pixels (vision), not the filename or manifest. Product renders come from **OAI-image-2 only** (see project memory). If you cannot visually confirm SKU ↔ garment match, do NOT render / publish / deploy — flag it. Wrong-garment imagery is the #1 recurring defect (lh-005 fanny-pack hallucination, never-made renders leaking onto cards).
 
 > Cross-refs: Context7-first → **Development Protocol** below · WebFetch/cache-bust → **Learnings → Audit Discipline** · Playwright-live-verify + canonical-sources → project memory.
 


### PR DESCRIPTION
## What
Preserves a stranded (uncommitted) prior-session edit to the root `CLAUDE.md`: a **product-image fidelity gate**.

Adds, under the Verification Protocol:
- A matrix row: *product image about to touch the site → read the actual pixels (vision), confirm correct garment for that SKU vs catalog/dossier.*
- A standalone **MANDATORY** clause: before rendering, creating content, or editing skyyrose.co, every product image must be eyes-on verified as the correct garment for its SKU. Filenames/manifests can lie; wrong-garment imagery is the #1 recurring defect (lh-005 fanny-pack hallucination). Product renders are OAI-image-2 only.

## Why
Docs-only, on-canon (matches the anti-hallucination + imagery-verification rules already in project memory). Found stranded in the working tree during unrelated work; opening as its own reviewable PR rather than letting it ride into a feature branch or get lost.

## Scope
1 file, +3 lines, `CLAUDE.md` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a mandatory product-image fidelity gate to `CLAUDE.md` to prevent wrong-garment images from reaching the site. Adds a verification-matrix row and a standalone rule requiring eyes-on SKU↔garment checks (read pixels, not filenames) before any render, content, or skyyrose.co edit; product renders use OAI-image-2 only.

<sup>Written for commit ef7c5eef536b5437992af1d1d722d8c027772d4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added stricter verification guidance for product imagery to reduce incorrect garment photos appearing on the site.
  * Clarified that visual confirmation is required before publishing or editing product-related content, improving accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->