### PR TITLE
fix(mcp): wire MCP tool routes to correct backend endpoints + mount unmounted routers

### DIFF
--- a/main_enterprise.py
+++ b/main_enterprise.py
@@ -323,6 +323,16 @@ from api.v1.wordpress_integration import router as wordpress_router
 
 app.include_router(wordpress_router, prefix="/api/v1")
 
+# Feature flags
+from api.v1.feature_flags import router as feature_flags_router
+
+app.include_router(feature_flags_router)  # router already carries full /api/v1/flags prefix
+
+# WordPress content (sync/status) — no path collision with wordpress_integration routes
+from api.v1.wordpress import router as wordpress_content_router
+
+app.include_router(wordpress_content_router, prefix="/api/v1")
+
 # Analytics & pipeline
 from api.v1 import (
     approval_router,

--- a/mcp_tools/tools/advanced.py
+++ b/mcp_tools/tools/advanced.py
@@ -124,7 +124,7 @@ async def multi_agent_workflow(params: MultiAgentWorkflowInput) -> str:
         ... })
     """
     data = await _make_api_request(
-        "workflows/execute",
+        "orchestration/workflows",
         method="POST",
         data={
             "workflow_name": params.workflow_name,

--- a/mcp_tools/tools/marketing.py
+++ b/mcp_tools/tools/marketing.py
@@ -105,7 +105,7 @@ async def marketing_campaign(params: MarketingCampaignInput) -> str:
         ... })
     """
     data = await _make_api_request(
-        "marketing/campaign",
+        "marketing/campaigns",
         method="POST",
         data={
             "campaign_type": params.campaign_type,

--- a/mcp_tools/tools/ml.py
+++ b/mcp_tools/tools/ml.py
@@ -98,9 +98,13 @@ async def ml_prediction(params: MLPredictionInput) -> str:
         ... })
     """
     data = await _make_api_request(
-        f"ml/predict/{params.model_type.value}",
+        "ml/predict",
         method="POST",
-        data={"data": params.data, "confidence_threshold": params.confidence_threshold},
+        data={
+            "model_type": params.model_type.value,
+            "data": params.data,
+            "confidence_threshold": params.confidence_threshold,
+        },
     )
 
     return _format_response(


### PR DESCRIPTION
## Summary

Fixes 3 MCP tool route mismatches against the backend API, and mounts 2 routers that were absent from `main_enterprise.py`.

---

### Change 1 — MCP marketing route (`mcp_tools/tools/marketing.py`)

- **Before:** `"marketing/campaign"` (no such route)
- **After:** `"marketing/campaigns"` → matches `POST /api/v1/marketing/campaigns`
- Body fields (`campaign_type`, `target_audience`, `content_template`, `schedule`) already matched `MarketingCampaignRequest` — no field corrections needed

### Change 2 — MCP ml route (`mcp_tools/tools/ml.py`)

- **Before:** `f"ml/predict/{params.model_type.value}"` (URL-path encoding of a body field; no such parameterized route)
- **After:** `"ml/predict"` + `"model_type": params.model_type.value` moved into POST body → matches `POST /api/v1/ml/predict` and `MLPredictionRequest` fields (`model_type`, `data`, `confidence_threshold`)
- **Field correction required:** `model_type` was incorrectly encoded in the URL; backend expects it as a POST body field

### Change 3 — MCP orchestration route (`mcp_tools/tools/advanced.py`)

- **Before:** `"workflows/execute"` (no such route)
- **After:** `"orchestration/workflows"` → matches `POST /api/v1/orchestration/workflows`
- Body fields (`workflow_name`, `parameters`, `agents`, `parallel`) already matched `WorkflowExecutionRequest` — no field corrections needed

### Change 4 — Mount `feature_flags` router (`main_enterprise.py`)

- Added `from api.v1.feature_flags import router as feature_flags_router`
- Added `app.include_router(feature_flags_router)` with **no `prefix=`** arg
- Reason: `api/v1/feature_flags.py` declares `prefix="/api/v1/flags"` on the router itself — adding a prefix at mount time would double it

### Change 5 — Mount `wordpress` content router (`main_enterprise.py`) — **MOUNTED (no collision)**

- Collision check performed: `api/v1/wordpress.py` routes (`POST /wordpress/sync`, `GET /wordpress/status`) vs `api/v1/wordpress_integration.py` routes (`/products/sync`, `/products/sync-collection`, `/webhooks/*`, `/health`) — **zero METHOD+path overlaps**
- Added `from api.v1.wordpress import router as wordpress_content_router`
- Added `app.include_router(wordpress_content_router, prefix="/api/v1")`

---

## Verification

```
# Import + route check
python -c "from main_enterprise import app; routes = [r.path for r in app.routes]; print(len(routes), 'routes')"
# → 329 routes

# feature_flags routes present
python -c "from main_enterprise import app; [print(r.path) for r in app.routes if '/flags' in r.path]"
# → /api/v1/flags, /api/v1/flags/{flag_name}, /api/v1/flags/{flag_name}/rollout, /api/v1/flags/{flag_name}

# wordpress sync/status routes present
python -c "from main_enterprise import app; [print(r.path) for r in app.routes if '/wordpress' in r.path]"
# → includes /api/v1/wordpress/sync, /api/v1/wordpress/status

# Ruff check — all changed files
ruff check mcp_tools/tools/marketing.py mcp_tools/tools/ml.py mcp_tools/tools/advanced.py main_enterprise.py
# → All checks passed.

# Test suite (filtered to relevant areas)
pytest tests/ -k "ml or marketing or orchestration or feature_flag or wordpress" -x -q
# → 667 passed, 5632 deselected, 3 xfailed in 39.83s
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired MCP tools to the correct backend endpoints and mounted missing routers to expose feature flags and WordPress content APIs. This fixes request shapes and prevents 404s.

- **Bug Fixes**
  - Marketing: use "marketing/campaigns" (matches POST /api/v1/marketing/campaigns).
  - ML: use "ml/predict" and send "model_type" in the POST body with "data" and "confidence_threshold".
  - Orchestration: use "orchestration/workflows" (matches POST /api/v1/orchestration/workflows).
  - Mount feature flags router without a prefix (router includes "/api/v1/flags").
  - Mount WordPress content router at "/api/v1"; no route collisions with existing integration routes.

<sup>Written for commit cd1cf818dc647d2d0d11d53e9be5e22939ea57b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

