### PR TITLE
feat(evaluation): Q-mode (wire mode into gate) + Q-data (curated centroid allowlist/floor) [Track Q]

### DIFF
--- a/evaluation/core.py
+++ b/evaluation/core.py
@@ -73,7 +73,10 @@ class EvaluationCore:
         if budget is not None:
             budget.add(verdict.cost_usd)
         attempts = 0
-        while not verdict.passed and attempts < cap:
+        # Only revise when the judge is calibrated (hard_gate).  A soft_signal
+        # verdict means kappa < KAPPA_FLOOR — we don't trust the judge enough to
+        # spend money on a revise loop; return the scored verdict as-is.
+        while verdict.mode == "hard_gate" and not verdict.passed and attempts < cap:
             self._ensure_affordable(budget, est_call_cost_usd)
             attempts += 1
             critique = {

--- a/evaluation/domains/copy.py
+++ b/evaluation/domains/copy.py
@@ -183,6 +183,7 @@ class CopyAdapter:
         self,
         regenerate_fn: Callable[[CopyBrief, dict], Awaitable[str]] | None = None,
         review_state_path: Path | None = None,
+        mode: str = "soft_signal",
     ) -> None:
         self._regenerate_fn = regenerate_fn
         self._review_state = (
@@ -190,6 +191,7 @@ class CopyAdapter:
             if review_state_path
             else (Path(__file__).parent / "copy-review-state.json")
         )
+        self._mode = mode
 
     def deterministic_checks(self, subject: str, ref: CopyBrief) -> list[str]:
         text = subject or ""
@@ -242,6 +244,7 @@ class CopyAdapter:
             failure_tags=all_tags,
             reason=str(judge_output.get("reason", ""))[:300],
             detail={"brand_analysis": judge_output.get("brand_analysis", "")},
+            mode=self._mode,
         )
 
     async def revise(self, ref: CopyBrief, critique: dict) -> str:

--- a/scripts/build_brand_centroid.py
+++ b/scripts/build_brand_centroid.py
@@ -37,10 +37,22 @@ def main() -> int:
         help="Vision encoder: 'clip' (CLIP-base, default) or 'dino' (DINOv2, "
         "stronger image-only similarity).",
     )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help="Optional JSON allowlist of approved filenames. Accepts a list "
+        '["a.png", ...] or an object {"approved": ["a.png", ...]}. '
+        "Only listed files are used; a missing file raises an error.",
+    )
     args = parser.parse_args()
 
     if not args.approved_dir.is_dir():
         print(f"FATAL: approved-dir not found: {args.approved_dir}", file=sys.stderr)
+        return 1
+
+    if args.manifest is not None and not args.manifest.is_file():
+        print(f"FATAL: manifest not found: {args.manifest}", file=sys.stderr)
         return 1
 
     print(f"Building {args.encoder} centroid from {args.approved_dir}...")
@@ -48,6 +60,7 @@ def main() -> int:
         args.approved_dir,
         threshold_percentile=args.threshold_percentile,
         encoder=args.encoder,
