### PR TITLE
feat(theme): resolve product images through SOT, add no-hardcoded gate

### DIFF
--- a/scripts/validate_catalog_consistency.py
+++ b/scripts/validate_catalog_consistency.py
@@ -72,6 +72,20 @@ _SIMILARITIES_JSON: Path = (
 )
 _SKU_RESOLVER_PY: Path = _REPO_ROOT / "skyyrose" / "elite_studio" / "sku_resolver.py"
 _DOSSIERS_DIR: Path = _REPO_ROOT / "wordpress-theme" / "skyyrose-flagship" / "data" / "dossiers"
+_THEME_DIR: Path = _REPO_ROOT / "wordpress-theme" / "skyyrose-flagship"
+# A hardcoded `/images/products/<file>` path literal in a template — the thing
+# templates must NOT do (they must resolve via skyyrose_sot_product_image_uri()).
+_HARDCODED_PRODUCT_IMG_RE = re.compile(
+    r"/images/products/[A-Za-z0-9_./-]+\.(?:webp|avif|jpe?g|png)"
+)
+# Template surfaces the SOT rule applies to. `inc/` is excluded — it holds the
+# resolver itself, which legitimately names the products path in fallback logic.
+_TEMPLATE_GLOBS: tuple[str, ...] = (
+    "*.php",
+    "template-parts/**/*.php",
+    "woocommerce/**/*.php",
+    "patterns/**/*.php",
+)
 
 # Retired SKUs — must not appear in downstream files
 _RETIRED_SKUS: frozenset[str] = frozenset({"br-013"})
@@ -613,6 +627,48 @@ def check_brand_primary() -> CheckResult:
     return _ok(name, f"brand_primary={bp!r} exists in logos block")
 
 
+def check_no_hardcoded_product_images() -> CheckResult:
+    """Fail if any template hardcodes an `/images/products/...` path literal.
+
+    Templates must resolve product imagery through ``skyyrose_sot_product_image_uri()``
+    (inc/collection-sot-reader.php), so the homepage/landing tiles follow the SOT and
+    cannot silently drift to a stale or wrong asset — the front-page commercial-runway
+    regression (a phantom-subdir 404 on the br-006 jacket) is exactly what this guards.
+    ``inc/`` is excluded: it holds the resolver itself.
+    """
+    name = "no_hardcoded_product_images"
+    if not _THEME_DIR.exists():
+        return _fail(name, f"theme dir not found: {_THEME_DIR}")
+
+    offenders: list[str] = []
+    seen: set[Path] = set()
+    for pattern in _TEMPLATE_GLOBS:
+        for php in sorted(_THEME_DIR.glob(pattern)):
+            if php in seen or not php.is_file():
+                continue
+            seen.add(php)
+            try:
+                text = php.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            try:
+                rel = php.relative_to(_REPO_ROOT)
+            except ValueError:
+                rel = php
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if _HARDCODED_PRODUCT_IMG_RE.search(line):
+                    offenders.append(f"{rel}:{lineno}")
+
+    if offenders:
+        return _fail(
+            name,
+            f"{len(offenders)} hardcoded product-image path(s) — resolve via "
+            "skyyrose_sot_product_image_uri() instead",
+            details=offenders[:50],
+        )
+    return _ok(name, "no hardcoded product-image paths in templates")
+
+
 # ---------------------------------------------------------------------------
 # Check registry
 # ---------------------------------------------------------------------------
@@ -631,6 +687,7 @@ ALL_CHECKS: dict[str, Any] = {
     "retired_sku_guard": check_retired_sku_guard,
     "dossier_slugs": check_dossier_slugs,
     "brand_primary": check_brand_primary,
+    "no_hardcoded_product_images": check_no_hardcoded_product_images,
 }
 
 # Checks that must pass before others can meaningfully run

