### PR TITLE
refactor(embeddings): structlog event-name logging in embedding_engine

### DIFF
--- a/orchestration/embedding_engine.py
+++ b/orchestration/embedding_engine.py
@@ -17,16 +17,16 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import logging
 import os
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from enum import StrEnum
 from typing import Any
 
+import structlog
 from pydantic import BaseModel, ConfigDict, Field
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 # =============================================================================
@@ -72,7 +72,7 @@ class EmbeddingCache:
                 # Move to end (most recently used)
                 self._cache.move_to_end(key)
                 self._hits += 1
-                logger.debug(f"Embedding cache hit for key: {key[:8]}...")
+                logger.debug("embedding_cache_hit", key_prefix=key[:8])
                 return self._cache[key]
             self._misses += 1
             return None
@@ -124,7 +124,7 @@ def get_embedding_cache() -> EmbeddingCache:
     if _embedding_cache is None:
         cache_size = int(os.getenv("EMBEDDING_CACHE_SIZE", "1024"))
         _embedding_cache = EmbeddingCache(maxsize=cache_size)
-        logger.info(f"Initialized embedding cache with maxsize={cache_size}")
+        logger.info("embedding_cache_initialized", maxsize=cache_size)
     return _embedding_cache
 
 
@@ -247,7 +247,10 @@ class SentenceTransformerEngine(BaseEmbeddingEngine):
             self._dimension = self._model.get_sentence_embedding_dimension()
             self._initialized = True
             logger.info(
-                f"SentenceTransformer initialized: {self.config.st_model_name} (dim={self._dimension})"
+                "embedding_provider_initialized",
+                provider="sentence_transformer",
+                model=self.config.st_model_name,
+                dim=self._dimension,
             )
 
         except ImportError:
@@ -255,7 +258,11 @@ class SentenceTransformerEngine(BaseEmbeddingEngine):
                 "sentence-transformers not installed. Run: pip install sentence-transformers"
             )
         except Exception as e:
-            logger.error(f"SentenceTransformer initialization failed: {e}")
+            logger.error(
+                "embedding_provider_init_failed",
+                provider="sentence_transformer",
+                error=str(e),
+            )
             raise
 
     async def embed_text(self, text: str) -> list[float]:
@@ -334,13 +341,20 @@ class OpenAIEmbeddingEngine(BaseEmbeddingEngine):
             self._dimension = self.MODEL_DIMS.get(self.config.openai_model, 1536)
             self._initialized = True
             logger.info(
-                f"OpenAI Embeddings initialized: {self.config.openai_model} (dim={self._dimension})"
+                "embedding_provider_initialized",
+                provider="openai",
+                model=self.config.openai_model,
+                dim=self._dimension,
             )
 
         except ImportError:
             raise ImportError("openai not installed. Run: pip install openai")
         except Exception as e:
-            logger.error(f"OpenAI Embeddings initialization failed: {e}")
+            logger.error(
+                "embedding_provider_init_failed",
+                provider="openai",
+                error=str(e),
+            )
             raise
 
     async def embed_text(self, text: str) -> list[float]:
@@ -442,13 +456,20 @@ class CohereEmbeddingEngine(BaseEmbeddingEngine):
             self._dimension = self.MODEL_DIMS.get(self.config.cohere_model, 1024)
             self._initialized = True
             logger.info(
-                f"Cohere Embeddings initialized: {self.config.cohere_model} (dim={self._dimension})"
+                "embedding_provider_initialized",
+                provider="cohere",
+                model=self.config.cohere_model,
+                dim=self._dimension,
             )
 
         except ImportError:
             raise ImportError("cohere not installed. Run: pip install cohere")
         except Exception as e:
-            logger.error(f"Cohere Embeddings initialization failed: {e}")
+            logger.error(
+                "embedding_provider_init_failed",
+                provider="cohere",
+                error=str(e),
+            )
             raise
 
     async def embed_text(self, text: str) -> list[float]:
