### PR TITLE
feat(ml): resolve P1 #11 (ProcessingQueue wiring) + P1 #12 (bg-removal composite)

### DIFF
--- a/services/image_ingestion.py
+++ b/services/image_ingestion.py
@@ -28,6 +28,7 @@ from services.image_deduplication import (
     ImageDeduplicator,
     get_deduplicator,
 )
+from services.ml.processing_queue import ProcessingQueue, TaskType
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +168,7 @@ class ImageIngestionService:
         r2_client: Any | None = None,
         deduplicator: ImageDeduplicator | None = None,
         timeout: float = 30.0,
+        processing_queue: ProcessingQueue | None = None,
     ) -> None:
         """Initialize ingestion service.
 
@@ -174,10 +176,14 @@ class ImageIngestionService:
             r2_client: R2 storage client (optional, for testing)
             deduplicator: Image deduplicator (optional)
             timeout: HTTP timeout for downloads
+            processing_queue: ML processing queue (optional; in-memory default)
         """
         self._r2_client = r2_client
         self._deduplicator = deduplicator or get_deduplicator()
         self._timeout = timeout
+        # ProcessingQueue is in-memory (no external infra); default-construct one
+        # so ingested assets are actually submitted, not silently dropped.
+        self._queue = processing_queue or ProcessingQueue()
         self._http_client: httpx.AsyncClient | None = None
 
     async def _get_http_client(self) -> httpx.AsyncClient:
