### PR TITLE
feat(observability): wire brand-centroid gate scores into token_tracker → EmbeddingObserver [Track-OBS]

### DIFF
--- a/core/token_tracker.py
+++ b/core/token_tracker.py
@@ -37,6 +37,7 @@ class TaskType(StrEnum):
     TRANSLATE = "translate"
     CODE = "code"
     EMBED = "embed"  # OBS-wire: server-side image/text embedding encode
+    GATE = "gate"  # OBS-wire: brand-centroid gate verdict (cosine score vs centroid)
 
 
 # Provider cost per 1M tokens (as of 2026-01-08)
@@ -410,3 +411,59 @@ def record_embedding_usage(
         )
     except Exception:  # noqa: BLE001 — telemetry must never break the encode path
         logger.warning("record_embedding_usage_failed", exc_info=True)
+
+
+def record_gate_score(
+    *,
+    model: str,
+    score: float,
+    accepted: bool,
+    threshold: float,
+    subject: str | None = None,
+    agent_id: str | None = None,
+) -> None:
+    """Record one brand-centroid gate verdict into the global tracker.
+
+    OBS-wire: ``embedding_gate.evaluate`` produced a cosine score per render but emitted
+    nothing, so ``EmbeddingObserver`` (PSI drift) had no signal. One ``TaskType.GATE`` row
+    per evaluate carries ``score``/``accepted``/``threshold`` in metadata; ``gate_scores``
+    reads them back. Gate scoring uses local embedding weights, so token counts and cost
+    are 0. NEVER raises — telemetry must not break the gate.
+    """
+    try:
+        meta: dict[str, Any] = {
+            "score": float(score),
+            "accepted": bool(accepted),
+            "threshold": float(threshold),
+        }
+        if subject is not None:
+            meta["subject"] = subject
+        get_token_tracker().record(
+            TokenUsage(
+                provider="embeddings",
+                model=model,
+                task_type=TaskType.GATE,
+                agent_id=agent_id if agent_id is not None else current_agent_id.get(),
+                input_tokens=0,
+                output_tokens=0,
+                metadata=meta,
+            )
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break the gate
+        logger.warning("record_gate_score_failed", exc_info=True)
+
+
+def gate_scores(since: datetime | None = None) -> list[float]:
+    """Cosine scores from recorded ``TaskType.GATE`` rows, oldest-first.
+
+    The read path the ``EmbeddingObserver`` consumes as ``live_scores`` for PSI drift.
+    Filters out non-gate rows (EMBED encodes, LLM calls) and any malformed gate row.
+    """
+    out: list[float] = []
+    for u in get_token_tracker().records(since):
+        if u.task_type is TaskType.GATE and "score" in u.metadata:
+            try:
+                out.append(float(u.metadata["score"]))
+            except (TypeError, ValueError):
+                continue
+    return out

--- a/skyyrose/elite_studio/quality/embedding_gate.py
+++ b/skyyrose/elite_studio/quality/embedding_gate.py
@@ -48,18 +48,45 @@ def score_against_centroid(image: Path | str | Image.Image, centroid: BrandCentr
 
 
 def evaluate(image: Path | str | Image.Image, centroid: BrandCentroid) -> GateVerdict:
-    """Decide whether `image` is on-brand enough to proceed to paid QA."""
+    """Decide whether `image` is on-brand enough to proceed to paid QA.
+
+    Emits the verdict score to the token tracker (Track-OBS) so ``EmbeddingObserver`` can
+    compute PSI drift over the gate-score distribution. Emission is the single chokepoint
+    every gate site funnels through, and never affects the returned verdict.
+    """
     score = score_against_centroid(image, centroid)
     if score >= centroid.threshold:
-        return GateVerdict(
+        verdict = GateVerdict(
             accepted=True,
             score=score,
             threshold=centroid.threshold,
             reason=f"on-brand (score {score:.3f} >= threshold {centroid.threshold:.3f})",
         )
-    return GateVerdict(
-        accepted=False,
-        score=score,
-        threshold=centroid.threshold,
-        reason=(f"below brand threshold (score {score:.3f} < threshold {centroid.threshold:.3f})"),
-    )
+    else:
+        verdict = GateVerdict(
+            accepted=False,
+            score=score,
+            threshold=centroid.threshold,
+            reason=f"below brand threshold (score {score:.3f} < threshold {centroid.threshold:.3f})",
+        )
+    _emit_gate_score(centroid.model_id, verdict)
+    return verdict
+
+
+def _emit_gate_score(model_id: str, verdict: GateVerdict) -> None:
+    """Record the gate verdict's score for PSI-drift observability (Track-OBS).
+
+    Telemetry must NEVER break the gate, so both the import and the call are guarded — the
+    verdict is returned regardless of the tracker's availability or failure.
+    """
+    try:
+        from core.token_tracker import record_gate_score
+
+        record_gate_score(
+            model=model_id,
+            score=verdict.score,
+            accepted=verdict.accepted,
+            threshold=verdict.threshold,
+        )
+    except Exception:  # noqa: BLE001 — observability must not affect gating
+        pass

--- a/tests/core/test_token_tracker_gate.py
+++ b/tests/core/test_token_tracker_gate.py
@@ -1,0 +1,74 @@
+"""Track-OBS: brand-centroid gate-score telemetry in token_tracker.
+
+The embedding gate (``embedding_gate.evaluate``) produces a cosine score per render
+but emitted nothing, so ``EmbeddingObserver`` (PSI drift) had no signal. These rows
+(``TaskType.GATE``) carry the score/accepted/threshold; ``gate_scores()`` is the read
+path the observer consumes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core import token_tracker
+from core.token_tracker import (
+    TaskType,
+    gate_scores,
+    get_token_tracker,
+    record_embedding_usage,
+    record_gate_score,
+)
+
+
+def _fresh():
+    t = get_token_tracker()
+    t.clear()
+    return t
+
+
+def test_record_gate_score_adds_zero_cost_gate_row():
+    t = _fresh()
+    record_gate_score(model="test", score=0.72, accepted=True, threshold=0.65, subject="br-001")
+    rows = t.records()
+    assert len(rows) == 1
+    r = rows[0]
+    assert r.task_type == TaskType.GATE
+    assert r.provider == "embeddings"
+    assert r.metadata["score"] == pytest.approx(0.72)
+    assert r.metadata["accepted"] is True
+    assert r.metadata["threshold"] == pytest.approx(0.65)
+    assert r.metadata["subject"] == "br-001"
+    # gate scoring uses local weights — no token cost
+    assert r.input_tokens == 0 and r.output_tokens == 0 and r.calculate_cost() == 0.0
+
+
+def test_gate_scores_returns_only_gate_rows():
+    _fresh()
+    record_gate_score(model="test", score=0.50, accepted=False, threshold=0.65)
+    record_gate_score(model="test", score=0.90, accepted=True, threshold=0.65)
+    # an embedding ENCODE row must not pollute the gate-score stream
+    record_embedding_usage(model="test")
+    assert gate_scores() == [pytest.approx(0.50), pytest.approx(0.90)]
+
+
+def test_gate_scores_since_filter():
+    t = _fresh()
+    record_gate_score(model="test", score=0.10, accepted=False, threshold=0.65)
+    cutoff = t.records()[-1].timestamp
+    record_gate_score(model="test", score=0.95, accepted=True, threshold=0.65)
+    after = gate_scores(since=cutoff)
+    # only scores at/after the cutoff timestamp
+    assert 0.95 in [pytest.approx(s) for s in after] or after == [pytest.approx(0.95)]
+
+
+def test_record_gate_score_never_raises(monkeypatch):
+    # telemetry must NEVER break the gate: a tracker failure is swallowed.
+    _fresh()
+
+    class Boom:
+        def record(self, *_a, **_k):
+            raise RuntimeError("tracker down")
+
+    monkeypatch.setattr(token_tracker, "get_token_tracker", lambda: Boom())
+    # must not raise
+    record_gate_score(model="test", score=0.5, accepted=True, threshold=0.65)

--- a/tests/elite_studio/test_embedding_gate.py
+++ b/tests/elite_studio/test_embedding_gate.py
@@ -51,3 +51,38 @@ def test_evaluate_rejects_below_threshold(
     verdict = embedding_gate.evaluate(render_image, fake_centroid)
     assert verdict.accepted is False
     assert "below" in verdict.reason.lower()
+
+
+@pytest.mark.unit
+def test_evaluate_emits_gate_score_to_tracker(
+    fake_centroid: BrandCentroid, render_image: Path, monkeypatch
+) -> None:
+    # Track-OBS: every evaluate records its verdict score for PSI-drift observability.
+    from core import token_tracker
+
+    monkeypatch.setattr(embedding_gate, "score_against_centroid", lambda *_a, **_kw: 0.80)
+    token_tracker.get_token_tracker().clear()
+    embedding_gate.evaluate(render_image, fake_centroid)
+    assert token_tracker.gate_scores() == [pytest.approx(0.80)]
+    row = token_tracker.get_token_tracker().records()[-1]
+    assert row.task_type is token_tracker.TaskType.GATE
+    assert row.model == "test"  # centroid.model_id
+    assert row.metadata["accepted"] is True
+    assert row.metadata["threshold"] == pytest.approx(0.65)
+
+
+@pytest.mark.unit
+def test_evaluate_telemetry_failure_does_not_break_gate(
+    fake_centroid: BrandCentroid, render_image: Path, monkeypatch
+) -> None:
+    # A broken tracker must never break the gate verdict.
+    from core import token_tracker
+
+    monkeypatch.setattr(embedding_gate, "score_against_centroid", lambda *_a, **_kw: 0.80)
+    monkeypatch.setattr(
+        token_tracker,
+        "record_gate_score",
+        lambda **_k: (_ for _ in ()).throw(RuntimeError("telemetry down")),
+    )
+    verdict = embedding_gate.evaluate(render_image, fake_centroid)
+    assert verdict.accepted is True and verdict.score == pytest.approx(0.80)

--- a/tests/monitoring/test_embedding_observer.py
+++ b/tests/monitoring/test_embedding_observer.py
@@ -84,3 +84,23 @@ def test_format_gate_report_renders_markdown():
     out = format_gate_report(rep)
     assert "Embedding Gate Health" in out
     assert "psi_drift" in out  # the drift alert is rendered
+
+
+def test_gate_scores_feed_observer_end_to_end():
+    # The wire Track-OBS closes: gate verdicts recorded via record_gate_score are read by
+    # gate_scores() and consumed by EmbeddingObserver as the live PSI distribution. Before
+    # this, the observer was built (#640) but had NO signal source.
+    from core import token_tracker
+    from core.token_tracker import gate_scores, record_gate_score
+
+    token_tracker.get_token_tracker().clear()
+    reference = PSIReference.from_scores([0.80, 0.82, 0.85, 0.83, 0.81, 0.84])  # on-brand
+    for s in [0.30, 0.32, 0.28, 0.35, 0.31, 0.29]:  # a drifted-off-brand run
+        record_gate_score(model="test", score=s, accepted=s >= 0.65, threshold=0.65)
+
+    live = gate_scores()
+    assert len(live) == 6
+    rep = EmbeddingObserver(reference=reference).evaluate(live, accepted=[False] * 6)
+    assert rep.n_scores == 6
+    assert rep.psi is not None and rep.psi > PSI_PAGE
+    assert any(a.rule == "psi_drift" and a.severity == AlertSeverity.PAGE for a in rep.alerts)


### PR DESCRIPTION
Closes the last gap in the Track-OBS observability slice: `EmbeddingObserver` (PSI drift, shipped #640) was **built but unwired** — `embedding_gate.evaluate` produced a cosine score per render and emitted nothing, so the observer had no live signal.

## What
- **`token_tracker.record_gate_score(...)`** — new `TaskType.GATE` row carrying `score`/`accepted`/`threshold` in metadata (0-cost — local embedding weights). Never raises (telemetry must not break the gate).
- **`token_tracker.gate_scores(since=None)`** — the read path the observer consumes as `live_scores` for PSI.
- **`embedding_gate.evaluate`** now emits each verdict via a guarded `_emit_gate_score` helper.

## Where it emits — the chokepoint, not the 3 sites
The gate is called from 3 *independent copies* of the same control flow (`compositor_agent.py:75`, `compositor/orchestrator.py:742`, `stage_g_visual_qa.py:164`) — a long-standing dual-copy (memory logs an alias "re-introduced after inline fix"). Emitting inside `evaluate()` — the single function all 3 call — gives:
- correct **per-render count** (exactly one emit per evaluate, no double-count),
- automatic coverage of all 3 sites **plus** the oai_render Q-fusion centroid check (#669),
- no triple-edit / no standing maintenance trap on the copies.

SKU isn't cleanly available at either the sites or `evaluate()`, and PSI only needs the score distribution, so the row carries score/accepted/threshold (no SKU).

## The wire, proven end-to-end
A test records gate verdicts via `record_gate_score`, reads them with `gate_scores()`, feeds them to `EmbeddingObserver.evaluate()`, and asserts a **PAGE-level `psi_drift` alert** on a drifted distribution — the exact path that was previously disconnected.

## Verification
- TDD: 4 token_tracker (gate row + read filter + `since` + never-raises) · 2 evaluate (emits + telemetry-failure-doesn't-break-gate) · 1 end-to-end wire.
- **347 passed / 0 failed / 1 skipped** across `tests/elite_studio` + `tests/core` + `tests/monitoring` (no regression from the emit).
- ruff + black + isort clean.

## Still open after this
Track-OBS `OBS-struct` (`logging`→`structlog`, target module unconfirmed); Track-Q `Q-calib` (deferred — needs a render rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jgg82oTFsM8bcJezB5Fyfv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires brand-centroid gate scores into `token_tracker` and feeds `EmbeddingObserver` so PSI drift has live data. Each `embedding_gate.evaluate` now emits a `TaskType.GATE` record; `gate_scores()` exposes the stream for the observer. [Track-OBS]

- **New Features**
  - `token_tracker.record_gate_score(model, score, accepted, threshold, ...)`: records zero-cost gate verdict metadata; never raises.
  - `token_tracker.gate_scores(since=None)`: returns cosine scores from `TaskType.GATE`, oldest-first; filters non-gate rows and malformed data.
  - `embedding_gate.evaluate(...)`: emits verdicts via guarded `_emit_gate_score`, using the single chokepoint to cover all gate call sites without double-counting.

<sup>Written for commit bd8ecddb6f8ce24ef163c245dea74e45091aad55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gate-score tracking to capture evaluation outcomes and score details.
  * Gate evaluations now emit score telemetry without affecting the result.

* **Bug Fixes**
  * Improved resilience so telemetry failures are ignored and no longer interrupt gate checks.
  * Score history now filters out unrelated records and skips malformed values.

* **Tests**
  * Added coverage for score recording, retrieval, timestamp filtering, and failure handling.
  * Added end-to-end coverage for drift detection using recorded gate scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->