@@ -584,14 +605,21 @@ class VoyageEmbeddingEngine(BaseEmbeddingEngine):
             self._dimension = self.config.voyage_output_dimension or base_dim
             self._initialized = True
             logger.info(
-                f"Voyage Embeddings initialized: {self.config.voyage_model} "
-                f"(dim={self._dimension}, asymmetric=True)"
+                "embedding_provider_initialized",
+                provider="voyage",
+                model=self.config.voyage_model,
+                dim=self._dimension,
+                asymmetric=True,
             )
 
         except ImportError:
             raise ImportError("voyageai not installed. Run: pip install voyageai")
         except Exception as e:
-            logger.error(f"Voyage Embeddings initialization failed: {e}")
+            logger.error(
+                "embedding_provider_init_failed",
+                provider="voyage",
+                error=str(e),
+            )
             raise
 
     def _embed_kwargs(self, texts: list[str], input_type: str) -> dict[str, Any]:

--- a/tests/orchestration/test_embedding_engine_logging.py
+++ b/tests/orchestration/test_embedding_engine_logging.py
@@ -1,0 +1,50 @@
+"""
+Structured-logging contract for the embedding engine
+=====================================================
+
+The embedding engine feeds the ``token_tracker`` -> ``EmbeddingObserver``
+observability pipeline, which queries on structured fields (provider, model,
+dim). These tests pin the engine to ``structlog`` event-name + kwargs logging
+so those fields stay machine-queryable instead of buried in free-text.
+
+``structlog.testing.capture_logs`` captures emitted events as dicts with an
+``event`` key plus any bound kwargs; it captures nothing for stdlib
+``logging.getLogger`` calls, so these tests fail loudly if the engine ever
+regresses to f-string logging.
+"""
+
+import pytest
+from structlog.testing import capture_logs
+
+import orchestration.embedding_engine as engine_mod
+from orchestration.embedding_engine import EmbeddingCache, get_embedding_cache
+
+
+@pytest.mark.unit
+def test_cache_init_emits_structured_event(monkeypatch):
+    """get_embedding_cache() logs a queryable event with the maxsize field."""
+    monkeypatch.setattr(engine_mod, "_embedding_cache", None)
+    monkeypatch.setenv("EMBEDDING_CACHE_SIZE", "256")
+
+    with capture_logs() as cap_logs:
+        get_embedding_cache()
+
+    events = {entry["event"]: entry for entry in cap_logs}
+    assert "embedding_cache_initialized" in events
+    assert events["embedding_cache_initialized"]["maxsize"] == 256
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cache_hit_emits_structured_event():
+    """A cache hit logs a structured debug event carrying the key prefix."""
+    cache = EmbeddingCache(maxsize=8)
+    await cache.put("hello", [0.1, 0.2, 0.3])
+
+    with capture_logs() as cap_logs:
+        result = await cache.get("hello")
+
+    assert result == [0.1, 0.2, 0.3]
+    hits = [e for e in cap_logs if e["event"] == "embedding_cache_hit"]
+    assert len(hits) == 1
+    assert "key_prefix" in hits[0]

--- a/tests/orchestration/test_embedding_engine_logging.py
+++ b/tests/orchestration/test_embedding_engine_logging.py
@@ -11,13 +11,45 @@ so those fields stay machine-queryable instead of buried in free-text.
 ``event`` key plus any bound kwargs; it captures nothing for stdlib
 ``logging.getLogger`` calls, so these tests fail loudly if the engine ever
 regresses to f-string logging.