+        manifest=args.manifest,
     )
     save_centroid(centroid, args.output)
     print(

--- a/skyyrose/elite_studio/quality/brand_centroid.py
+++ b/skyyrose/elite_studio/quality/brand_centroid.py
@@ -47,6 +47,10 @@ EncoderName = Literal["clip", "dino"]
 # cost (e.g. the oai_render QC gate) reference this constant instead of forking a copy.
 DEFAULT_CENTROID_PATH = Path(__file__).resolve().parents[1] / "data" / "brand_centroid.npz"
 
+# Minimum number of approved images required to build a stable centroid.
+# A mean embedding from fewer images is too noisy to be a reliable gate.
+MIN_APPROVED = 8
+
 SIDECAR_SCHEMA_VERSION = 1
 
 
@@ -104,6 +108,7 @@ def build_centroid(
     approved_dir: Path,
     threshold_percentile: float = 10.0,
     encoder: EncoderName = "clip",
+    manifest: Path | None = None,
 ) -> BrandCentroid:
     """Compute centroid + a robust threshold from approved hero shots.
 
@@ -116,10 +121,39 @@ def build_centroid(
         approved_dir: Directory of approved hero shots.
         threshold_percentile: Lower = more permissive gate.
         encoder: "clip" or "dino". DINOv2 typically ~2x discrimination gap.
+        manifest: Optional JSON file specifying a curated allowlist of
+            filenames to use from ``approved_dir``.  Accepts either a plain
+            list of filenames (``["a.png", "b.png"]``) or an object with an
+            ``"approved"`` key (``{"approved": ["a.png", "b.png"]}``).
+            When provided, only images whose basename appears in the
+            allowlist are used.  A manifest entry that has no matching file
+            in ``approved_dir`` raises ``ValueError`` — no silent skips.
+            When ``None``, all images in ``approved_dir`` are used
+            (back-compat behaviour).
     """
     paths = _list_images(approved_dir)
     if not paths:
         raise ValueError(f"no image files in {approved_dir}")
+
+    if manifest is not None:
+        raw = json.loads(manifest.read_text())
+        if isinstance(raw, dict):
+            allowlist: list[str] = raw["approved"]
+        else:
+            allowlist = list(raw)
+        # Build a name→path map from the directory listing.
+        by_name = {p.name: p for p in paths}
+        filtered: list[Path] = []
+        for name in allowlist:
+            if name not in by_name:
+                raise ValueError(f"manifest entry {name!r} not found in {approved_dir}")
+            filtered.append(by_name[name])
+        paths = filtered
+
+    if len(paths) < MIN_APPROVED:
+        raise ValueError(
+            f"need >= {MIN_APPROVED} approved images for a stable centroid, got {len(paths)}"
+        )
 
     embeddings = np.stack([_embed(encoder, p) for p in paths])
     raw_centroid = embeddings.mean(axis=0)

--- a/tests/elite_studio/test_brand_centroid.py
+++ b/tests/elite_studio/test_brand_centroid.py
@@ -16,12 +16,17 @@ from skyyrose.elite_studio.quality import brand_centroid
 pytestmark = pytest.mark.slow
 
 
+_N_APPROVED = 8  # must match MIN_APPROVED in brand_centroid
+
+
 @pytest.fixture
 def approved_dir(tmp_path: Path) -> Path:
     d = tmp_path / "approved"
     d.mkdir()
-    for i, color in enumerate([(20, 20, 20), (40, 40, 40), (10, 10, 10)]):
-        Image.new("RGB", (224, 224), color=color).save(d / f"shot_{i}.png")
+    # Use _N_APPROVED distinct grey shades so we meet the MIN_APPROVED floor.
+    shades = [int(i * 255 / (_N_APPROVED - 1)) for i in range(_N_APPROVED)]
+    for i, shade in enumerate(shades):
+        Image.new("RGB", (224, 224), color=(shade, shade, shade)).save(d / f"shot_{i}.png")
     return d
 
 
@@ -29,7 +34,7 @@ def test_build_centroid_returns_normalized_vector(approved_dir: Path) -> None:
     result = brand_centroid.build_centroid(approved_dir)
     assert result.centroid.shape == (512,)
     assert pytest.approx(float(np.linalg.norm(result.centroid)), abs=1e-4) == 1.0
-    assert result.sample_count == 3
+    assert result.sample_count == _N_APPROVED
 
 
 def test_build_centroid_records_threshold(approved_dir: Path) -> None:

--- a/tests/elite_studio/test_brand_centroid_floor.py
+++ b/tests/elite_studio/test_brand_centroid_floor.py
@@ -1,0 +1,139 @@
+"""Model-free tests for brand_centroid MIN_APPROVED floor + manifest allowlist.
+
+These tests monkeypatch ``_embed`` so no CLIP/DINOv2 model is loaded.
+They run in the default (non-slow) suite.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from skyyrose.elite_studio.quality import brand_centroid
+from skyyrose.elite_studio.quality.brand_centroid import MIN_APPROVED, build_centroid
+
+
+def _make_images(directory: Path, n: int) -> list[Path]:
+    """Write ``n`` minimal PNG stubs (zero-byte files with .png extension)."""
+    paths = []
+    for i in range(n):
+        p = directory / f"img_{i:03d}.png"
+        p.touch()
+        paths.append(p)
+    return paths
+
+
+def _fixed_embed(encoder, path: Path) -> np.ndarray:
+    """Return a deterministic nonzero unit vector keyed on the filename."""
+    seed = int.from_bytes(path.name.encode(), "little") % (2**31)
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal(512).astype(np.float32)
+    return v / np.linalg.norm(v)
+
+
+# ── MIN_APPROVED floor ────────────────────────────────────────────────────────
+
+
+def test_floor_raises_when_below_min(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(brand_centroid, "_embed", _fixed_embed)
+    d = tmp_path / "approved"
+    d.mkdir()
+    _make_images(d, MIN_APPROVED - 1)
+
+    with pytest.raises(ValueError, match=str(MIN_APPROVED)):
+        build_centroid(d)
+
+
+def test_floor_passes_at_exactly_min(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(brand_centroid, "_embed", _fixed_embed)
+    d = tmp_path / "approved"
+    d.mkdir()
+    _make_images(d, MIN_APPROVED)
+
+    result = build_centroid(d)
+    assert result.sample_count == MIN_APPROVED
+    assert result.centroid.shape == (512,)
+    assert pytest.approx(float(np.linalg.norm(result.centroid)), abs=1e-4) == 1.0
+
+
+# ── manifest allowlist ────────────────────────────────────────────────────────
+
+
+def test_manifest_list_format_selects_subset(tmp_path: Path, monkeypatch) -> None:
+    """Manifest as a plain list selects only those files; centroid uses subset."""
+    monkeypatch.setattr(brand_centroid, "_embed", _fixed_embed)
+    d = tmp_path / "approved"
+    d.mkdir()
+    all_paths = _make_images(d, MIN_APPROVED + 4)  # 12 total
+    subset_names = [p.name for p in all_paths[:MIN_APPROVED]]  # pick first 8
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps(subset_names))
+
+    result = build_centroid(d, manifest=manifest)
+    assert result.sample_count == MIN_APPROVED
+    assert set(Path(p).name for p in result.sample_paths) == set(subset_names)
+
+
+def test_manifest_object_format_selects_subset(tmp_path: Path, monkeypatch) -> None:
+    """Manifest as {"approved": [...]} is also accepted."""
+    monkeypatch.setattr(brand_centroid, "_embed", _fixed_embed)
+    d = tmp_path / "approved"
+    d.mkdir()
+    all_paths = _make_images(d, MIN_APPROVED + 2)
+    subset_names = [p.name for p in all_paths[:MIN_APPROVED]]
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"approved": subset_names}))
+
+    result = build_centroid(d, manifest=manifest)
+    assert result.sample_count == MIN_APPROVED
+    assert set(Path(p).name for p in result.sample_paths) == set(subset_names)
+
+
+def test_manifest_missing_file_raises(tmp_path: Path, monkeypatch) -> None:
+    """A manifest entry with no matching file in approved_dir is an error."""
+    monkeypatch.setattr(brand_centroid, "_embed", _fixed_embed)
+    d = tmp_path / "approved"
+    d.mkdir()
+    _make_images(d, MIN_APPROVED)
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps(["does_not_exist.png"]))
+
+    with pytest.raises(ValueError, match="does_not_exist.png"):
+        build_centroid(d, manifest=manifest)
+
+
+def test_manifest_subset_below_floor_raises(tmp_path: Path, monkeypatch) -> None:
+    """Manifest that selects fewer than MIN_APPROVED files raises the floor error."""
+    monkeypatch.setattr(brand_centroid, "_embed", _fixed_embed)
+    d = tmp_path / "approved"
+    d.mkdir()
+    all_paths = _make_images(d, MIN_APPROVED + 2)
+    # Select only 3 — below the floor.
+    subset_names = [p.name for p in all_paths[:3]]
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps(subset_names))
+
+    with pytest.raises(ValueError, match=str(MIN_APPROVED)):
+        build_centroid(d, manifest=manifest)
+
+
+# ── back-compat: no manifest + >= MIN_APPROVED ────────────────────────────────
+
+
+def test_no_manifest_uses_all_images(tmp_path: Path, monkeypatch) -> None:
+    """Without a manifest, all images in approved_dir are used (back-compat)."""
+    monkeypatch.setattr(brand_centroid, "_embed", _fixed_embed)
+    d = tmp_path / "approved"
+    d.mkdir()
+    n = MIN_APPROVED + 3
+    _make_images(d, n)
+
+    result = build_centroid(d)
+    assert result.sample_count == n

--- a/tests/quality/test_copy_evaluator_e2e.py
+++ b/tests/quality/test_copy_evaluator_e2e.py
@@ -148,7 +148,10 @@ async def test_gate_default_budget_blocks_runaway_revisions():
     async def producer(ref):
         return "weak draft"
 
-    agent = CopyEvaluator(judge_fn=judge, adapter=CopyAdapter(regenerate_fn=regenerate_fn))
+    agent = CopyEvaluator(
+        judge_fn=judge,
+        adapter=CopyAdapter(regenerate_fn=regenerate_fn, mode="hard_gate"),
+    )
 
     with pytest.raises(CostCapExceeded):
         await agent.gate(ref=_brief(), producer=producer, cap=50)
@@ -173,7 +176,10 @@ async def test_gate_unbounded_opt_out_still_runs_full_cap():
     async def producer(ref):
         return "weak draft"
 
-    agent = CopyEvaluator(judge_fn=judge, adapter=CopyAdapter(regenerate_fn=regenerate_fn))
+    agent = CopyEvaluator(
+        judge_fn=judge,
+        adapter=CopyAdapter(regenerate_fn=regenerate_fn, mode="hard_gate"),
+    )
     v = await agent.gate(ref=_brief(), producer=producer, cap=5, unbounded=True)
 
     assert v.attempts == 5

--- a/tests/quality/test_copy_evaluator_e2e.py
+++ b/tests/quality/test_copy_evaluator_e2e.py
@@ -98,7 +98,10 @@ async def test_gate_revises_once_then_passes():
     async def producer(ref):
         return "Initial draft, weak voice."
 
-    agent = CopyEvaluator(judge_fn=judge, adapter=CopyAdapter(regenerate_fn=regenerate_fn))
+    agent = CopyEvaluator(
+        judge_fn=judge,
+        adapter=CopyAdapter(regenerate_fn=regenerate_fn, mode="hard_gate"),
+    )
     v = await agent.gate(ref=_brief(), producer=producer, cap=2)
 
     assert v.passed is True
@@ -119,7 +122,10 @@ async def test_gate_caps_revisions_when_never_passes():
     async def producer(ref):
         return "weak draft"
 
-    agent = CopyEvaluator(judge_fn=judge, adapter=CopyAdapter(regenerate_fn=regenerate_fn))
+    agent = CopyEvaluator(
+        judge_fn=judge,
+        adapter=CopyAdapter(regenerate_fn=regenerate_fn, mode="hard_gate"),
+    )
     v = await agent.gate(ref=_brief(), producer=producer, cap=2)
 
     assert v.passed is False

--- a/tests/quality/test_eval_core.py
+++ b/tests/quality/test_eval_core.py
@@ -28,7 +28,7 @@ class _Adapter:
         return []
 
 
-def _v(passed, score=1.0):
+def _v(passed, score=1.0, mode="hard_gate"):
     return Verdict(
         domain="test",
         passed=passed,
@@ -37,6 +37,7 @@ def _v(passed, score=1.0):
         failure_tags=() if passed else ("x",),
         reason="",
         cost_usd=0.01,
+        mode=mode,
     )
 
 
@@ -86,3 +87,39 @@ async def test_gate_exhausts_cap_and_returns_failing_verdict():
 
     v = await core.gate(ad, ref={}, producer=_producer, cap=2)
     assert v.passed is False and v.attempts == 2
+
+
+async def test_gate_soft_signal_does_not_revise():
+    """soft_signal verdict (uncalibrated judge) must not trigger the revise loop."""
+    revise_calls = 0
+
+    class _TrackingAdapter(_Adapter):
+        async def revise(self, ref, critique):
+            nonlocal revise_calls
+            revise_calls += 1
+            return "revised"
+
+    core = EvaluationCore(judge_fn=lambda req: ({}, 0.01))
+    ad = _TrackingAdapter(det=[], verdicts=[_v(False, mode="soft_signal")])
+
+    async def _producer(ref):
+        return "initial"
+
+    v = await core.gate(ad, ref={}, producer=_producer, cap=3)
+    assert v.passed is False
+    assert v.attempts == 0  # loop never entered
+    assert revise_calls == 0  # revise never called
+
+
+async def test_gate_hard_gate_revises_to_cap():
+    """hard_gate failing verdict must run the revise loop up to cap."""
+    core = EvaluationCore(judge_fn=lambda req: ({}, 0.01))
+    # Three failing hard_gate verdicts; cap=2 means 2 revisions maximum.
+    ad = _Adapter(det=[], verdicts=[_v(False), _v(False), _v(False)])
+
+    async def _producer(ref):
+        return "initial"
+
+    v = await core.gate(ad, ref={}, producer=_producer, cap=2)
+    assert v.passed is False
+    assert v.attempts == 2  # revise loop ran the full cap

--- a/tests/quality/test_eval_cost_cap.py
+++ b/tests/quality/test_eval_cost_cap.py
@@ -37,7 +37,7 @@ class _Adapter:
         return "revised"
 
 
-def _v(passed, cost=0.01):
+def _v(passed, cost=0.01, mode="hard_gate"):
     return Verdict(
         domain="test",
         passed=passed,
@@ -46,6 +46,7 @@ def _v(passed, cost=0.01):
         failure_tags=() if passed else ("x",),
         reason="",
         cost_usd=cost,
+        mode=mode,
     )
 
 


### PR DESCRIPTION
## What

Two HIGH Track-Q hardening fixes from the embeddings-reframe register (spec lines 183–184), both verified first-hand (the spec markers are `⊘` audit-grounded — and Q-data's was partly stale).

## Q-mode — wire `verdict.mode` into the gate action

`EvaluationCore.gate()` ran the paid producer→judge→**revise** loop on `not verdict.passed` alone, **ignoring `verdict.mode`** — so an uncalibrated judge (`soft_signal`, Cohen's κ < `KAPPA_FLOOR` 0.65) drove the same paid revisions as a calibrated one. `decide_mode(κ)` computed the mode but it was only ever *printed* by an offline eval script, never wired to runtime.

- `gate()` revise loop is now gated on `verdict.mode == "hard_gate"`. A `soft_signal` verdict is **advisory** — returned as-is, no paid revise.
- `CopyAdapter` gains a `mode` param (default `"soft_signal"`) that `parse_verdict` stamps onto the verdict — a domain is promoted to `hard_gate` only after calibration confirms κ ≥ 0.65.
- **Safe:** `gate()` is not on the live content path (content uses single-shot `evaluate()`); this is hardening before promotion.

## Q-data — curated allowlist + min-sample floor for the brand centroid

`build_centroid` globbed **all** images in `approved_dir` with only an empty-check — a 1-image dir built a degenerate/noisy centroid, and there was no curation. (The spec also said "make `--approved-dir` required" — **already done** in the live CLI; that part was stale.)

- `MIN_APPROVED = 8` floor — raises below it (a mean embedding from fewer images is too noisy to gate on).
- Optional curated `manifest.json` allowlist — filters `approved_dir` to listed basenames; a manifest entry with **no matching file raises** (no silent skips). `None` = all images (back-compat).
- CLI gains `--manifest`; `--approved-dir` left required.

## Test plan

- [x] TDD — `test_gate_soft_signal_does_not_revise` (asserts `attempts==0` **and** `revise` never called) + `test_gate_hard_gate_revises_to_cap`. Existing revise-loop tests set `mode="hard_gate"` (a calibrated-gate represents the enforce path — an honest contract update, **not** a weakening).
- [x] New `tests/elite_studio/test_brand_centroid_floor.py` — model-free (encoder mocked) floor + allowlist + missing-entry tests.
- [x] Full `tests/quality/` + brand-centroid suites green (my independent re-run); `evaluation.core` + `brand_centroid` import cleanly; ruff/black/isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wire calibrated-only revise loops into the evaluation gate and add brand centroid data controls. This prevents paid revisions on uncalibrated judges and stabilizes centroid quality with a sample floor and optional curation.

- **Bug Fixes**
  - Only run the revise loop when `verdict.mode == "hard_gate"`; `soft_signal` verdicts return as-is.
  - `CopyAdapter` now accepts `mode` (default `soft_signal`) and stamps it on the verdict; promote to `hard_gate` after judge calibration.
  - Brand centroid: enforce `MIN_APPROVED = 8`; add optional `manifest.json` allowlist (list or `{"approved": [...]}`); missing entries raise; CLI adds and validates `--manifest`.

- **Migration**
  - Ensure at least 8 approved images in `--approved-dir` or centroid build will fail.
  - Use `--manifest` to curate images; all listed files must exist in the directory.
  - After calibrating a domain, pass `mode="hard_gate"` to `CopyAdapter` to enable revise loops.

<sup>Written for commit 326264915364290ba3c7157791db1b2ef2be7229. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Evaluation Improvements**
  * Soft-signal failures now return results without triggering automatic revisions.
  * Hard-gate failures continue revising up to the configured attempt limit.
  * Copy evaluations can now specify their review mode.

* **Brand Quality**
  * Added support for approved-image manifests when building brand centroids.
  * Centroid generation now requires at least eight approved images.
  * Added validation for missing or insufficient manifest entries.

* **Tests**
  * Expanded coverage for evaluation modes, revision behavior, image manifests, and minimum image requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->