--- a/tasks/sot-resolver-reconciliation.md
+++ b/tasks/sot-resolver-reconciliation.md
@@ -1,0 +1,44 @@
+# SOT-First Product Image Resolver — Build + Reconciliation
+
+**Built 2026-06-30. Source-only; deploy STOP-AND-SHOW gated.**
+
+## What was built
+1. **Runtime resolver** — `skyyrose_sot_product_image( $sku, $view )` + `skyyrose_sot_product_image_uri()`
+   in `inc/collection-sot-reader.php`. Reads the deployed per-collection `data/collections/<slug>/sot.json`
+   (front-first: front_model_image → image), falls back to catalog CSV columns, then placeholder.
+   Reuses the existing cached loader `skyyrose_get_collection_sot()`.
+2. **11 tiles converted** — `front-page.php` (7 refs) + `template-landing-kids-capsule.php` (4 refs) now
+   call the resolver by SKU+view. Zero `/images/products/...` literals remain.
+3. **Gate** — `check_no_hardcoded_product_images` in `scripts/validate_catalog_consistency.py` fails the
+   build if any template hardcodes an `/images/products/...` path. "SOT seen before everything," enforced.
+
+## Verification (all ran 2026-06-30)
+- Resolver runtime harness: **8/8** SKU+view → correct SOT path (real catalog + real sot.json).
+- php -l + PHPCS: clean on resolver + both templates.
+- Validator: **17/17** checks pass; new gate **proven can-fail** (flags a violation, ignores the resolver call).
+- black + ruff clean; 6 catalog tests pass (no regression).
+- Eyes-on (pixels) all 6 new SOT images = correct garment for SKU+collection.
+
+## Reconciliation — what each tile renders now vs. after
+| Tile (SKU) | Was (hardcoded) | Now (SOT front) | Verdict |
+|---|---|---|---|
+| br-006 ×3 | sherpa packshot 1024² 59KB | br-006-onmodel 1024×1536 240KB | **ADOPT** — on-model upgrade, correct garment |
+| lh-004 ×2 | varsity 896×1200 103KB | lh-004-onmodel 1024×1536 298KB | **ADOPT** — same varsity-bomber, on-model |
+| sg-009 | sherpa packshot 1024² 60KB | sg-009-onmodel 1024×1536 223KB | **ADOPT** — on-model upgrade |
+| sg-006 | hoodie packshot 1024² 60KB | sg-006-onmodel 1024×1536 203KB | **ADOPT** — on-model upgrade |
+| kids-001 front | red-set on-model 896×1200 83KB | kids-001-onmodel 1024×1536 152KB | **ADOPT** — on-model, correct |
+| kids-001 back | red-set-back | (same) | no change |
+| kids-002 back | purple-set-back | (same) | no change |
+| **kids-002 front** | purple-set **on-model** 896×1200 142KB | **ghost-mannequin** 1024² 60KB | **DECIDE** — SOT front is a ghost; on-model exists |
+
+## The one decision: kids-002 front
+- The catalog sets kids-002 `front_model_image = ghost/kids-002-ghost-front.webp` (a flat ghost render).
+- An on-model purple-set shot exists and is live: `kids-purple-set-front-model.webp` (142KB, on-model).
+- kids-001 uses an on-model; kids-002 was set to a ghost — likely a leftover, not intentional.
+- **Recommended:** repoint kids-002 `front_model_image` → the on-model (1-line catalog edit + regen),
+  for consistency with kids-001. Then the resolver renders the on-model. (Founder call — it changes the SOT.)
+- Until decided, the kids-capsule landing renders the ghost. Deploy is held anyway.
+
+## Deploy gate
+Source-only so far. Going live needs `deploy-theme.sh` → skyyrose.co (STOP-AND-SHOW), then
+post-verify (curl 200 + Playwright mobile/desktop). Hold until kids-002 decided + founder approves.

--- a/wordpress-theme/skyyrose-flagship/data/render-keepers.json
+++ b/wordpress-theme/skyyrose-flagship/data/render-keepers.json
@@ -9,7 +9,7 @@
       "sku": "br-006",
       "style": "on-model",
       "view": "front",