+
+``tests/test_utils_modules.py`` exercises ``utils.logging_utils.configure_logging()``,
+which calls ``structlog.configure(wrapper_class=structlog.make_filtering_bound_logger
+(logging.INFO), ...)`` and never resets it. That reconfiguration is process-global and
+outlives the test that made it: for the rest of the pytest session, every
+``structlog.get_logger()`` proxy resolves to ``BoundLoggerFilteringAtInfo``, whose
+``.debug()`` is an unconditional no-op (``_nop``, returns immediately) that never reaches
+the processor chain -- so ``capture_logs()`` never sees the event at all, independent of
+whatever processors are installed. This only reproduces in full-suite order (something
+must call ``configure_logging()`` before this file runs); each test below forces its own
+non-filtering wrapper class on the module logger so the ``.debug()``/``.info()`` calls
+always reach ``capture_logs()``'s processor chain, regardless of ambient global structlog
+config left behind by other tests.
 """
 
 import pytest
+import structlog
 from structlog.testing import capture_logs
 
 import orchestration.embedding_engine as engine_mod
 from orchestration.embedding_engine import EmbeddingCache, get_embedding_cache
+
+
+@pytest.fixture(autouse=True)
+def _unfiltered_module_logger(monkeypatch):
+    """Force a non-filtering wrapper class on the module logger.
+
+    Guards against ``utils.logging_utils.configure_logging()`` /
+    ``core.structured_logging.configure_logging()`` (called by other tests
+    earlier in a full-suite run, never reset) installing
+    ``make_filtering_bound_logger(logging.INFO)`` process-wide, which turns
+    ``logger.debug(...)`` into a silent no-op before it ever reaches
+    ``capture_logs()``.
+    """
+    monkeypatch.setattr(
+        engine_mod,
+        "logger",
+        structlog.wrap_logger(None, wrapper_class=structlog.make_filtering_bound_logger(0)),
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What

Swap stdlib `logging` → `structlog` in `orchestration/embedding_engine.py` and convert all **10 log call sites** to structlog event-name + kwargs, matching the `core/token_tracker.py` convention.

## Why

The embedding engine feeds the `token_tracker` → `EmbeddingObserver` observability pipeline, which queries on **structured fields** (provider, model, dim). f-string logs bury those fields in free text — not machine-queryable. This makes them filterable.

## Changes

- `import logging` → `import structlog`; `logging.getLogger` → `structlog.get_logger`
- Cache logs: `embedding_cache_hit` (key_prefix), `embedding_cache_initialized` (maxsize)
- 4 provider inits collapsed into one event `embedding_provider_initialized` with a `provider` discriminator + `model`/`dim` fields (Voyage adds `asymmetric=True`)
- 4 failures → `embedding_provider_init_failed` with `provider` + `error` fields (still re-raise — caller traceback preserved)

## Tests

New `tests/orchestration/test_embedding_engine_logging.py` — `structlog.testing.capture_logs` tripwire asserting structured events. It captures nothing from stdlib `logging`, so it **physically fails against f-string logging** (regression guard).

## Verification

- `pytest tests/orchestration/test_embedding_engine_logging.py tests/orchestration/test_embedding_engine.py` → **12 passed**
- ruff / black / isort → clean
- No existing test couples to log text → zero behavior break

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jgg82oTFsM8bcJezB5Fyfv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the embedding engine from stdlib `logging` to `structlog` with event-name + kwargs so provider/model/dim fields are queryable in the `token_tracker` → `EmbeddingObserver` pipeline. Consolidates provider init logs, adds cache events, and hardens structured-log tests to avoid global filter interference.

- **Refactors**
  - Replaced `logging.getLogger` with `structlog.get_logger` and converted 10 calls to event-name + kwargs.
  - Added `embedding_cache_initialized` (maxsize) and `embedding_cache_hit` (key_prefix) events.
  - Collapsed provider init logs into `embedding_provider_initialized` with `provider`, `model`, `dim` (Voyage also sets `asymmetric=True`).
  - Standardized failures to `embedding_provider_init_failed` with `provider` and `error`; tests use `structlog.testing.capture_logs` and an autouse fixture that forces a non-filtering wrapper so debug/info events are captured reliably across the full test suite.

<sup>Written for commit 1d758a5b3a63aa511d34aee79b09aa4f31948f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding cache and provider initialization logging with clearer, structured event details.
  * Added more informative error logging when embedding provider initialization fails.

* **Tests**
  * Added coverage to verify cache initialization and cache-hit logging events include the expected details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->