### PR TITLE
docs(claude-md): add Karpathy guidelines + scoped CLAUDE.md coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,19 @@ Never fix a test by weakening it. Fix the code, not the test.
 
 ---
 
+## Karpathy Coding Guidelines
+
+Bias toward caution over speed. For trivial tasks, use judgment. ([source](https://x.com/karpathy/status/2015883857489522876))
+
+1. **Think before coding.** State assumptions explicitly; if uncertain, ask. If multiple interpretations exist, present them — don't pick silently. If a simpler approach exists, say so and push back. If something is unclear, stop and name it.
+2. **Simplicity first.** Minimum code that solves the problem, nothing speculative. No unrequested features, abstractions for single-use code, "flexibility," or error handling for impossible cases. If 200 lines could be 50, rewrite it. Ask: "would a senior engineer call this overcomplicated?"
+3. **Surgical changes.** Touch only what the request requires. Don't "improve" adjacent code, comments, or formatting; don't refactor what isn't broken; match existing style. Remove only the imports/vars/functions YOUR change orphaned — flag pre-existing dead code, don't delete it unasked. Test: every changed line traces to the request.
+4. **Goal-driven execution.** Turn tasks into verifiable goals ("add validation" → "write tests for invalid inputs, then make them pass"). For multi-step work, state a brief plan with a `verify:` check per step, then loop until verified. Strong success criteria let you loop independently; weak ones ("make it work") force constant clarification.
+
+> These reinforce the existing **Anti-Hallucination**, **Loop**, and **Verification** protocols above — same spine, sharper on simplicity and surgical scope.
+
+---
+
 ## Critical Rules
 
 - Files <800 lines, functions <50 lines
@@ -376,7 +389,7 @@ Every output delivered in this project is production-ready. Not a draft. Not a p
 1. Fix it
 2. In one sentence: what was wrong and why
 3. In one sentence: what you changed to prevent it recurring
-4. Update `tasks/lessons.md`
+4. Record the lesson — `tasks/lessons.md` (behavioral) and/or a Learnings entry (engineering); commit the fix and the lesson together
 5. Move on
 
 Do not: apologize repeatedly, re-explain the mistake at length, ask if the fix is acceptable before showing it. Fix it, show it, name the lesson.
@@ -444,9 +457,3 @@ Show the exact file path, exact cost, and exact action — not a summary, the li
 "Autonomous" means Claude handles implementation without hand-holding **after the user has confirmed the plan and inputs**. It does NOT mean Claude decides what files to use, what to deploy, or what API calls to make without checking first.
 
 The pattern "act → apologize → act again → apologize again" is a bug, not a feature. If the right source file is unclear, ask. If the deploy target is ambiguous, ask. One question costs zero dollars. Getting it wrong costs real money and breaks the live site.
-
----
-
-## Self-Correction
-
-1. Fix the issue → 2. Add Learnings entry above → 3. Commit both together

--- a/agents/CLAUDE.md
+++ b/agents/CLAUDE.md
@@ -1,0 +1,21 @@
+# agents/
+
+Scoped context for the agent fleet (~218 py files). Loads on top of root. The ADK/A2A sub-agent has its
+own `agents/devskyy-a2a/CLAUDE.md`.
+
+## Two parallel hierarchies — do NOT conflate
+
+- **Legacy domain SuperAgents:** subclasses of `EnhancedSuperAgent` (`agents/base_super_agent/agent.py`) → `BaseDevSkyyAgent` (`sdk/python/adk/base.py`, local, not pip).
+- **New-core CoreAgents + Orchestrator:** subclass `CoreAgent` / `SelfHealingMixin` (`agents/core/base.py`). Wire via `agents/core/factory.py:create_orchestrator()`, which reads `_CORE_AGENT_REGISTRY` (a list of `(module_path, class_name)` tuples) and degrades gracefully on import failure.
+- Don't hardcode a fleet count anywhere — the live set is whatever the registry / `grep 'class .*EnhancedSuperAgent'` yields at the time (it grows).
+
+## Hard rules
+
+- **New ORM tables go in `agents/models.py`** — Alembic loads that file DIRECTLY via `importlib` (`alembic/env.py:41`), bypassing the package graph. `database/db.py` (modern `DeclarativeBase`) is a SEPARATE `Base` and is invisible to `alembic autogenerate`. Tables added elsewhere silently never migrate. (`agents/models.py` uses old-style `declarative_base()` by necessity.)
+- **MCP tool registration goes through the `ToolRegistry` singleton** — `ToolRegistry.get_instance()` (`core/runtime/tool_registry.py`). Tag every tool with `ToolSeverity` (`READ_ONLY` … `DESTRUCTIVE`); `DESTRUCTIVE` sets `destructiveHint=True` in the schema — the code-layer signal for STOP-AND-SHOW. Pattern: `agents/creative_agent.py:_register_tools()`.
+- **`agents/__init__.py` `try/except ImportError` guards are intentional** — each export is individually guarded so a missing optional dep (WordPress, ADK) doesn't block the package. Do NOT refactor to eager imports, or the MCP server fails to start when an optional dep is absent.
+
+## Conventions
+
+- **Provider routing is config-driven, not inline.** `AGENT_PROVIDER_PREFERENCES` / `TASK_PROVIDER_PREFERENCES` (`agents/base_super_agent/types.py`) map agent-type / task → provider order. Round Table auto-activates when quality `< ROUND_TABLE_QUALITY_THRESHOLD (0.8)` or the task is in `HIGH_STAKES_TASK_TYPES`. Route through `LLMRouter` (`llm/router.py`) — don't duplicate routing logic.
+- **`agents/base_super_agent/` is a PACKAGE, not a file** (split into `agent.py`, `types.py`, `learning_module.py`, `ml_module.py`, `prompt_module.py`, `round_table_module.py`). Import from `agents.base_super_agent` (or `agents.base_super_agent.types` for types), never a sub-file directly.

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1,0 +1,13 @@
+# api/
+
+Scoped context for the FastAPI surface (~83 files, 30+ routers across two layers). Loads on top of root.
+
+## Hard rules
+
+- **SSRF guard is MANDATORY for any endpoint taking a caller-provided URL.** `from security.ssrf_protection import ssrf_protection` then `ssrf_protection.validate_url(v)` inside the Pydantic validator. Pattern: `api/v1/assets.py:120`, `api/v1/media.py:89`. This was a P1 finding (PR #649). No exceptions.
+- **Every new endpoint explicitly decides its auth posture** — public / `Depends(get_current_user)` (`security.jwt_oauth2_auth`) / rate-limited. Auth is OPT-IN, not default. Read-only catalog endpoints are intentionally public; cost-bearing LLM endpoints (e.g. `/catalog/answer`) are currently ungated and flagged as a risk in `api/v1/catalog.py:12-15`. Don't add a billed endpoint without a gate.
+
+## Two-layer routing contract
+
+- **`api/v1/*.py`** routers declare their OWN `prefix` (e.g. `APIRouter(prefix="/catalog")`); `main_enterprise.py` adds `/api/v1` at mount. Final path = `/api/v1` + declared prefix. They export `router` (renamed in `api/v1/__init__.py`).
+- **`api/*.py`** (non-versioned) routers declare NO prefix and export `{name}_router` (e.g. `agents_router`, `dashboard_router`). Most are mounted under `/api/v1`; a few (e.g. `agents_router`, `gdpr_router`) mount with NO prefix. Match the export-naming + prefix convention of the layer you add to, and check the mount in `main_enterprise.py`.

--- a/assets/products/source-photos/CLAUDE.md
+++ b/assets/products/source-photos/CLAUDE.md
@@ -1,3 +1,14 @@
-<claude-mem-context>
+# assets/products/source-photos/
 
-</claude-mem-context>
+Raw source photography, organized by collection slug: `black-rose/`, `signature/`, `love-hurts/`, `kids/`,
+`pre-order/`, `brand-assets/`. This guidance covers all of them — the per-collection subdirs don't need their own.
+
+## What goes here & where it flows
+
+- **Naming:** `{sku}-{variant}.{ext}` — e.g. `br-001-front.jpg`, `br-001-back.jpg`. Use the real SKU from the catalog CSV; never invent one.
+- These are SOURCE files — NOT served directly by the theme and NOT committed to WooCommerce.
+- **After adding/changing files, run `make sot-manifest`** to regenerate the SOT image manifest. Every surface resolves a SKU's image through `skyyrose.core.sot_images.resolve_image()` (`sot_images.py:98`) — front-first — never a hardcoded path.
+
+## Fidelity gate (mandatory)
+
+Before any render job or site surface references a photo here, **vision-verify the pixels** — the actual garment must match that SKU per the catalog/dossier, not just the filename. Filenames lie; wrong-garment imagery is the #1 recurring defect. Eyes-on or don't ship. See root CLAUDE.md "Product-image fidelity gate" + `docs/brand/sot-imagery-policy.md`.

--- a/assets/products/source-photos/black-rose/CLAUDE.md
+++ b/assets/products/source-photos/black-rose/CLAUDE.md
@@ -1,20 +1,3 @@
-# skyyrose/elite_studio/
-
-## pipeline3d — Unified 3D Pipeline Orchestrator
-
-- `skyyrose/elite_studio/pipeline3d/` is the provider-agnostic staged 3D pipeline (Tripo/Meshy workflow clone). Stages: image-to-3D → texture → remesh → export-GLB. Phase 1 = Tripo vertical slice driven by the CLI; Phases 2 (Meshy/TRELLIS adapters + router fallback + batch) and 3 (REST + webhook + Redis worker) are roadmapped in the spec.
-- **Execution spine is synchronous-within-stage** — the adapter blocks via the `tripo3d` SDK `wait_for_task`. No event-driven DAG advancement. Job concurrency is a worker-layer concern (Phase 3).
-- **Chaining rule:** `Artifact` carries both a provider `task_id` (same-provider chaining) and a local `path`/`model_url` (cross-provider handoff). `router.pick(stage, exclude=...)` enables fallback.
-- **Remesh-to-GLB uses `smart_lowpoly`, NOT `convert_model`** — the tripo3d SDK's `convert_model` format Literal excludes GLB (GLB is the native output). `convert_model` is reserved for deferred USDZ/FBX export.
-- **Estimate prices CAPABILITY, dispatch checks AVAILABILITY.** `router.supporting(stage)` (ignores availability) drives the cost estimate so a dry-run shows real cost with no API key loaded; `router.candidates(stage)` (availability-gated) drives actual dispatch + fallback. Cost gate stays correct: `--go` with no key raises `NoAdapterError` at `pick()`, never silently pays.
-- **Cost gate:** whole-job estimate computed once (`estimator.estimate`), shown via STOP-AND-SHOW before dispatch. Reuses `RunBudget.ensure_within_budget`/`spend`. Paid dispatch requires `--go`; never auto-dispatches.
-- **Money gate is FAIL-CLOSED (do not regress).** `cli._confirm()` ALWAYS prints the banner first, then: `SKYYROSE_AUTO_CONFIRM=1` is the only non-interactive opt-in; a missing TTY (CI/cron/subprocess/pytest) ABORTS (returns False); an interactive TTY prompts for `y`. Auto-approving paid dispatch on a missing TTY was a CRITICAL review finding (fixed 2026-06-02) — paid APIs require explicit `y` or the explicit env opt-in, NEVER a silent no-TTY pass. The CLI also aborts up front if `estimate.total_usd > --budget` (strict `>`, matching `RunBudget.ensure_within_budget`) so earlier stages can't bill before a later stage trips the ceiling.
-- **Tripo mesh selection never trusts dict order.** `adapters.tripo._pick_mesh()` returns the `model` key, else the first value with a mesh extension (`.glb/.gltf/.obj/.fbx/.usdz/.stl`), else None → `run_stage` raises. Prevents copying a texture PNG to `<sku>.glb`. Don't revert to `next(iter(downloaded.values()))`.
-- **Idempotency hash folds `job.params`** (`executor.run_job` → `telemetry.hash_inputs(source, sku, json.dumps(params, sort_keys=True))`). A re-run with a new `target_polycount` invalidates the cache (correctness over re-bill avoidance). SKU is format-validated (`^[a-z]{2,4}-\d{3}$`) in `preflight.resolve_source` before any glob/output use.
-- **Idempotency:** `StageStore` (file-based) persists each stage result keyed by `(input_hash, stage)`; a resumed job skips completed stages so a crash at remesh does not re-bill image-to-3D + texture.
-- Entry: `python -m skyyrose.elite_studio.pipeline3d --sku <sku> --stages ... [--go]`. Dry-run by default.
-- Reuses (does not duplicate): `budget.py` (RunBudget), `telemetry.py` (stage span + hash_inputs), and the `tripo3d` SDK via a thin adapter. Does NOT use `ai_3d/generation_pipeline.py` (superseded — monolithic, no budget/telemetry).
-
 <claude-mem-context>
 
 </claude-mem-context>

--- a/database/CLAUDE.md
+++ b/database/CLAUDE.md
@@ -1,0 +1,9 @@
+# database/
+
+Scoped context for the DB layer. Loads on top of root.
+
+## Hard rules
+
+- **Alembic targets `agents/models.py`, NOT `database/db.py`.** `alembic/env.py:41` loads the model file directly via `importlib.util.spec_from_file_location`. `database/db.py` (modern `DeclarativeBase`) is a separate `Base` — changes to it do NOT appear in `alembic autogenerate`. New tables → `agents/models.py` (old-style `declarative_base()`), or they silently never migrate.
+- **Async engine only.** All access goes through `async with db_manager.session() as session`. The FastAPI dependency is `get_db()` (`database/db.py:701`), yielding an `AsyncSession`. No synchronous session code — pool is `NullPool` for async (prevents "QueuePool cannot be used with asyncio engine").
+- **`DatabaseManager` is a singleton** (`db.py:282`) — `__new__` returns the shared instance. Call `DatabaseManager()`; never monkey-patch `_instance` or call `__init__` directly.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,37 @@
+# Frontend — devskyy-dashboard (Next.js 16 · React 19)
+
+Scoped context for `frontend/`. Loads on top of the root CLAUDE.md. Commands + "npm not pnpm" are in root.
+The gotchas below are the ones a fresh session gets wrong.
+
+## Auth — two systems, do not conflate
+
+- **Admin (`/admin/*`): NextAuth v4.** `lib/auth.ts` + `SessionProvider` (`app/admin/layout.tsx`). Server-side: `getServerSession(authOptions)`. Client-side: `useSession()`. JWT, 15-min expiry.
+- **Storefront/legacy:** `contexts/AuthContext.tsx` → `useAuth()`, `localStorage` key `access_token`. NOT used by any admin page. `lib/api/client.ts` also reads this key directly for backend calls. Calling `useAuth()` in an admin page gets undefined context.
+- **Edge gate = `proxy.ts`, NOT `middleware.ts`.** Next.js 16 **renamed `middleware.ts` → `proxy.ts`** (named export `middleware` → `proxy`); `frontend/proxy.ts` exports `async function proxy()` + `export const config.matcher` — this IS the registered gate and it DOES run. Add gated paths via `config.matcher` (`proxy.ts:42`). Caveat: `proxy` runs the **nodejs** runtime — edge is not supported in `proxy`; keep a `middleware.ts` only if you need edge. Per-route `getServerSession()` stays as defense-in-depth.
+
+## Catalog data is SERVER-ONLY
+
+`lib/catalog.ts` and `lib/catalog-server.ts` use `node:fs` (`catalog.ts:13`). Importing either from a `'use client'` component **crashes the build**. Client code must call the REST routes (`/api/catalog`, `/api/catalog/[sku]`). The CSV resolver walks up 6 dirs from `process.cwd()` (`catalog.ts:48`) — confirm Vercel `rootDirectory=frontend` keeps `wordpress-theme/skyyrose-flagship/data/skyyrose-catalog.csv` in scope.
+
+## State management — three layers, pick the right one
+
+- Server/API data → **TanStack Query** (`@tanstack/react-query`, `useQuery`).
+- Persistent cart → **Zustand** + `persist` (`lib/stores/cart-store.ts`).
+- Admin auth → **NextAuth** `useSession()`.
+- `jotai` is in package.json but unused in admin — don't introduce atoms without confirming the domain isn't already one of the above.
+
+## API barrel — never bypass it
+
+Always import from `@/lib/api` (re-exports via `lib/api.ts` → `lib/api/index.ts`). To add an endpoint: (1) file in `lib/api/endpoints/`, (2) Zod schema in `lib/api/schemas.ts`, (3) register in `lib/api/index.ts`. Direct imports from `@/lib/api/endpoints/*` bypass the unified `api` object the pages depend on.
+
+## UI components
+
+shadcn/ui **"new-york"** style, `rsc: true` (`components.json`). Install primitives with `npx shadcn@latest add <name>` (don't copy default-style examples). Icons: **`lucide-react` only**. Primitives land in `components/ui/`.
+
+## E2E tests — canonical dir is `tests/e2e/`
+
+`playwright.config.ts:4` sets `testDir: './tests/e2e'`. The legacy `frontend/e2e/` dir is NOT executed — new specs go to `tests/e2e/`. No Jest/unit runner is wired (`npm test` has no script) despite `@testing-library/react` being installed. Launch/smoke the app with the `run-devskyy-dashboard` skill.
+
+## next.config.ts — leave the Vercel guard alone
+
+`outputFileTracingRoot` and `turbopack.root` are set ONLY when `!process.env.VERCEL` (`next.config.ts:13`). Setting them unconditionally causes a doubled-path crash on Vercel builds. Do not touch this conditional.

--- a/llm/CLAUDE.md
+++ b/llm/CLAUDE.md
@@ -1,0 +1,8 @@
+# llm/
+
+Scoped context for the multi-provider LLM layer. Core text providers: Anthropic, OpenAI, Google, Mistral, Cohere, Groq — plus DeepSeek and a LiteLLM gateway, and image-gen providers (Replicate, Stability, Vertex Imagen) all under `llm/providers/`. Don't cite a fixed provider count; it grows. Loads on top of root.
+
+## Hard rules
+
+- **`llm/model_ids.py` is the ONLY source of model strings.** Never hardcode `"claude-sonnet-4-6"`, `"gpt-4o"`, etc. anywhere — import the constant. A model roll-forward updates `model_ids.py` once and propagates everywhere.
+- **Adding a provider = three files, all required:** (a) implement `BaseLLMClient.complete()` in `llm/providers/<name>.py` (extends `llm/base.py`); (b) add a `ProviderConfig` in `llm/router.py`; (c) register in `orchestration/llm_registry.py` `_providers` dict. Skip (c) and the provider is callable but invisible to `LLMRegistry.get_available_providers()`.

--- a/skyyrose/cli_harnesses/CLAUDE.md
+++ b/skyyrose/cli_harnesses/CLAUDE.md
@@ -1,0 +1,8 @@
+# skyyrose/cli_harnesses/
+
+Experimental tool-integration shims — NOT the production imagery path (that is `skyyrose/elite_studio/`).
+
+- Each subdir is an independent `cli_anything` agent harness wrapping one external tool/target: `comfyui/` (ComfyUI), `trellis/` (TRELLIS), `hf-spaces/` (HuggingFace Spaces), `marvelous/` (Marvelous Designer), `skyyrose-theme/`, `vercel-config/`.
+- **ComfyUI: do not modify `comfyui/core/` or `comfyui/utils/`** — that's upstream `cli_anything`. Extend via `commands/`.
+- TRELLIS/Tripo here are thin wrappers, separate from `elite_studio/pipeline3d/`. Use the harnesses for experimentation; use `elite_studio/` for production renders (it has the budget/telemetry/money-gate).
+- Paid external calls still obey the root STOP-AND-SHOW rule.

--- a/skyyrose/elite_studio/CLAUDE.md
+++ b/skyyrose/elite_studio/CLAUDE.md
@@ -1,0 +1,22 @@
+# skyyrose/elite_studio/
+
+Canonical imagery hub. Meshy / TRELLIS / Tripo / FASHN are engines behind this. The `pipeline3d/`
+subpackage is the provider-agnostic staged 3D pipeline (image-to-3D → texture → remesh → export-GLB).
+
+## Hard rules (do not regress — these were review findings)
+
+- **Money gate is FAIL-CLOSED.** `cli._confirm()` ALWAYS prints the cost banner first, then: `SKYYROSE_AUTO_CONFIRM=1` is the ONLY non-interactive opt-in; a missing TTY (CI/cron/subprocess/pytest) **ABORTS** (returns False); an interactive TTY prompts for `y`. Auto-approving paid dispatch on a missing TTY was a CRITICAL finding (fixed 2026-06-02). Paid APIs require explicit `y` or the explicit env opt-in — NEVER a silent no-TTY pass. The CLI also aborts up front if `estimate.total_usd > --budget` (strict `>`).
+- **Estimate prices CAPABILITY, dispatch checks AVAILABILITY.** `router.supporting(stage)` (ignores availability) drives the cost estimate, so a dry-run shows real cost with no API key loaded. `router.candidates(stage)` (availability-gated) drives actual dispatch + fallback. `--go` with no key raises `NoAdapterError` at `pick()`, never silently pays.
+- **Tripo mesh selection never trusts dict order.** `adapters.tripo._pick_mesh()` returns the `model` key, else the first value with a mesh extension (`.glb/.gltf/.obj/.fbx/.usdz/.stl`), else None → `run_stage` raises. Prevents copying a texture PNG to `<sku>.glb`. Do NOT revert to `next(iter(downloaded.values()))`.
+
+## Conventions
+
+- **Remesh-to-GLB uses `smart_lowpoly`, NOT `convert_model`** — the tripo3d SDK's `convert_model` format Literal excludes GLB (GLB is the native output). `convert_model` is reserved for deferred USDZ/FBX export.
+- **Chaining:** `Artifact` carries both a provider `task_id` (same-provider chaining) and a local `path`/`model_url` (cross-provider handoff). `router.pick(stage, exclude=...)` enables fallback.
+- **Idempotency:** `StageStore` (file-based) persists each stage result keyed by `(input_hash, stage)`; a resumed job skips completed stages (a crash at remesh does not re-bill image-to-3D + texture). The hash folds `job.params` (`telemetry.hash_inputs`), so changing `target_polycount` invalidates the cache (correctness over re-bill avoidance). SKU is format-validated `^[a-z]{2,4}-\d{3}$` in `preflight.resolve_source` before any glob/output use.
+- **Execution spine is synchronous-within-stage** — adapters block via the SDK `wait_for_task`. No event-driven DAG; job concurrency is a Phase-3 worker concern.
+- Reuses (does NOT duplicate): `budget.py` (RunBudget), `telemetry.py` (stage span + hash_inputs), the `tripo3d` SDK via a thin adapter. Does NOT use `ai_3d/generation_pipeline.py` (superseded — monolithic, no budget/telemetry).
+
+## Entry
+
+`python -m skyyrose.elite_studio.pipeline3d --sku <sku> --stages ... [--go]` — dry-run by default; `--go` dispatches paid work (subject to the money gate above).

--- a/wordpress-theme/skyyrose-flagship/CLAUDE.md
+++ b/wordpress-theme/skyyrose-flagship/CLAUDE.md
@@ -1,0 +1,25 @@
+# SkyyRose Theme — scoped context
+
+Loads on top of root. Root already covers: `.min` is `SCRIPT_DEBUG`-gated (rebuild after every CSS/JS edit),
+`index.php?rest_route=` not `/wp-json/`, escape/sanitize, nonce+capability, no `innerHTML`, PHPCS. The items
+below are NOT in root and a fresh session trips on them.
+
+## Build commands run from `wordpress-theme/` (the PARENT), not here
+
+There is NO `package.json` in `skyyrose-flagship/` — it lives at `wordpress-theme/package.json`. From `wordpress-theme/`:
+`npm run build` (CSS+JS) · `npm run build:css` · `npm run build:js` · `npm run rebuild` (clean+build) · `npm run watch:build`.
+From inside `skyyrose-flagship/` you can still run the raw scripts: `node scripts/build-css.js` / `node scripts/build-js.js`.
+
+## Adding a template = TWO edits in `inc/enqueue.php` (or CSS loads wrong, silently)
+
+1. `$template_map` in `skyyrose_get_current_template_slug()` (~`enqueue.php:426`) — maps `template-*.php` filename → slug string.
+2. `$template_styles` in `skyyrose_enqueue_template_styles()` (~`enqueue.php:485`) — maps slug → CSS file (a JS section mirrors this).
+Then create the source CSS/JS and run `npm run build` to emit `.min`. Miss either array → new template gets wrong CSS or none.
+
+## Brand constants — use them, never hardcode
+
+Color constants (`SKYYROSE_COLOR_ROSE_GOLD` / `_GOLD` / `_CRIMSON` / `_SILVER`) are defined in committed `inc/brand-colors.php`. `functions.php` ALSO includes `inc/brand.generated.php` (loaded first) — that file is **generated from `assets/brand/brand.yaml` at build and is NOT committed** (you won't see it in a fresh checkout); it supplies `SKYYROSE_BRAND_TAGLINE` + helpers like `skyyrose_brand_collections()`. NEVER hardcode a hex value or the tagline in PHP — reference the constants.
+
+## Kill-switch awareness
+
+`SKYYROSE_COMING_SOON_MODE` (`functions.php:~39`) — `true` makes all public traffic see HTTP 503. Default `false`; don't toggle without intent. `CONCATENATE_SCRIPTS = false` (`functions.php:~50`) is an intentional override for WP.com MIME/concat errors — don't "fix" it.


### PR DESCRIPTION
## Summary
- Root `CLAUDE.md`: add Karpathy coding guidelines + merge Self-Correction section.
- 10 new/updated scoped `CLAUDE.md` files (agents/, api/, database/, frontend/, llm/, skyyrose/cli_harnesses/, skyyrose/elite_studio/, wordpress-theme/skyyrose-flagship/, assets/products/source-photos/{,black-rose/}).

## Test plan
- [x] Diff scope confirmed markdown-only (`git diff --name-only main HEAD | grep -v '\.md$'` → empty)
- [x] Spot-checked 3 files for well-formed, non-truncated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Karpathy coding guidelines to the root `CLAUDE.md` and adds scoped `CLAUDE.md` coverage across key areas to provide clear, enforceable guidance. Consolidates the self-correction policy and fixes a misfiled pipeline doc.

- **New Features**
  - Root `CLAUDE.md`: added Karpathy Coding Guidelines; merged Self-Correction into “After a Mistake” (keep learnings + commit-together).
  - Scoped coverage added/updated for `agents/`, `api/`, `database/`, `frontend/`, `llm/`, `skyyrose/cli_harnesses/`, `skyyrose/elite_studio/`, `wordpress-theme/skyyrose-flagship/`, and product source photos.
  - Key guardrails: mandatory SSRF URL validation in `api/*` (`FastAPI`); `Next.js 16` uses `proxy.ts` as the gate; `Alembic` targets `agents/models.py` (async-only access); model strings come from `llm/model_ids.py`; fail-closed money gate in `elite_studio`; SKU-based naming + `make sot-manifest` + image fidelity check for product photos.

- **Bug Fixes**
  - Moved `elite_studio/pipeline3d` rules out of `assets/products/source-photos/black-rose/CLAUDE.md` into `skyyrose/elite_studio/CLAUDE.md`; reset the subdir doc to the correct photo guidance.

<sup>Written for commit 452233bbdb29a1fe34a83f64881c1f88d37aced0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