-      "asset": "wordpress-theme/skyyrose-flagship/assets/images/products/black-rose-sherpa-jacket/black-rose-sherpa-jacket-front-model.webp",
+      "asset": "wordpress-theme/skyyrose-flagship/assets/images/products/black-rose-sherpa-jacket-front-model.webp",
       "founder_note": "real product — approved 2026-06-10"
     },
     {

--- a/wordpress-theme/skyyrose-flagship/front-page.php
+++ b/wordpress-theme/skyyrose-flagship/front-page.php
@@ -305,7 +305,7 @@ get_header();
 	</div>
 	<div class="commercial-runway__rail stagger-grid">
 		<a class="commercial-tile commercial-tile--wide magnetic" href="<?php echo esc_url( home_url( '/collection-black-rose/' ) ); ?>">
-			<img src="<?php echo esc_url( SKYYROSE_ASSETS_URI . '/images/products/black-rose-sherpa-jacket/black-rose-sherpa-jacket-front-model.webp' ); ?>"
+			<img src="<?php echo esc_url( skyyrose_sot_product_image_uri( 'br-006', 'front' ) ); ?>"
 				alt="<?php esc_attr_e( 'Black Rose sherpa jacket on model', 'skyyrose' ); ?>"
 				loading="lazy"
 				decoding="async"
@@ -316,7 +316,7 @@ get_header();
 			<em><?php esc_html_e( 'Cold-weather statement pieces with Oakland weight.', 'skyyrose' ); ?></em>
 		</a>
 		<a class="commercial-tile magnetic" href="<?php echo esc_url( home_url( '/collection-love-hurts/' ) ); ?>">
-			<img src="<?php echo esc_url( SKYYROSE_ASSETS_URI . '/images/products/love-hurts-varsity-jacket-front-model.webp' ); ?>"
+			<img src="<?php echo esc_url( skyyrose_sot_product_image_uri( 'lh-004', 'front' ) ); ?>"
 				alt="<?php esc_attr_e( 'Love Hurts varsity jacket on model', 'skyyrose' ); ?>"
 				loading="lazy"
 				decoding="async"
@@ -327,7 +327,7 @@ get_header();
 			<em><?php esc_html_e( 'Built for nights that need proof.', 'skyyrose' ); ?></em>
 		</a>
 		<a class="commercial-tile magnetic" href="<?php echo esc_url( home_url( '/collection-signature/' ) ); ?>">
-			<img src="<?php echo esc_url( SKYYROSE_ASSETS_URI . '/images/products/signature-sherpa-jacket-front-model.webp' ); ?>"
+			<img src="<?php echo esc_url( skyyrose_sot_product_image_uri( 'sg-009', 'front' ) ); ?>"
 				alt="<?php esc_attr_e( 'Signature sherpa jacket on model', 'skyyrose' ); ?>"
 				loading="lazy"
 				decoding="async"
@@ -482,7 +482,7 @@ get_header();
 				data-style-title="<?php esc_attr_e( 'Statement Layer', 'skyyrose' ); ?>"
 				data-style-kicker="<?php esc_attr_e( 'Black Rose', 'skyyrose' ); ?>"
 				data-style-copy="<?php esc_attr_e( 'Structured outerwear, dark palette, heavyweight presence. Start with the sherpa and build the rest quiet.', 'skyyrose' ); ?>"
-				data-style-image="<?php echo esc_url( SKYYROSE_ASSETS_URI . '/images/products/black-rose-sherpa-jacket/black-rose-sherpa-jacket-front-model.webp' ); ?>"
+				data-style-image="<?php echo esc_url( skyyrose_sot_product_image_uri( 'br-006', 'front' ) ); ?>"
 				data-style-alt="<?php esc_attr_e( 'Black Rose sherpa jacket style recommendation', 'skyyrose' ); ?>"
 				data-style-link="<?php echo esc_url( home_url( '/collection-black-rose/' ) ); ?>">
 				<span><?php esc_html_e( 'Statement', 'skyyrose' ); ?></span>
@@ -495,7 +495,7 @@ get_header();
 				data-style-title="<?php esc_attr_e( 'Clean Daily Rotation', 'skyyrose' ); ?>"
 				data-style-kicker="<?php esc_attr_e( 'Signature', 'skyyrose' ); ?>"
 				data-style-copy="<?php esc_attr_e( 'Soft luxury staples with mint, gold, and easy proportions. Built for repeat wear without losing identity.', 'skyyrose' ); ?>"
-				data-style-image="<?php echo esc_url( SKYYROSE_ASSETS_URI . '/images/products/mint-lavender-hoodie-front-model.webp' ); ?>"
+				data-style-image="<?php echo esc_url( skyyrose_sot_product_image_uri( 'sg-006', 'front' ) ); ?>"
 				data-style-alt="<?php esc_attr_e( 'Mint lavender hoodie style recommendation', 'skyyrose' ); ?>"
 				data-style-link="<?php echo esc_url( home_url( '/collection-signature/' ) ); ?>">
 				<span><?php esc_html_e( 'Daily', 'skyyrose' ); ?></span>
@@ -508,7 +508,7 @@ get_header();
 				data-style-title="<?php esc_attr_e( 'Night Signal', 'skyyrose' ); ?>"
 				data-style-kicker="<?php esc_attr_e( 'Love Hurts', 'skyyrose' ); ?>"
 				data-style-copy="<?php esc_attr_e( 'Varsity energy, crimson edge, and pieces that read from across the room. Designed for entrance moments.', 'skyyrose' ); ?>"
-				data-style-image="<?php echo esc_url( SKYYROSE_ASSETS_URI . '/images/products/love-hurts-varsity-jacket-front-model.webp' ); ?>"
+				data-style-image="<?php echo esc_url( skyyrose_sot_product_image_uri( 'lh-004', 'front' ) ); ?>"
 				data-style-alt="<?php esc_attr_e( 'Love Hurts varsity jacket style recommendation', 'skyyrose' ); ?>"
 				data-style-link="<?php echo esc_url( home_url( '/collection-love-hurts/' ) ); ?>">
 				<span><?php esc_html_e( 'Night', 'skyyrose' ); ?></span>
@@ -518,7 +518,7 @@ get_header();
 		<div class="style-atelier__result rv-blur" aria-live="polite">
 			<div class="style-atelier__image">
 				<img id="styleAtelierImage"
-					src="<?php echo esc_url( SKYYROSE_ASSETS_URI . '/images/products/black-rose-sherpa-jacket/black-rose-sherpa-jacket-front-model.webp' ); ?>"
+					src="<?php echo esc_url( skyyrose_sot_product_image_uri( 'br-006', 'front' ) ); ?>"
 					alt="<?php esc_attr_e( 'Black Rose sherpa jacket style recommendation', 'skyyrose' ); ?>"
 					loading="lazy"
 					decoding="async"

--- a/wordpress-theme/skyyrose-flagship/inc/collection-sot-reader.php
+++ b/wordpress-theme/skyyrose-flagship/inc/collection-sot-reader.php
@@ -89,7 +89,7 @@ function skyyrose_get_collection_sot( $slug ) {
 /**
  * Extract a "resolved" image path from a sot.json imagery slot.
  *
- * sot.json imagery values are either null or an object with a "resolved" key
+ * Imagery slot values are either null or an object with a "resolved" key
  * containing a path relative to the theme's assets/ directory, e.g.:
  *   "images/homepage-col-black-rose.webp"
  *
@@ -201,4 +201,109 @@ function skyyrose_sot_lockup( $slug ) {
 	}
 
 	return '';
+}
+
+/**
+ * Resolve a per-SKU PRODUCT image through the SOT, front-first.
+ *
+ * This is the runtime bridge that closes the documented gap (templates used to
+ * hardcode `/images/products/...` paths instead of consulting the SOT). Every
+ * surface that shows a product image — editorial tiles, style cards, landing
+ * pages — must resolve it through here so the imagery follows the catalog/SOT
+ * and can never silently drift to a stale or wrong asset.
+ *
+ * Resolution order:
+ *   1. The deployed collection sot.json (data/collections/<slug>/sot.json) —
+ *      products[].images.<slot>.resolved, walked front-first per the SOT
+ *      `_authority` (on-model render before flat packshot).
+ *   2. The catalog CSV columns via skyyrose_get_product() (also theme-local).
+ *   3. '' — caller / the _uri wrapper substitutes a placeholder.
+ *
+ * View → ordered image-slot chain:
+ *   'front'    → front_model_image, image
+ *   'back'     → back_model_image, back_image
+ *   'packshot' → image, front_model_image
+ *
+ * Returns a theme-relative URI with a leading '/' (assets-relative, matching
+ * skyyrose_sot_hero/scene/lockup), so callers concatenate:
+ *   esc_url( SKYYROSE_ASSETS_URI . skyyrose_sot_product_image( $sku, $view ) )
+ * or use skyyrose_sot_product_image_uri() for a ready full URL.
+ *
+ * @since 1.6.7
+ * @param string $sku  Product SKU, e.g. 'br-006'.
+ * @param string $view 'front' | 'back' | 'packshot'. Defaults to 'front'.
+ * @return string Theme-relative URI (leading '/'), or '' on miss.
+ */
+function skyyrose_sot_product_image( $sku, $view = 'front' ) {
+	$sku = sanitize_key( $sku );
+	if ( '' === $sku ) {
+		return '';
+	}
+
+	$chains = array(
+		'front'    => array( 'front_model_image', 'image' ),
+		'back'     => array( 'back_model_image', 'back_image' ),
+		'packshot' => array( 'image', 'front_model_image' ),
+	);
+	$chain  = $chains[ $view ] ?? $chains['front'];
+
+	// Collection comes from the product SOT (the catalog), so this stays correct
+	// for any future SKU without a hardcoded prefix map.
+	$product    = function_exists( 'skyyrose_get_product' ) ? skyyrose_get_product( $sku ) : null;
+	$collection = is_array( $product ) ? ( $product['collection'] ?? '' ) : '';
+
+	// 1. Preferred: the deployed collection sot.json imagery view.
+	if ( '' !== $collection ) {
+		$sot = skyyrose_get_collection_sot( $collection );
+		if ( ! empty( $sot['products'] ) && is_array( $sot['products'] ) ) {
+			foreach ( $sot['products'] as $entry ) {
+				if ( ! is_array( $entry ) || ( $entry['sku'] ?? '' ) !== $sku ) {
+					continue;
+				}
+				$images = isset( $entry['images'] ) && is_array( $entry['images'] ) ? $entry['images'] : array();
+				foreach ( $chain as $slot ) {
+					$resolved = $images[ $slot ]['resolved'] ?? '';
+					if ( is_string( $resolved ) && '' !== $resolved ) {
+						return '/' . ltrim( $resolved, '/' );
+					}
+				}
+				break; // SKU matched but no slot in chain — fall through to CSV.
+			}
+		}
+	}
+
+	// 2. Fallback: catalog CSV columns. CSV paths are "assets/images/products/..";
+	// strip the leading "assets" so the return matches the assets-relative convention.
+	if ( is_array( $product ) ) {
+		foreach ( $chain as $slot ) {
+			$val = $product[ $slot ] ?? '';
+			if ( is_string( $val ) && '' !== $val ) {
+				return '/' . ltrim( preg_replace( '#^assets/#', '', $val ), '/' );
+			}
+		}
+	}
+
+	return '';
+}
+
+/**
+ * Full URL for a per-SKU product image, with a placeholder on miss.
+ *
+ * Template-friendly wrapper around skyyrose_sot_product_image(): always returns
+ * a valid URL, so a SOT miss degrades to the product placeholder rather than a
+ * broken `SKYYROSE_ASSETS_URI . ''`.
+ *
+ * Usage: <img src="<?php echo esc_url( skyyrose_sot_product_image_uri( 'br-006', 'front' ) ); ?>">
+ *
+ * @since 1.6.7
+ * @param string $sku  Product SKU.
+ * @param string $view 'front' | 'back' | 'packshot'.
+ * @return string Full image URL (never empty).
+ */
+function skyyrose_sot_product_image_uri( $sku, $view = 'front' ) {
+	$rel = skyyrose_sot_product_image( $sku, $view );
+	if ( '' === $rel ) {
+		return get_theme_file_uri( 'assets/images/placeholder-product.jpg' );
+	}
+	return SKYYROSE_ASSETS_URI . $rel;
 }

--- a/wordpress-theme/skyyrose-flagship/template-landing-kids-capsule.php
+++ b/wordpress-theme/skyyrose-flagship/template-landing-kids-capsule.php
@@ -85,7 +85,7 @@ get_header();
 				</div>
 
 				<div class="lp-story__image lp-rv" data-delay="2">
-					<img src="<?php echo esc_url( SKYYROSE_ASSETS_URI . '/images/products/kids-purple-set-front-model.webp' ); ?>"
+					<img src="<?php echo esc_url( skyyrose_sot_product_image_uri( 'kids-002', 'front' ) ); ?>"
 						alt="<?php echo esc_attr__( 'Kids Capsule purple set, model shot', 'skyyrose' ); ?>"
 						loading="lazy" decoding="async"
 						width="896" height="1200"
@@ -134,9 +134,9 @@ get_header();
 			</div>
 
 			<div class="lp-editorial__grid lp-editorial__grid--top">
-				<div class="lp-editorial__item lp-rv" data-delay="1"><img src="<?php echo esc_url( SKYYROSE_ASSETS_URI . '/images/products/kids-red-set-front-model.webp' ); ?>" alt="<?php echo esc_attr__( 'Kids Capsule red set, model shot', 'skyyrose' ); ?>" loading="lazy" decoding="async" width="896" height="1200"></div>
-				<div class="lp-editorial__item lp-rv" data-delay="2"><img src="<?php echo esc_url( SKYYROSE_ASSETS_URI . '/images/products/kids-purple-set-back-model.webp' ); ?>" alt="<?php echo esc_attr__( 'Kids Capsule purple set, back view', 'skyyrose' ); ?>" loading="lazy" decoding="async" width="896" height="1200"></div>
-				<div class="lp-editorial__item lp-rv" data-delay="3"><img src="<?php echo esc_url( SKYYROSE_ASSETS_URI . '/images/products/kids-red-set-back-model.webp' ); ?>" alt="<?php echo esc_attr__( 'Kids Capsule red set, back view', 'skyyrose' ); ?>" loading="lazy" decoding="async" width="896" height="1200"></div>
+				<div class="lp-editorial__item lp-rv" data-delay="1"><img src="<?php echo esc_url( skyyrose_sot_product_image_uri( 'kids-001', 'front' ) ); ?>" alt="<?php echo esc_attr__( 'Kids Capsule red set, model shot', 'skyyrose' ); ?>" loading="lazy" decoding="async" width="896" height="1200"></div>
+				<div class="lp-editorial__item lp-rv" data-delay="2"><img src="<?php echo esc_url( skyyrose_sot_product_image_uri( 'kids-002', 'back' ) ); ?>" alt="<?php echo esc_attr__( 'Kids Capsule purple set, back view', 'skyyrose' ); ?>" loading="lazy" decoding="async" width="896" height="1200"></div>
+				<div class="lp-editorial__item lp-rv" data-delay="3"><img src="<?php echo esc_url( skyyrose_sot_product_image_uri( 'kids-001', 'back' ) ); ?>" alt="<?php echo esc_attr__( 'Kids Capsule red set, back view', 'skyyrose' ); ?>" loading="lazy" decoding="async" width="896" height="1200"></div>
 			</div>
 		</div>
 	</section>


### PR DESCRIPTION
## Summary
- Templates hardcoded `/images/products/...` paths (Codex homepage-v2 build), bypassing the SOT — which let br-006 drift to a phantom-subdir 404 and a non-canonical packshot.
- New `skyyrose_sot_product_image(_uri)($sku, $view)` in `inc/collection-sot-reader.php` resolves front-first from the deployed per-collection `sot.json`, falls back to catalog CSV, then placeholder.
- All 11 editorial/landing tile refs (`front-page.php` ×7 + `template-landing-kids-capsule.php` ×4) now resolve by SKU instead of a literal path.
- New validator check `no_hardcoded_product_images` fails the build on any `/images/products/` literal in a template — regression gate, proven can-fail.

## Test plan
- [x] Resolver runtime harness: 6/6 SKUs correct, run against `origin/main`'s own catalog/sot.json (isolated worktree)
- [x] `validate_catalog_consistency.py`: 14/14 checks pass on `origin/main`'s actual check set
- [x] `php -l` + PHPCS clean on all 3 PHP files
- [x] ruff + black clean
- [x] Eyes-on (pixels) all new SOT images = correct garment for SKU/collection
- [x] kids-002 confirmed against the asset-hub founder verdict (stays the ghost-mannequin, not swapped)
- [ ] Post-merge: deploy + live Playwright verify (mobile + desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all product images through the SOT with a new resolver and update templates to use it, preventing drift and fixing the br-006 404. Adds a validator gate to block hardcoded `/images/products/...` paths.

- New Features
  - Added `skyyrose_sot_product_image()` and `skyyrose_sot_product_image_uri()` that resolve images via deployed collection `sot.json`, then catalog CSV, then placeholder.
  - Replaced 11 hardcoded image refs with SKU-based calls in `front-page.php` and `template-landing-kids-capsule.php`.
  - Introduced `no_hardcoded_product_images` check in `scripts/validate_catalog_consistency.py` to fail builds on `/images/products/` literals.

- Bug Fixes
  - Homepage and landing tiles now pull correct, canonical SOT images; resolves the br-006 phantom-subdir 404 and non-canonical packshot drift.

<sup>Written for commit 16f0dc28e3801fad27cb49624b5ba2fd5f022db8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

