### PR TITLE
feat(api): /api/v1/lora/* router → imagery SDXL backend (LoRA Phase 1, un-breaks 4 MCP tools)

### DIFF
--- a/api/v1/__init__.py
+++ b/api/v1/__init__.py
@@ -34,6 +34,7 @@ from api.v1.commerce import router as commerce_router
 from api.v1.competitors import router as competitors_router
 from api.v1.descriptions import router as descriptions_router
 from api.v1.hf_spaces import hf_spaces_router
+from api.v1.lora import lora_router
 from api.v1.marketing import router as marketing_router
 from api.v1.media import router as media_router
 from api.v1.ml import router as ml_router
@@ -66,6 +67,7 @@ __all__ = [
     "social_media_router",
     "wordpress_agent_router",
     "wordpress_theme_router",
+    "lora_router",
     "training_router",
     "sync_router",
     "claude_sdk_router",

--- a/api/v1/lora.py
+++ b/api/v1/lora.py
@@ -1,0 +1,293 @@
+"""LoRA Training API Router (api/v1/lora.py).
+
+Exposes 4 endpoints that proxy into the imagery/ SDXL backend:
+
+  POST /lora/train               → 202 accepted; training runs as BackgroundTask
+  GET  /lora/dataset/preview     → dataset summary (WooCommerce products, no GPU)
+  GET  /lora/versions/{version}  → version metadata from SQLite tracker
+  GET  /lora/products/{sku}/history → per-SKU training history
+
+No paid-API gate: SDXL training is local GPU compute, not a per-call billed service.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException
+from pydantic import BaseModel, Field
+
+from imagery.lora_trainer import SkyyRoseLoRATrainer
+from imagery.lora_version_tracker import LoRAVersion, LoRAVersionTracker
+from imagery.product_training_dataset import fetch_products_from_woocommerce
+
+logger = logging.getLogger(__name__)
+
+lora_router = APIRouter(prefix="/lora", tags=["LoRA Training"])
+
+# Canonical DB path — matches SkyyRoseLoRATrainer default (lora_trainer.py:167)
+LORA_VERSIONS_DB: Path = Path("models/lora-versions.db")
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class TrainLoRARequest(BaseModel):
+    """Body for POST /lora/train."""
+
+    collections: list[str] | None = Field(
+        default=None,
+        description="Collections to include (BLACK_ROSE, LOVE_HURTS, SIGNATURE). None = all.",
+    )
+    max_products: int | None = Field(default=None, description="Cap on number of products.")
+    epochs: int = Field(default=100, ge=1, description="Training epochs.")
+    version: str | None = Field(
+        default=None, description="Version label; auto-assigned if omitted."
+    )
+
+
+class TrainLoRAResponse(BaseModel):
+    status: str
+    version: str | None
+    message: str
+    monitor: str
+
+
+class SampleProduct(BaseModel):
+    sku: str
+    name: str
+    collection: str
+    image_count: int
+    quality_score: float
+
+
+class DatasetPreviewResponse(BaseModel):
+    total_products: int
+    total_images: int
+    avg_quality_score: float
+    collections: dict[str, int]
+    sample_products: list[SampleProduct]
+
+
+class ProductContributionOut(BaseModel):
+    sku: str
+    product_name: str
+    collection: str
+    images_count: int
+    quality_score: float
+
+
+class LoRAVersionOut(BaseModel):
+    version: str
+    base_model: str
+    created_at: datetime
+    training_config: dict[str, Any]
+    model_path: str
+    total_images: int
+    total_products: int
+    collections: dict[str, int]
+    products: list[ProductContributionOut]
+
+
+class ProductHistoryResponse(BaseModel):
+    sku: str
+    versions: list[LoRAVersionOut]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _version_to_out(lv: LoRAVersion) -> LoRAVersionOut:
+    return LoRAVersionOut(
+        version=lv.version,
+        base_model=lv.base_model,
+        created_at=lv.created_at,
+        training_config=lv.training_config,
+        model_path=lv.model_path,
+        total_images=lv.total_images,
+        total_products=lv.total_products,
+        collections=lv.collections,
+        products=[
+            ProductContributionOut(
+                sku=p.sku,
+                product_name=p.product_name,
+                collection=p.collection,
+                images_count=p.images_count,
+                quality_score=p.quality_score,
+            )
+            for p in (lv.products or [])
+        ],
+    )
+
+
+def _make_tracker() -> LoRAVersionTracker:
+    return LoRAVersionTracker(db_path=LORA_VERSIONS_DB)
+
+
+# ---------------------------------------------------------------------------
+# Background training wrapper (swallows + logs so 202 is never undone)
+# ---------------------------------------------------------------------------
+
+
+async def _run_training(
+    trainer: SkyyRoseLoRATrainer,
+    *,
+    collections: list[str] | None,
+    epochs: int,
+    max_products: int | None,
+    version: str | None,
+) -> None:
+    """Wrapper executed as a BackgroundTask.
+
+    Catches all exceptions so Starlette never re-raises them after the 202
+    response has been sent (e.g. ImportError when diffusers/peft are absent).
+    """
+    try:
+        await trainer.train_from_products(
+            collections=collections,
+            epochs=epochs,
+            max_products=max_products,
+            version=version,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("LoRA background training failed: %s", exc, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@lora_router.post("/train", status_code=202, response_model=TrainLoRAResponse)
+async def start_lora_training(
+    body: TrainLoRARequest,
+    background_tasks: BackgroundTasks,
+) -> TrainLoRAResponse:
+    """Dispatch a LoRA fine-tuning run as a background task.
+
+    Returns 202 immediately; training runs for hours on local GPU.
+    Monitor progress via GET /api/v1/training/status.
+    """
+    trainer = SkyyRoseLoRATrainer(version_db_path=LORA_VERSIONS_DB)
+    background_tasks.add_task(
+        _run_training,
+        trainer,
+        collections=body.collections,
+        epochs=body.epochs,
+        max_products=body.max_products,
+        version=body.version,
+    )
+    return TrainLoRAResponse(
+        status="accepted",
+        version=body.version,  # echoed back; None means auto-assigned after training
+        message=(
+            "LoRA training dispatched. Version will be assigned on completion when not specified."
+        ),
+        monitor="/api/v1/training/status",
+    )
+
+
+@lora_router.get("/dataset/preview", response_model=DatasetPreviewResponse)
+async def preview_dataset(
+    collections: str | None = None,
+    max_products: int = 50,
+) -> DatasetPreviewResponse:
+    """Preview the training dataset without starting training.
+
+    Args:
+        collections: Comma-joined collection names (e.g. "SIGNATURE,BLACK_ROSE").
+                     Omit to include all collections.
+        max_products: Maximum products to fetch (default 50).
+    """
+    parsed_collections: list[str] | None = (
+        [c.strip() for c in collections.split(",") if c.strip()] if collections else None
+    )
+    try:
+        products = await fetch_products_from_woocommerce(
+            collections=parsed_collections,
+            max_products=max_products,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("WooCommerce fetch failed during dataset preview: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to fetch products from WooCommerce. Check connectivity.",
+        ) from exc
+
+    total_images = sum(len(p.image_urls) for p in products)
+    avg_quality = sum(p.quality_score for p in products) / len(products) if products else 0.0
+
+    collection_counts: dict[str, int] = {}
+    for p in products:
+        collection_counts[p.collection] = collection_counts.get(p.collection, 0) + 1
+
+    sample = [
+        SampleProduct(
+            sku=p.sku,
+            name=p.name,
+            collection=p.collection,
+            image_count=len(p.image_urls),
+            quality_score=p.quality_score,
+        )
+        for p in products[:5]
+    ]
+
+    return DatasetPreviewResponse(
+        total_products=len(products),
+        total_images=total_images,
+        avg_quality_score=avg_quality,
+        collections=collection_counts,
+        sample_products=sample,
+    )
+
+
+@lora_router.get("/versions/{version}", response_model=LoRAVersionOut)
+async def get_version_info(version: str) -> LoRAVersionOut:
+    """Return metadata for a specific LoRA version.
+
+    Raises 404 if the version does not exist in the database.
+    """
+    tracker = _make_tracker()
+    try:
+        await tracker.initialize()
+        lv = await tracker.get_version(version)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=f"Version not found: {version}") from exc
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Version tracker error for %r: %s", version, exc, exc_info=True)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to retrieve version from database.",
+        ) from exc
+
+    return _version_to_out(lv)
+
+
+@lora_router.get("/products/{sku}/history", response_model=ProductHistoryResponse)
+async def get_product_training_history(sku: str) -> ProductHistoryResponse:
+    """Return all LoRA versions that included the given SKU.
+
+    Returns an empty list (200) when the SKU has no training history.
+    """
+    tracker = _make_tracker()
+    try:
+        await tracker.initialize()
+        versions = await tracker.get_product_history(sku)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Version tracker error for SKU %r: %s", sku, exc, exc_info=True)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to retrieve product training history from database.",
+        ) from exc
+
+    return ProductHistoryResponse(
+        sku=sku,
+        versions=[_version_to_out(lv) for lv in versions],
+    )

--- a/main_enterprise.py
+++ b/main_enterprise.py
@@ -331,6 +331,7 @@ from api.v1 import (
     code_router,
     commerce_router,
     hf_spaces_router,
+    lora_router,
     marketing_router,
     media_router,
     ml_router,
@@ -353,6 +354,7 @@ app.include_router(autonomous_router, prefix="/api/v1")
 app.include_router(monitoring_router, prefix="/api/v1")
 app.include_router(orchestration_router, prefix="/api/v1")
 app.include_router(sync_router, prefix="/api/v1")
+app.include_router(lora_router, prefix="/api/v1")
 app.include_router(training_router, prefix="/api/v1")
 app.include_router(wordpress_agent_router, prefix="/api/v1")
 app.include_router(wordpress_theme_router, prefix="/api/v1")

--- a/tests/api/test_lora.py
+++ b/tests/api/test_lora.py
@@ -1,0 +1,296 @@
+"""Tests for the LoRA Training API (api/v1/lora.py).
+
+Covers all 4 routes:
+  POST /lora/train       → 202 accepted (background dispatch, not awaited inline)
+  GET  /lora/dataset/preview → 200 summary shape
+  GET  /lora/versions/{version} → 200 or 404
+  GET  /lora/products/{sku}/history → 200 (may be empty list)
+
+All imagery backends are monkeypatched — no real WooCommerce calls, no real GPU
+training, no real SQLite reads.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.v1 import lora as lmod
+from api.v1.lora import lora_router
+from imagery.lora_version_tracker import LoRAVersion, ProductContribution
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(lora_router)
+    return TestClient(app)
+
+
+def _make_lora_version(version: str = "v1.0.0") -> LoRAVersion:
+    """Return a minimal LoRAVersion dataclass instance for stubbing."""
+    return LoRAVersion(
+        id=1,
+        version=version,
+        base_model="runwayml/stable-diffusion-v1-5",
+        created_at=datetime(2026, 6, 26, 0, 0, 0),
+        training_config={"epochs": 100, "lr": 1e-4},
+        model_path="models/skyyrose-luxury-lora",
+        total_images=120,
+        total_products=10,
+        collections={"SIGNATURE": 5, "BLACK_ROSE": 5},
+        products=[
+            ProductContribution(
+                id=1,
+                lora_version_id=1,
+                product_id=101,
+                sku="sg-001",
+                product_name="The Classic",
+                collection="SIGNATURE",
+                images_count=12,
+                quality_score=0.85,
+            )
+        ],
+    )
+
+
+def _make_product_source(sku: str = "sg-001", collection: str = "SIGNATURE") -> MagicMock:
+    """Return a mock ProductTrainingSource with real-looking data."""
+    p = MagicMock()
+    p.product_id = 101
+    p.sku = sku
+    p.name = "The Classic"
+    p.collection = collection
+    p.image_urls = ["https://example.com/img1.jpg", "https://example.com/img2.jpg"]
+    p.local_image_paths = []  # pre-download; always empty at preview stage
+    p.quality_score = 0.85
+    return p
+
+
+# ---------------------------------------------------------------------------
+# POST /lora/train → 202
+# ---------------------------------------------------------------------------
+
+
+def test_train_returns_202(monkeypatch):
+    """Train dispatches background task and returns 202 immediately."""
+    trainer_instance = MagicMock()
+    trainer_instance.train_from_products = AsyncMock(return_value=Path("models/output"))
+
+    TrainerClass = MagicMock(return_value=trainer_instance)
+    monkeypatch.setattr(lmod, "SkyyRoseLoRATrainer", TrainerClass)
+
+    resp = _client().post(
+        "/lora/train",
+        json={"collections": ["SIGNATURE", "BLACK_ROSE"], "max_products": 20, "epochs": 50},
+    )
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["status"] == "accepted"
+    assert "message" in body
+    assert "monitor" in body
+
+
+def test_train_with_version_echoes_version(monkeypatch):
+    """When caller supplies a version it is echoed back in the response."""
+    trainer_instance = MagicMock()
+    trainer_instance.train_from_products = AsyncMock(return_value=Path("models/output"))
+    monkeypatch.setattr(lmod, "SkyyRoseLoRATrainer", MagicMock(return_value=trainer_instance))
+
+    resp = _client().post(
+        "/lora/train",
+        json={"version": "v2.0.0", "epochs": 100},
+    )
+    assert resp.status_code == 202
+    assert resp.json()["version"] == "v2.0.0"
+
+
+def test_train_still_202_when_background_task_raises(monkeypatch):
+    """Even if training eventually fails, the request has already returned 202."""
+    trainer_instance = MagicMock()
+    trainer_instance.train_from_products = AsyncMock(side_effect=ImportError("diffusers missing"))
+    monkeypatch.setattr(lmod, "SkyyRoseLoRATrainer", MagicMock(return_value=trainer_instance))
+
+    # Under TestClient(raise_server_exceptions=True default), an unhandled background
+    # exception would propagate and fail the test. If we still get 202, the wrapper
+    # caught and logged it correctly.
+    resp = _client().post("/lora/train", json={"epochs": 100})
+    assert resp.status_code == 202
+
+
+def test_train_dispatches_not_inline(monkeypatch):
+    """train_from_products is called (by BackgroundTasks) — not blocking the response."""
+    trainer_instance = MagicMock()
+    train_mock = AsyncMock(return_value=Path("models/output"))
+    trainer_instance.train_from_products = train_mock
+    monkeypatch.setattr(lmod, "SkyyRoseLoRATrainer", MagicMock(return_value=trainer_instance))
+
+    resp = _client().post("/lora/train", json={"collections": ["SIGNATURE"], "epochs": 10})
+    assert resp.status_code == 202
+    # TestClient executes BackgroundTasks before returning, so assert it ran exactly once.
+    train_mock.assert_called_once()
+    # Confirm collections + epochs were forwarded
+    _, kwargs = train_mock.call_args
+    assert kwargs.get("epochs") == 10
+    assert "SIGNATURE" in (kwargs.get("collections") or [])
+
+
+# ---------------------------------------------------------------------------
+# GET /lora/dataset/preview
+# ---------------------------------------------------------------------------
+
+
+def test_preview_returns_summary_shape(monkeypatch):
+    """Preview builds correct counts from mocked products."""
+    products = [
+        _make_product_source("sg-001", "SIGNATURE"),
+        _make_product_source("sg-002", "SIGNATURE"),
+        _make_product_source("br-001", "BLACK_ROSE"),
+    ]
+
+    async def _fake_fetch(**kwargs):
+        return products
+
+    monkeypatch.setattr(lmod, "fetch_products_from_woocommerce", _fake_fetch)
+
+    resp = _client().get("/lora/dataset/preview?collections=SIGNATURE,BLACK_ROSE&max_products=50")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_products"] == 3
+    assert body["total_images"] == 6  # 3 products × 2 images each
+    assert "avg_quality_score" in body
+    assert "collections" in body
+    assert body["collections"]["SIGNATURE"] == 2
+    assert body["collections"]["BLACK_ROSE"] == 1
+    assert "sample_products" in body
+    assert len(body["sample_products"]) <= 5
+
+
+def test_preview_no_collections_fetches_all(monkeypatch):
+    """Omitting collections param fetches without collection filter."""
+    products = [_make_product_source("sg-001")]
+
+    async def _fake_fetch(**kwargs):
+        return products
+
+    monkeypatch.setattr(lmod, "fetch_products_from_woocommerce", _fake_fetch)
+
+    resp = _client().get("/lora/dataset/preview")
+    assert resp.status_code == 200
+    assert resp.json()["total_products"] == 1
+
+
+def test_preview_wc_failure_is_502_or_503(monkeypatch):
+    """WooCommerce fetch failure → 502 or 503; raw exception NOT in response body."""
+
+    async def _boom(**kwargs):
+        raise ConnectionError("WC is down")
+
+    monkeypatch.setattr(lmod, "fetch_products_from_woocommerce", _boom)
+
+    resp = _client().get("/lora/dataset/preview")
+    assert resp.status_code in (502, 503)
+    # Raw exception string must not leak to the client
+    assert "WC is down" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# GET /lora/versions/{version}
+# ---------------------------------------------------------------------------
+
+
+def test_version_info_happy_path(monkeypatch):
+    """Existing version returns 200 with all expected fields."""
+    lv = _make_lora_version("v1.0.0")
+
+    tracker_instance = MagicMock()
+    tracker_instance.initialize = AsyncMock()
+    tracker_instance.get_version = AsyncMock(return_value=lv)
+    monkeypatch.setattr(lmod, "LoRAVersionTracker", MagicMock(return_value=tracker_instance))
+
+    resp = _client().get("/lora/versions/v1.0.0")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == "v1.0.0"
+    assert body["base_model"] == lv.base_model
+    assert body["total_products"] == lv.total_products
+    assert body["total_images"] == lv.total_images
+    assert "collections" in body
+    assert "products" in body
+
+
+def test_version_info_not_found_is_404(monkeypatch):
+    """Missing version → 404, not 500."""
+    tracker_instance = MagicMock()
+    tracker_instance.initialize = AsyncMock()
+    tracker_instance.get_version = AsyncMock(side_effect=ValueError("Version not found: v9.9.9"))
+    monkeypatch.setattr(lmod, "LoRAVersionTracker", MagicMock(return_value=tracker_instance))
+
+    resp = _client().get("/lora/versions/v9.9.9")
+    assert resp.status_code == 404
+
+
+def test_version_info_tracker_error_is_502(monkeypatch):
+    """Unexpected DB error → 502; exception text not leaked."""
+    tracker_instance = MagicMock()
+    tracker_instance.initialize = AsyncMock()
+    tracker_instance.get_version = AsyncMock(side_effect=RuntimeError("DB exploded"))
+    monkeypatch.setattr(lmod, "LoRAVersionTracker", MagicMock(return_value=tracker_instance))
+
+    resp = _client().get("/lora/versions/v1.0.0")
+    assert resp.status_code == 502
+    assert "DB exploded" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# GET /lora/products/{sku}/history
+# ---------------------------------------------------------------------------
+
+
+def test_product_history_returns_versions_list(monkeypatch):
+    """SKU with training history returns 200 and the list."""
+    lv = _make_lora_version("v1.0.0")
+    tracker_instance = MagicMock()
+    tracker_instance.initialize = AsyncMock()
+    tracker_instance.get_product_history = AsyncMock(return_value=[lv])
+    monkeypatch.setattr(lmod, "LoRAVersionTracker", MagicMock(return_value=tracker_instance))
+
+    resp = _client().get("/lora/products/sg-001/history")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["sku"] == "sg-001"
+    assert len(body["versions"]) == 1
+    assert body["versions"][0]["version"] == "v1.0.0"
+
+
+def test_product_history_empty_is_200(monkeypatch):
+    """SKU with no history returns 200 with empty list (not 404)."""
+    tracker_instance = MagicMock()
+    tracker_instance.initialize = AsyncMock()
+    tracker_instance.get_product_history = AsyncMock(return_value=[])
+    monkeypatch.setattr(lmod, "LoRAVersionTracker", MagicMock(return_value=tracker_instance))
+
+    resp = _client().get("/lora/products/new-sku/history")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["sku"] == "new-sku"
+    assert body["versions"] == []
+
+
+def test_product_history_tracker_error_is_502(monkeypatch):
+    """Unexpected DB error → 502; exception text not leaked."""
+    tracker_instance = MagicMock()
+    tracker_instance.initialize = AsyncMock()
+    tracker_instance.get_product_history = AsyncMock(side_effect=RuntimeError("DB exploded"))
+    monkeypatch.setattr(lmod, "LoRAVersionTracker", MagicMock(return_value=tracker_instance))
+
+    resp = _client().get("/lora/products/sg-001/history")
+    assert resp.status_code == 502
+    assert "DB exploded" not in resp.text


### PR DESCRIPTION
## What

The 4 LoRA training MCP tools (`devskyy_train_lora_from_products`, `_lora_dataset_preview`, `_lora_version_info`, `_lora_product_history`) **404'd** — they call `/api/v1/lora/*` but no such routes existed. This builds `api/v1/lora.py` and wires them to the **real `imagery/` SDXL backend**.

## Backend choice (verified first-hand)

The tools' contracts (collections / epochs / user-version / SKU-history) match the `imagery/` system **exactly** — `SkyyRoseLoRATrainer` (SDXL+PEFT, 938 lines), `LoRAVersionTracker` (SQLite versioning, 558 lines), `ProductTrainingDataset` (WooCommerce fetch, 526 lines) — all real code, zero stubs. The newer `scripts/flux_lora` (FLUX/Replicate) has only flat run-records — no version/SKU/product-contribution model — so the read endpoints can **only** be honestly backed by `imagery/`. Wiring to `imagery/` was the confirmed-correct choice over FLUX.

## Routes

| Route | Backing | Behavior |
|-------|---------|----------|
| `POST /lora/train` | `SkyyRoseLoRATrainer.train_from_products` | **202** — dispatched as a `BackgroundTask` (training blocks for hours on local GPU; never awaited inline). Background failures (e.g. `diffusers`/`peft` absent) are **logged, not silently swallowed**; the 202 stands. |
| `GET /lora/dataset/preview` | `fetch_products_from_woocommerce` | Summary: counts, avg quality, per-collection, sample of 5. WC failure → 502. |
| `GET /lora/versions/{version}` | `LoRAVersionTracker.get_version` | Not-found (`ValueError`) → 404; DB error → 502. |
| `GET /lora/products/{sku}/history` | `LoRAVersionTracker.get_product_history` | Empty → 200 with `[]` (honest — the SQLite genuinely tracks this). |

**No paid-API STOP-AND-SHOW gate** — SDXL training is local GPU compute, not a billed per-call service (unlike Replicate). Registered in `main_enterprise.py` + `api/v1/__init__.py` mirroring the `training_status` router.

## Test plan

- [x] TDD — 13 tests (`tests/api/test_lora.py`), `imagery/` backends mocked (no real WooCommerce / GPU / Replicate). Covers happy paths, 404, 502, background-dispatch proof, and the deps-missing → still-202 path.
- [x] `import api.v1.lora` resolves **every** `imagery/` backend symbol (the real wiring, which mocks can't verify); `LoRAVersionOut` fields match the real `LoRAVersion` dataclass; `version_db_path` matches the real `SkyyRoseLoRATrainer.__init__`.
- [x] ruff + black + isort clean.

## Known follow-up (not in this PR)

`scripts/train_lora_from_products.py:238` constructs `SkyyRoseLoRATrainer(model_path=…, base_model=…)` — a **stale signature** that would `TypeError` against the current `__init__(config, device, version_db_path)`. Pre-existing CLI bug, separate from this API router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `/api/v1/lora/*` router backed by the `imagery` SDXL backend for LoRA training, dataset preview, and version/history reads. Restores the four LoRA MCP tools.

- **New Features**
  - Adds 4 routes wired to `SkyyRoseLoRATrainer`, `fetch_products_from_woocommerce`, and `LoRAVersionTracker`: `POST /lora/train` (202, background), `GET /lora/dataset/preview`, `GET /lora/versions/{version}`, `GET /lora/products/{sku}/history`.
  - Registers the router in `api/v1/__init__.py` and `main_enterprise.py`; SDXL training runs on local GPU (no paid API gate).

- **Bug Fixes**
  - Unblocks `devskyy_train_lora_from_products`, `_lora_dataset_preview`, `_lora_version_info`, `_lora_product_history`.

<sup>Written for commit 4eaad62a1b9e6fb543946b3bdcd7a384b84ecd99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LoRA training endpoints, dataset preview (with optional collection filtering and sample items), LoRA version lookup, and per-product training history under `/api/v1`.
  * Exposed the LoRA router as part of the public v1 API routing.

* **Bug Fixes**
  * Training now responds immediately (202) while running in the background, with errors contained and logged.
  * Improved handling for missing versions and upstream data/tracker failures with appropriate HTTP responses.

* **Tests**
  * Added a comprehensive LoRA API test suite covering success, empty states, and error scenarios.

* **Chores**
  * Updated Jest config to ignore built artifacts during module resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->