### PR TITLE
feat(qc-tools): file://-robust GLB + render-review QC sheets

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -57,6 +57,8 @@
 - `pyrightconfig.json` (~332 tok)
 - `README.md` — Project documentation (~1442 tok)
 - `render-review.html` — all-engines render keep/delete QC sheet, 1719 inline `<img>` across 18 engine groups (HUB/source/OAI/Gemini/FLUX/Tripo/LoRA/legacy/…); localStorage marks + Blob delete-list download; works over file:// (plain images, no decoder), file://-robust via per-img "⚠ file missing" badge + accurate note (~190000 tok — do NOT full-read; edit by anchor) (~190k tok)
+- `requirements-dev.txt` — Development Dependencies (~85 tok)
+- `requirements-full.txt` — DevSkyy - Full ML/3D Dependencies (~46 tok)
 - `requirements-imagery.txt` — Nano Banana 2 — SkyyRose AI Image Pipeline (~130 tok)
 - `requirements-trellis.txt` — TRELLIS clothing 3D pipeline dependencies (~326 tok)
 - `run_generation.sh` (~179 tok)

--- a/glb-models.html
+++ b/glb-models.html
@@ -148,6 +148,11 @@ dl.onclick=()=>{const del=tiles.filter(t=>t.dataset.state=='del').map(t=>t.datas
 // file:// robustness: show the HTTP-server banner and flag any tile whose model fails to load
 if(location.protocol==='file:')fwarn.style.display='block';
 fwx.onclick=()=>fwarn.style.display='none';
-tiles.forEach(t=>{const m=t.querySelector('model-viewer');m.addEventListener('error',()=>{t.dataset.err='1';});m.addEventListener('load',()=>{t.dataset.err='';});});
+if(typeof fwx!=='undefined')fwx.setAttribute('aria-label','Dismiss notice');
+tiles.forEach(t=>{const m=t.querySelector('model-viewer');const sku=t.dataset.sku||'model';
+  const k=t.querySelector('.k'),d=t.querySelector('.d');if(k)k.setAttribute('aria-label','Keep '+sku);if(d)d.setAttribute('aria-label','Delete '+sku);
+  if(!m)return;m.setAttribute('aria-label','3D model '+sku);
+  m.addEventListener('error',()=>{t.dataset.err='1';t.setAttribute('role','alert');t.setAttribute('aria-label',sku+' failed to load — serve over HTTP');});
+  m.addEventListener('load',()=>{t.dataset.err='';t.removeAttribute('role');t.removeAttribute('aria-label');});});
 c();
 </script></body></html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,7 +393,7 @@ exclude = ["tests*", "docs*", "legacy*"]
 # =============================================================================
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py313"
 line-length = 100
 exclude = [
     "legacy/",
@@ -465,7 +465,7 @@ known-first-party = ["core", "api", "security", "database", "wordpress", "agents
 
 [tool.black]
 line-length = 100
-target-version = ["py312"]
+target-version = ["py313"]
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,7 +393,7 @@ exclude = ["tests*", "docs*", "legacy*"]
 # =============================================================================
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py312"
 line-length = 100
 exclude = [
     "legacy/",
@@ -465,7 +465,7 @@ known-first-party = ["core", "api", "security", "database", "wordpress", "agents
 
 [tool.black]
 line-length = 100
-target-version = ["py313"]
+target-version = ["py312"]
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/render-review.html
+++ b/render-review.html
@@ -45,6 +45,13 @@ dl.onclick=()=>{const del=tiles.filter(t=>t.dataset.state==='del').map(t=>t.data
 // file:// note (accurate: images work locally) + per-image broken-file badge
 if(location.protocol==='file:')pnote.style.display='block';
 if(typeof pnx!=='undefined')pnx.onclick=()=>pnote.style.display='none';
-tiles.forEach(t=>{const img=t.querySelector('img');if(!img)return;const mark=()=>{t.dataset.err='1';};if(img.complete&&img.naturalWidth===0&&img.getAttribute('src'))mark();img.addEventListener('error',mark);img.addEventListener('load',()=>{if(t.dataset.err)t.dataset.err='';});});
+if(typeof pnx!=='undefined')pnx.setAttribute('aria-label','Dismiss notice');
+tiles.forEach(t=>{const img=t.querySelector('img');const path=t.dataset.path||'';const name=path.split('/').pop()||'render';
+  const k=t.querySelector('.k'),d=t.querySelector('.d');if(k)k.setAttribute('aria-label','Keep '+name);if(d)d.setAttribute('aria-label','Delete '+name);
+  if(!img)return;if(!img.getAttribute('alt'))img.setAttribute('alt','render '+name);
+  const mark=()=>{t.dataset.err='1';t.setAttribute('role','alert');t.setAttribute('aria-label','Image missing: '+name+' — serve over HTTP');};
+  if(img.complete&&img.naturalWidth===0&&img.getAttribute('src'))mark();
+  img.addEventListener('error',mark);
+  img.addEventListener('load',()=>{if(t.dataset.err){t.dataset.err='';t.removeAttribute('role');t.removeAttribute('aria-label');}});});
 counts();
 </script></body></html>


### PR DESCRIPTION
## What

Make the two standalone 3D/render QC review sheets robust when opened from `file://`, not just over an HTTP server.

### `glb-models.html` (33-SKU GLB keep/delete sheet)
- **Protocol-aware decoder config** — vendored local decoders (`renders/3d/_viewer/`) when served over HTTP; verified CDN fallback on `file://`:
  - meshopt → `cdn.jsdelivr.net/npm/meshoptimizer/meshopt_decoder.js`
  - ktx2/basis → `cdn.jsdelivr.net/npm/three@0.172.0/.../libs/basis/` (pinned)
  - draco → `gstatic.com/draco/versioned/decoders/1.5.6/`
- `#fwarn` banner (file:// only) with the exact `python3 -m http.server` command + per-tile load-error badge.
- Resolves the meshopt-decoder-not-initialized timeout (bug-164). The earlier "8/33 loaded" was `loading="lazy"` working as designed, not a failure.

### `render-review.html` (1719-image all-engines sheet)
- Per-`<img>` `onerror` "⚠ file missing" badge (the real failure mode for 1719 paths).
- Accurate `file://` info-note: images load locally, no CDN/decoder needed — unlike the GLB sheet (`<img>` element loads are not subject to Chrome's `file://` fetch block).

## Why
`file://` blocks `fetch()` of local WASM workers (GLB sheet) but not `<img>` element loads (render sheet). Each page now degrades honestly for its own mechanism instead of silently timing out / showing blank tiles.

## Verification (Playwright, HTTP `:8010`)
- `glb-models.html`: 33/33 `<model-viewer>` loaded, 0 load errors, geometry renders; CDN fallback URLs all curl-200 (gstatic `modelviewer/thirdparty` mirror 404s — caught by curl, not docs).
- `render-review.html`: 1719 tiles, `counts()` runs, 0 false error-flags, 0 console errors, banner hidden on HTTP; file:// banner + badge verified via computed-style (767KB page exceeds the 5s screenshot rasterize cap).

## Scope
Two untracked standalone HTML QC tools + OpenWolf learning entries (`.wolf/cerebrum.md`, `.wolf/anatomy.md`). No production code, no library deps, no theme/site changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the GLB and render QC sheets reliable when opened from file:// with clear warnings, CDN fallbacks, and stronger accessibility.

- **New Features**
  - `glb-models.html`: configures `@google/model-viewer` decoders before the first element; `meshopt`/`ktx2` use vendored decoders over HTTP with CDN fallback on `file://` (`meshopt` via jsDelivr, `ktx2/basis` via `three@0.172.0`); `draco` via `gstatic`; shows a `file://` server banner; per-tile load-error badge with role=alert; aria-labels on model tiles, keep/delete buttons, and dismiss; delete-list download.
  - `render-review.html`: per-image “⚠ file missing” badge with role=alert; accurate `file://` note (plain `<img>` loads, no decoders); alt text for renders; aria-labels on keep/delete buttons and dismiss.

- **Migration**
  - GLB sheet must be served over HTTP: `python3 -m http.server 8010` → `http://127.0.0.1:8010/glb-models.html`.
  - Image sheet requires no server; open `render-review.html` directly.

<sup>Written for commit f9d67205915caa124b6b61d59c2b6eee93f879b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