@@ -540,15 +546,23 @@ class ImageIngestionService:
         Returns:
             Processing job ID
         """
-        # P1 #11: ProcessingQueue integration is not implemented. Returning a
-        # job_id without submission silently dropped every queued asset. Raise
-        # so callers either wire the queue or make an explicit fallback.
-        raise NotImplementedError(
-            "ProcessingQueue integration is not yet wired. _queue_for_processing "
-            "previously generated a uuid and logged it without submitting any work, "
-            "silently losing every ingested asset. Wire to the real processing queue "
-            "or remove this call from ingest_*() entry points before relying on it."
+        # P1 #11: submit the asset to the (in-memory) ProcessingQueue and return
+        # the real job_id. The queue's task handlers are registered by the ML
+        # pipeline; ingestion's job is only to enqueue, not to process.
+        job_id = await self._queue.submit_job(
+            TaskType.BACKGROUND_REMOVAL,
+            {
+                "asset_id": asset_id,
+                "r2_key": r2_key,
+                "source": source.value,
+                "product_id": product_id,
+                "woocommerce_product_id": woocommerce_product_id,
+                "metadata": metadata,
+                "callback_url": callback_url,
+            },
+            correlation_id=correlation_id,
         )
+        return job_id
 
     async def ingest_batch(
         self,

--- a/services/ml/enhancement/background_removal.py
+++ b/services/ml/enhancement/background_removal.py
@@ -15,12 +15,15 @@ Version: 1.0.0
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import logging
 from enum import StrEnum
+from io import BytesIO
 from typing import Any
 
 import httpx
+from PIL import Image, ImageColor
 from pydantic import BaseModel
 from services.ml.replicate_client import ReplicateClient, ReplicateConfig
 
@@ -180,6 +183,31 @@ class BackgroundRemovalService:
         """Compute hash of image data for verification."""
         return hashlib.sha256(image_data).hexdigest()[:16]
 
+    def _composite_on_color(self, cutout_bytes: bytes, color: str) -> bytes:
+        """Composite an RGBA cutout over a solid color; return flattened PNG bytes."""
+        cutout = Image.open(BytesIO(cutout_bytes)).convert("RGBA")
+        rgb = ImageColor.getrgb(color)
+        background = Image.new("RGBA", cutout.size, (rgb[0], rgb[1], rgb[2], 255))
+        flattened = Image.alpha_composite(background, cutout).convert("RGB")
+        out = BytesIO()
+        flattened.save(out, format="PNG")
+        return out.getvalue()
+
+    def _composite_on_image(self, cutout_bytes: bytes, background_bytes: bytes) -> bytes:
+        """Composite an RGBA cutout over a background image; return flattened PNG bytes."""
+        cutout = Image.open(BytesIO(cutout_bytes)).convert("RGBA")
+        background = Image.open(BytesIO(background_bytes)).convert("RGBA").resize(cutout.size)
+        flattened = Image.alpha_composite(background, cutout).convert("RGB")
+        out = BytesIO()
+        flattened.save(out, format="PNG")
+        return out.getvalue()
+
+    @staticmethod
+    def _to_png_data_url(png_bytes: bytes) -> str:
+        """Encode flattened PNG bytes as a self-contained base64 data URL."""
+        encoded = base64.b64encode(png_bytes).decode("ascii")
+        return f"data:image/png;base64,{encoded}"
+
     async def remove_background(
         self,
         image_url: str,
@@ -272,25 +300,27 @@ class BackgroundRemovalService:
                 cause=last_error,
             )
 
-        # P1 #12: SOLID_COLOR and CUSTOM_IMAGE composite paths are not implemented.
-        # Code structure suggested they composite, but they only assigned the value
-        # and returned the transparent result with a misleading background_value.
-        # Callers must use BackgroundType.TRANSPARENT until PIL/cv2 compositing is wired.
+        # P1 #12: composite the transparent cutout onto the requested background.
+        # The composited image is returned as a self-contained PNG data URL (no
+        # external storage), so result_url always points at the actual output and
+        # background_value is never misleading.
         background_value: str | None = None
         if background_type == BackgroundType.SOLID_COLOR:
-            raise NotImplementedError(
-                f"BackgroundType.SOLID_COLOR composite path is not implemented "
-                f"(requested color={background_color or '#FFFFFF'}). "
-                f"Use BackgroundType.TRANSPARENT and composite downstream, or wire "
-                f"PIL/cv2 compositing here."
-            )
-        if background_type == BackgroundType.CUSTOM_IMAGE:
-            raise NotImplementedError(
-                f"BackgroundType.CUSTOM_IMAGE composite path is not implemented "
-                f"(requested image={background_image_url}). "
-                f"Use BackgroundType.TRANSPARENT and composite downstream, or wire "
-                f"PIL/cv2 compositing here."
-            )
+            color = background_color or "#FFFFFF"
+            cutout_bytes = await self._download_image_bytes(result_url, correlation_id)
+            result_url = self._to_png_data_url(self._composite_on_color(cutout_bytes, color))
+            background_value = color
+        elif background_type == BackgroundType.CUSTOM_IMAGE:
+            if not background_image_url:
+                raise BackgroundRemovalError(
+                    "BackgroundType.CUSTOM_IMAGE requires background_image_url",
+                    image_url=image_url,
+                    correlation_id=correlation_id,
+                )
+            cutout_bytes = await self._download_image_bytes(result_url, correlation_id)
+            bg_bytes = await self._download_image_bytes(background_image_url, correlation_id)
+            result_url = self._to_png_data_url(self._composite_on_image(cutout_bytes, bg_bytes))
+            background_value = background_image_url
 
         processing_time_ms = int((time.time() - start_time) * 1000)
 

--- a/services/ml/enhancement/background_removal.py
+++ b/services/ml/enhancement/background_removal.py
@@ -25,6 +25,7 @@ from typing import Any
 import httpx
 from PIL import Image, ImageColor
 from pydantic import BaseModel
+from security.ssrf_protection import SSRFProtection
 from services.ml.replicate_client import ReplicateClient, ReplicateConfig
 
 from core.errors.production_errors import (
@@ -185,7 +186,12 @@ class BackgroundRemovalService:
 
     def _composite_on_color(self, cutout_bytes: bytes, color: str) -> bytes:
         """Composite an RGBA cutout over a solid color; return flattened PNG bytes."""
-        cutout = Image.open(BytesIO(cutout_bytes)).convert("RGBA")
+        cutout = Image.open(BytesIO(cutout_bytes))
+        # Guard against DoS via oversized images (max 50MP)
+        max_pixels = 50_000_000
+        if cutout.width * cutout.height > max_pixels:
+            raise ValueError(f"Image too large: {cutout.width}x{cutout.height} exceeds {max_pixels} pixels")
+        cutout = cutout.convert("RGBA")
         rgb = ImageColor.getrgb(color)
         background = Image.new("RGBA", cutout.size, (rgb[0], rgb[1], rgb[2], 255))
         flattened = Image.alpha_composite(background, cutout).convert("RGB")
@@ -195,8 +201,17 @@ class BackgroundRemovalService:
 
     def _composite_on_image(self, cutout_bytes: bytes, background_bytes: bytes) -> bytes:
         """Composite an RGBA cutout over a background image; return flattened PNG bytes."""
-        cutout = Image.open(BytesIO(cutout_bytes)).convert("RGBA")
-        background = Image.open(BytesIO(background_bytes)).convert("RGBA").resize(cutout.size)
+        max_pixels = 50_000_000
+        cutout = Image.open(BytesIO(cutout_bytes))
+        if cutout.width * cutout.height > max_pixels:
+            raise ValueError(f"Cutout image too large: {cutout.width}x{cutout.height} exceeds {max_pixels} pixels")
+        cutout = cutout.convert("RGBA")
+
+        background = Image.open(BytesIO(background_bytes))
+        if background.width * background.height > max_pixels:
+            raise ValueError(f"Background image too large: {background.width}x{background.height} exceeds {max_pixels} pixels")
+        background = background.convert("RGBA").resize(cutout.size)
+
         flattened = Image.alpha_composite(background, cutout).convert("RGB")
         out = BytesIO()
         flattened.save(out, format="PNG")
@@ -305,29 +320,51 @@ class BackgroundRemovalService:
         # external storage), so result_url always points at the actual output and
         # background_value is never misleading.
         background_value: str | None = None
-        if background_type == BackgroundType.SOLID_COLOR:
-            color = background_color or "#FFFFFF"
-            cutout_bytes = await self._download_image_bytes(result_url, correlation_id)
-            result_url = self._to_png_data_url(self._composite_on_color(cutout_bytes, color))
-            background_value = color
-        elif background_type == BackgroundType.CUSTOM_IMAGE:
-            if not background_image_url:
-                raise BackgroundRemovalError(
-                    "BackgroundType.CUSTOM_IMAGE requires background_image_url",
-                    image_url=image_url,
-                    correlation_id=correlation_id,
-                )
-            cutout_bytes = await self._download_image_bytes(result_url, correlation_id)
-            bg_bytes = await self._download_image_bytes(background_image_url, correlation_id)
-            result_url = self._to_png_data_url(self._composite_on_image(cutout_bytes, bg_bytes))
-            background_value = background_image_url
+        try:
+            if background_type == BackgroundType.SOLID_COLOR:
+                color = background_color or "#FFFFFF"
+                cutout_bytes = await self._download_image_bytes(result_url, correlation_id)
+                result_url = self._to_png_data_url(self._composite_on_color(cutout_bytes, color))
+                background_value = color
+            elif background_type == BackgroundType.CUSTOM_IMAGE:
+                if not background_image_url:
+                    raise BackgroundRemovalError(
+                        "BackgroundType.CUSTOM_IMAGE requires background_image_url",
+                        image_url=image_url,
+                        correlation_id=correlation_id,
+                    )
+                # SSRF protection: validate URL before download
+                ssrf = SSRFProtection()
+                try:
+                    ssrf.validate_url(background_image_url)
+                except Exception as e:
+                    raise BackgroundRemovalError(
+                        f"Invalid background_image_url: {e}",
+                        image_url=image_url,
+                        correlation_id=correlation_id,
+                    ) from e
+                cutout_bytes = await self._download_image_bytes(result_url, correlation_id)
+                bg_bytes = await self._download_image_bytes(background_image_url, correlation_id)
+                result_url = self._to_png_data_url(self._composite_on_image(cutout_bytes, bg_bytes))
+                background_value = background_image_url
+        except BackgroundRemovalError:
+            raise
+        except (OSError, ValueError) as e:
+            raise BackgroundRemovalError(
+                f"Failed to composite background: {e}",
+                image_url=image_url,
+                correlation_id=correlation_id,
+                cause=e,
+            ) from e
 
         processing_time_ms = int((time.time() - start_time) * 1000)
+        result_is_inline = result_url.startswith("data:")
 
         logger.info(
             "Background removal complete",
             extra={
-                "result_url": result_url,
+                "result_url": "<inline-png-data-url>" if result_is_inline else result_url,
+                "result_url_inline": result_is_inline,
                 "model_used": model_used,
                 "processing_time_ms": processing_time_ms,
                 "correlation_id": correlation_id,

--- a/tests/services/ml/test_ml_enhancement.py
+++ b/tests/services/ml/test_ml_enhancement.py
@@ -670,10 +670,6 @@ class TestBackgroundRemovalService:
             assert result.result_url == mock_prediction_success.output
             assert result.background_type == BackgroundType.TRANSPARENT
 
-    @pytest.mark.xfail(
-        reason="services/ml/enhancement/background_removal.py:281 BackgroundType.SOLID_COLOR composite path not implemented",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_remove_background_with_solid_color(
         self, mock_replicate_client, mock_prediction_success, test_image_bytes
@@ -703,6 +699,7 @@ class TestBackgroundRemovalService:
 
             assert result.background_type == BackgroundType.SOLID_COLOR
             assert result.background_value == "#B76E79"
+            assert result.result_url.startswith("data:image/png;base64,")
 
     @pytest.mark.asyncio
     async def test_remove_background_all_models_fail(

--- a/tests/services/test_background_removal.py
+++ b/tests/services/test_background_removal.py
@@ -195,24 +195,28 @@ class TestRemoveBackground:
         assert result.background_type == BackgroundType.TRANSPARENT
         assert result.model_used == DEFAULT_BACKGROUND_REMOVAL_MODEL
 
-    @pytest.mark.xfail(
-        reason="services/ml/enhancement/background_removal.py:281 BackgroundType.SOLID_COLOR composite path not implemented",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_remove_background_with_solid_color(
         self, service: BackgroundRemovalService, mock_replicate_client: MagicMock
     ) -> None:
-        """Should handle solid color background request."""
+        """Should composite the cutout onto a solid color and return a PNG data URL."""
+        from io import BytesIO
+
+        from PIL import Image
+
         mock_prediction = MagicMock()
         mock_prediction.succeeded = True
         mock_prediction.output = "https://example.com/result.png"
         mock_replicate_client.run_prediction = AsyncMock(return_value=mock_prediction)
 
+        buffer = BytesIO()
+        Image.new("RGBA", (8, 8), (0, 0, 0, 0)).save(buffer, format="PNG")
+        cutout_png = buffer.getvalue()
+
         with patch.object(
             service, "_download_image_bytes", new_callable=AsyncMock
         ) as mock_download:
-            mock_download.return_value = b"fake-image-data"
+            mock_download.return_value = cutout_png
 
             result = await service.remove_background(
                 "https://example.com/product.jpg",
@@ -222,6 +226,7 @@ class TestRemoveBackground:
 
         assert result.background_type == BackgroundType.SOLID_COLOR
         assert result.background_value == "#FF0000"
+        assert result.result_url.startswith("data:image/png;base64,")
 
     @pytest.mark.asyncio
     async def test_remove_background_fallback_on_primary_failure(

--- a/tests/services/test_image_ingestion.py
+++ b/tests/services/test_image_ingestion.py
@@ -738,10 +738,6 @@ class TestUploadToR2:
 class TestQueueForProcessing:
     """Test _queue_for_processing method."""
 
-    @pytest.mark.xfail(
-        reason="services/image_ingestion.py:546 _queue_for_processing raises NotImplementedError until ProcessingQueue is wired",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_queue_returns_job_id(
         self,
@@ -764,10 +760,6 @@ class TestQueueForProcessing:
         # UUID format check
         assert len(job_id) == 36
 
-    @pytest.mark.xfail(
-        reason="services/image_ingestion.py:546 _queue_for_processing raises NotImplementedError until ProcessingQueue is wired",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_queue_with_optional_fields(
         self,
@@ -795,10 +787,6 @@ class TestQueueForProcessing:
 class TestIngest:
     """Test full ingest method."""
 
-    @pytest.mark.xfail(
-        reason="services/image_ingestion.py:546 _queue_for_processing raises NotImplementedError until ProcessingQueue is wired",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_successful_ingestion(
         self,
@@ -862,10 +850,6 @@ class TestIngest:
         # R2 upload should NOT have been called
         service._r2_client.upload_object.assert_not_called()
 
-    @pytest.mark.xfail(
-        reason="services/image_ingestion.py:546 _queue_for_processing raises NotImplementedError until ProcessingQueue is wired",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_ingestion_skip_dedup_check(
         self,
@@ -954,10 +938,6 @@ class TestIngest:
         assert result.status == IngestionStatus.FAILED
         assert "Unexpected error" in result.error_message
 
-    @pytest.mark.xfail(
-        reason="services/image_ingestion.py:546 _queue_for_processing raises NotImplementedError until ProcessingQueue is wired",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_ingestion_generates_correlation_id(
         self,
@@ -985,10 +965,6 @@ class TestIngest:
 class TestIngestBatch:
     """Test batch ingestion functionality."""
 
-    @pytest.mark.xfail(
-        reason="services/image_ingestion.py:546 _queue_for_processing raises NotImplementedError until ProcessingQueue is wired",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_batch_ingestion_success(
         self,
@@ -1010,10 +986,6 @@ class TestIngestBatch:
         assert len(results) == 3
         assert all(r.status == IngestionStatus.COMPLETED for r in results)
 
-    @pytest.mark.xfail(
-        reason="services/image_ingestion.py:546 _queue_for_processing raises NotImplementedError until ProcessingQueue is wired",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_batch_ingestion_partial_failure(
         self,


### PR DESCRIPTION
Resolves the two long-deferred P1 ML stubs (xfail catalog since May). Both are TDD-complete and un-xfailed.

## P1 #11 — `_queue_for_processing` wired to ProcessingQueue
`ImageIngestionService._queue_for_processing` raised `NotImplementedError`, silently dropping every ingested asset. Now submits to the existing in-memory `ProcessingQueue.submit_job` (`TaskType.BACKGROUND_REMOVAL`) and returns the real job_id. `ProcessingQueue` is DI'd into `__init__` (optional, default-constructed) so production injects a shared, handler-registered queue while the default serves the submit-only contract.
- Un-xfails 7 tests (`TestQueueForProcessing` + `TestIngest` + `TestIngestBatch`).

## P1 #12 — SOLID_COLOR + CUSTOM_IMAGE composite paths
`remove_background` raised `NotImplementedError` for these. Now composites the transparent Replicate cutout onto the requested solid color (or custom background image) via PIL `alpha_composite`, returned as a **self-contained PNG data URL** — no external storage, so `result_url` always points at the real output and `background_value` is never misleading.
- Un-xfails both SOLID_COLOR tests; the first now feeds real PNG bytes and asserts the data-URL output.

## Verification
- `tests/services/test_image_ingestion.py`: 65 passed
- `tests/services/test_background_removal.py` + `tests/services/ml/test_ml_enhancement.py`: 127 passed
- ruff / black / isort clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires image ingestion to the in-memory `ProcessingQueue` and adds SOLID_COLOR and CUSTOM_IMAGE background compositing with self-contained PNG data URLs. Adds SSRF protection, image size guards, and better error handling for compositing. Resolves P1 #11 and P1 #12.

- **New Features**
  - `_queue_for_processing` submits jobs to `ProcessingQueue.submit_job` with `TaskType.BACKGROUND_REMOVAL`, returning the real job_id; `ProcessingQueue` is DI in `__init__` with a default in-memory queue.
  - `remove_background` composites the transparent cutout onto a solid color or custom image via PIL and returns a `data:image/png;base64,...` URL; `background_value` reflects the color or image URL and CUSTOM_IMAGE validates `background_image_url`.

- **Bug Fixes**
  - Added SSRF checks via `SSRFProtection` for custom background URLs, DoS guards with 50MP limits, wrapped compositing errors as `BackgroundRemovalError`, and redacted inline PNG data URLs from logs.

<sup>Written for commit 6d9678782b25afe6b00a27c422dc1a9d5e667f51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ingested images are now automatically enqueued for background ML processing.
  * Background removal supports solid-color and custom-image backgrounds, returning a composited PNG result.

* **Bug Fixes**
  * Fixed image ingestion so assets are no longer dropped and background jobs produce a job ID.
  * Solid-color/custom-image background removal now validates inputs and outputs the final inline PNG URL.

* **Tests**
  * Removed expected-failure markers and updated assertions for queued jobs and base64 PNG data URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->