### PR TITLE
fix(dashboard): route all product data through SOT, fix broken product images

### DIFF
--- a/frontend/app/(storefront)/HomePage.tsx
+++ b/frontend/app/(storefront)/HomePage.tsx
@@ -5,7 +5,7 @@ import { motion, useScroll, useTransform, AnimatePresence } from 'framer-motion'
 import Link from 'next/link';
 import Image from 'next/image';
 import { ArrowRight, Play, Sparkles, ChevronDown } from 'lucide-react';
-import { getAllCollections } from '@/lib/collections';
+import type { CollectionConfig } from '@/lib/collections';
 
 const RotatingLogoFallback = lazy(
   () => import('@/components/3d/RotatingLogoFallback')
@@ -19,8 +19,11 @@ interface Particle {
   delay: number;
 }
 
-export default function HomePage() {
-  const collections = getAllCollections();
+interface HomePageProps {
+  collections: CollectionConfig[];
+}
+
+export default function HomePage({ collections }: HomePageProps) {
   const [heroLoaded, setHeroLoaded] = useState(false);
   const [particles, setParticles] = useState<Particle[]>([]);
   const heroRef = useRef<HTMLDivElement>(null);

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import HomePage from './(storefront)/HomePage';
 import SiteNav from '@/components/navigation/SiteNav';
 import IncentivePopup from '@/components/marketing/IncentivePopup';
+import { getAllEnrichedCollections } from '@/lib/catalog-server';
 
 export const metadata: Metadata = {
   title: 'SkyyRose | Luxury Grows from Concrete.',
@@ -16,11 +17,12 @@ export const metadata: Metadata = {
 };
 
 export default function Home() {
+  const collections = getAllEnrichedCollections();
   return (
     <div className="min-h-screen bg-[#0A0A0A]">
       <SiteNav />
       <main>
-        <HomePage />
+        <HomePage collections={collections} />
       </main>
       <IncentivePopup />
     </div>

--- a/frontend/app/pre-order/PreOrderPage.tsx
+++ b/frontend/app/pre-order/PreOrderPage.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Link from 'next/link';
-import Image from 'next/image';
 import {
   ArrowRight,
   Check,
@@ -16,11 +15,14 @@ import {
   Sparkles,
   ShoppingBag,
 } from 'lucide-react';
-import { getAllCollections, type CollectionConfig } from '@/lib/collections';
+import type { CollectionConfig } from '@/lib/collections';
 import { useCartStore, type CartItem } from '@/lib/stores/cart-store';
 
-export default function PreOrderPage() {
-  const collections = getAllCollections();
+interface PreOrderPageProps {
+  collections: CollectionConfig[];
+}
+
+export default function PreOrderPage({ collections }: PreOrderPageProps) {
   const [activeCollection, setActiveCollection] = useState<string>('all');
   const { items: cart, addItem, removeItem: removeCartItem, subtotal, itemCount } = useCartStore();
   const [email, setEmail] = useState('');
@@ -444,13 +446,15 @@ function ProductPreOrderCard({
     >
       {/* Image */}
       <div className="relative aspect-square overflow-hidden">
-        {!imageError ? (
-          <Image
-            src={image}
+        {!imageError && image ? (
+          // SOT paths are theme assets served by skyyrose.co, not the dashboard's
+          // public/ dir — next/image throws synchronously on an unconfigured host
+          // before onError can fire, so a plain <img> degrades gracefully instead.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={`/${image.replace(/^\/+/, '')}`}
             alt={name}
-            fill
-            sizes="(max-width: 768px) 50vw, 25vw"
-            className="object-cover"
+            className="absolute inset-0 h-full w-full object-cover"
             onError={() => setImageError(true)}
           />
         ) : (

--- a/frontend/app/pre-order/page.tsx
+++ b/frontend/app/pre-order/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import SiteNav from '@/components/navigation/SiteNav';
 import IncentivePopup from '@/components/marketing/IncentivePopup';
 import PreOrderPage from './PreOrderPage';
+import { getAllEnrichedCollections } from '@/lib/catalog-server';
 
 export const metadata: Metadata = {
   title: 'Pre-Order | SkyyRose',
@@ -15,10 +16,11 @@ export const metadata: Metadata = {
 };
 
 export default function PreOrder() {
+  const collections = getAllEnrichedCollections();
   return (
     <div className="min-h-screen bg-[#0A0A0A]">
       <SiteNav />
-      <PreOrderPage />
+      <PreOrderPage collections={collections} />
       <IncentivePopup />
     </div>
   );

--- a/frontend/components/collections/ProductCard.tsx
+++ b/frontend/components/collections/ProductCard.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useRef } from 'react';
 import { motion, useMotionValue, useSpring, useTransform } from 'framer-motion';
-import Image from 'next/image';
 import type { CollectionProduct } from '@/lib/collections';
 
 interface ProductCardProps {
@@ -64,13 +63,17 @@ export default function ProductCard({
       <div className="relative overflow-hidden rounded-lg bg-white/[0.02] border border-white/5 backdrop-blur-sm transition-all duration-300 group-hover:border-white/10 group-hover:bg-white/[0.04]">
         {/* Image */}
         <div className="relative aspect-[3/4] overflow-hidden bg-gradient-to-b from-white/[0.03] to-transparent">
-          {!imageError ? (
-            <Image
-              src={product.image}
+          {!imageError && product.image ? (
+            // SOT paths are theme assets served by skyyrose.co, not the dashboard's
+            // own public/ dir — next/image throws synchronously on an unconfigured
+            // host before onError can ever fire, so a plain <img> with graceful
+            // onError degrade is the established pattern here (see
+            // app/admin/catalog/page.tsx's ImagePreview for the same tradeoff).
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={`/${product.image.replace(/^\/+/, '')}`}
               alt={product.name}
-              fill
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-              className="object-cover transition-transform duration-500 group-hover:scale-105"
+              className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
               onError={() => setImageError(true)}
             />
           ) : (

--- a/frontend/components/collections/ProductQuickView.tsx
+++ b/frontend/components/collections/ProductQuickView.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X } from 'lucide-react';
-import Image from 'next/image';
 import type { CollectionProduct } from '@/lib/collections';
 import { useCartStore } from '@/lib/stores/cart-store';
 
@@ -126,13 +125,16 @@ export default function ProductQuickView({
               <div className="flex flex-col md:flex-row gap-8">
                 {/* Image */}
                 <div className="relative w-full md:w-1/2 aspect-[3/4] rounded-lg overflow-hidden bg-white/[0.02]">
-                  {!imageError ? (
-                    <Image
-                      src={product.image}
+                  {!imageError && product.image ? (
+                    // See ProductCard.tsx: SOT paths are theme assets served by
+                    // skyyrose.co, not the dashboard's public/ dir — next/image
+                    // throws synchronously on an unconfigured host before onError
+                    // can fire, so a plain <img> degrades gracefully instead.
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={`/${product.image.replace(/^\/+/, '')}`}
                       alt={product.name}
-                      fill
-                      sizes="(max-width: 768px) 100vw, 50vw"
-                      className="object-cover"
+                      className="absolute inset-0 h-full w-full object-cover"
                       onError={() => setImageError(true)}
                     />
                   ) : (

--- a/frontend/components/dashboard/personalization-analytics.tsx
+++ b/frontend/components/dashboard/personalization-analytics.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import {
   Card,
@@ -22,6 +23,7 @@ import {
   MousePointerClick,
   Heart,
 } from 'lucide-react';
+import { getCollection } from '@/lib/collections';
 
 // ─── Brand ───────────────────────────────────────────────────────────────────
 
@@ -124,37 +126,62 @@ function generateFunnel(): FunnelStage[] {
   ];
 }
 
-function generateTopProducts(): TopProduct[] {
-  const products: TopProduct[] = [
-    { sku: 'br-006', name: 'BLACK Rose Sherpa Jacket', heatScore: 0, collection: 'Black Rose' },
-    { sku: 'lh-004', name: 'Love Hurts Varsity Jacket', heatScore: 0, collection: 'Love Hurts' },
-    { sku: 'br-004', name: 'BLACK Rose Hoodie', heatScore: 0, collection: 'Black Rose' },
-    { sku: 'sg-001', name: 'The Bay Set', heatScore: 0, collection: 'Signature' },
-    { sku: 'br-001', name: 'BLACK Rose Crewneck', heatScore: 0, collection: 'Black Rose' },
-    { sku: 'sg-009', name: 'The Sherpa Jacket', heatScore: 0, collection: 'Signature' },
-  ];
-  return products
-    .map((p) => ({ ...p, heatScore: randomInt(15, 95) }))
-    .sort((a, b) => b.heatScore - a.heatScore);
+// SKUs tracked by this demo panel. Only the SKU is hardcoded — name and
+// collection are resolved live from the catalog below so this never shows a
+// stale product name (e.g. a since-renamed product). heatScore itself stays
+// simulated: this panel has no real behavioral-tracking backend yet.
+const TRACKED_SKUS = ['br-006', 'lh-004', 'br-004', 'sg-001', 'br-001', 'sg-009'];
+
+function generateTopProducts(catalogLookup: Map<string, { name: string; collection: string }>): TopProduct[] {
+  return TRACKED_SKUS.map((sku) => {
+    const entry = catalogLookup.get(sku);
+    return {
+      sku,
+      name: entry?.name ?? sku,
+      collection: entry?.collection ?? '',
+      heatScore: randomInt(15, 95),
+    };
+  }).sort((a, b) => b.heatScore - a.heatScore);
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function PersonalizationAnalytics() {
+  const { data: productsData } = useQuery({
+    queryKey: ['products', 'personalization-tracked'],
+    queryFn: async () => {
+      const res = await fetch('/api/products');
+      if (!res.ok) throw new Error('Failed to load products');
+      const json = await res.json();
+      return json.data.products as Array<{ sku: string; name: string; collection: string }>;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const catalogLookup = useMemo(() => {
+    const map = new Map<string, { name: string; collection: string }>();
+    for (const p of productsData ?? []) {
+      const collectionName = getCollection(p.collection)?.name ?? p.collection;
+      map.set(p.sku, { name: p.name, collection: collectionName });
+    }
+    return map;
+  }, [productsData]);
+
   const [metrics, setMetrics] = useState<PersonalizationMetrics>(generateMetrics);
   const [segments, setSegments] = useState<IntentSegment[]>(generateIntentSegments);
   const [funnel, setFunnel] = useState<FunnelStage[]>(generateFunnel);
-  const [topProducts, setTopProducts] = useState<TopProduct[]>(generateTopProducts);
+  const [topProducts, setTopProducts] = useState<TopProduct[]>([]);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const refreshData = useCallback(() => {
     setMetrics(generateMetrics());
     setSegments(generateIntentSegments());
     setFunnel(generateFunnel());
-    setTopProducts(generateTopProducts());
-  }, []);
+    setTopProducts(generateTopProducts(catalogLookup));
+  }, [catalogLookup]);
 
   useEffect(() => {
+    refreshData();
     intervalRef.current = setInterval(refreshData, 15000);
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);

--- a/frontend/lib/collections.ts
+++ b/frontend/lib/collections.ts
@@ -15,6 +15,12 @@ export interface CollectionScene {
   name: string;
   description: string;
   backgroundImage: string;
+  /**
+   * Always [] on the raw COLLECTIONS config below — real product data is
+   * SOT-authoritative and injected at request time by
+   * `getEnrichedCollection`/`getAllEnrichedCollections` in catalog-server.ts.
+   * Never hand-populate this array; it silently drifts from the catalog CSV.
+   */
   products: CollectionProduct[];
 }
 
@@ -53,43 +59,7 @@ export const COLLECTIONS: Record<CollectionSlug, CollectionConfig> = {
         name: 'The Garden',
         description: 'Wrought-iron racks amid gothic rose arbors',
         backgroundImage: '/images/scenes/black-rose-garden.jpg',
-        products: [
-          {
-            id: 'br-001',
-            name: 'BLACK Rose Crewneck',
-            price: 35,
-            image: '/images/scenes/black-rose-product-1.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'br-002',
-            name: 'BLACK Rose Joggers',
-            price: 50,
-            image: '/images/scenes/black-rose-product-2.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'br-003',
-            name: 'BLACK is Beautiful Jersey',
-            price: 45,
-            image: '/images/scenes/black-rose-product-3.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'br-004',
-            name: 'BLACK Rose Hoodie',
-            price: 40,
-            image: '/images/scenes/black-rose-product-4.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'br-005',
-            name: 'BLACK Rose Hoodie \u2014 Signature Edition',
-            price: 65,
-            image: '/images/scenes/black-rose-product-5.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-        ],
+        products: [],
       },
     ],
   },
@@ -112,44 +82,14 @@ export const COLLECTIONS: Record<CollectionSlug, CollectionConfig> = {
         name: 'The Ballroom',
         description: 'Candlelit manor with crystal chandeliers',
         backgroundImage: '/images/scenes/love-hurts-ballroom.jpg',
-        products: [
-          {
-            id: 'lh-006',
-            name: 'The Fannie',
-            price: 45,
-            image: '/images/scenes/love-hurts-product-1.jpg',
-            sizes: ['One Size'],
-          },
-          {
-            id: 'lh-002',
-            name: 'Love Hurts Joggers',
-            price: 95,
-            image: '/images/scenes/love-hurts-product-2.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'lh-003',
-            name: 'Love Hurts Basketball Shorts',
-            price: 75,
-            image: '/images/scenes/love-hurts-product-3.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-        ],
+        products: [],
       },
       {
         id: 'the-manor',
         name: 'The Manor',
         description: 'Golden pedestals with flickering candlelight',
         backgroundImage: '/images/scenes/love-hurts-manor.jpg',
-        products: [
-          {
-            id: 'lh-004',
-            name: 'Love Hurts Varsity Jacket',
-            price: 265,
-            image: '/images/scenes/love-hurts-product-4.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-        ],
+        products: [],
       },
     ],
   },
@@ -172,115 +112,21 @@ export const COLLECTIONS: Record<CollectionSlug, CollectionConfig> = {
         name: 'The Runway',
         description: 'Bay Bridge glass venue with industrial racks',
         backgroundImage: '/images/scenes/signature-runway.jpg',
-        products: [
-          {
-            id: 'sg-001',
-            name: "The Bridge Series 'The Bay Bridge' Shorts",
-            price: 195,
-            image: '/images/scenes/signature-product-1.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'sg-002',
-            name: "The Bridge Series 'Stay Golden' Shirt",
-            price: 65,
-            image: '/images/scenes/signature-product-2.jpg',
-            sizes: ['XS', 'S', 'M', 'L', 'XL', '2XL'],
-          },
-          {
-            id: 'sg-003',
-            name: "The Bridge Series 'Stay Golden' Shorts",
-            price: 65,
-            image: '/images/scenes/signature-product-3.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'sg-005',
-            name: "The Bridge Series 'The Bay Bridge' Shirt",
-            price: 25,
-            image: '/images/scenes/signature-product-5.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL'],
-          },
-        ],
+        products: [],
       },
       {
         id: 'the-showroom',
         name: 'The Showroom',
         description: 'Grand exhibition hall with marble columns',
         backgroundImage: '/images/scenes/signature-showroom.jpg',
-        products: [
-          {
-            id: 'sg-006',
-            name: 'Mint & Lavender Hoodie',
-            price: 45,
-            image: '/images/scenes/signature-product-6.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'sg-007',
-            name: 'The Signature Beanie',
-            price: 25,
-            image: '/images/scenes/signature-product-7.jpg',
-            sizes: ['One Size'],
-          },
-          {
-            id: 'sg-013',
-            name: 'Mint & Lavender Crewneck',
-            price: 40,
-            image: '/images/scenes/signature-product-8.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'sg-009',
-            name: 'The Sherpa Jacket',
-            price: 80,
-            image: '/images/scenes/signature-product-9.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'sg-014',
-            name: 'Mint & Lavender Sweatpants',
-            price: 45,
-            image: '/images/scenes/signature-product-10.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-        ],
+        products: [],
       },
       {
         id: 'the-fitting-room',
         name: 'The Fitting Room',
         description: 'Intimate dressing area with signature racks',
         backgroundImage: '/images/scenes/signature-fitting-room.jpg',
-        products: [
-          {
-            id: 'sg-011',
-            name: 'Original Label Tee (White)',
-            price: 30,
-            image: '/images/scenes/signature-beanie-1.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'sg-012',
-            name: 'Original Label Tee (Orchid)',
-            price: 30,
-            image: '/images/scenes/signature-beanie-2.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-          {
-            id: 'sg-007',
-            name: 'The Signature Beanie',
-            price: 25,
-            image: '/images/scenes/signature-beanie-3.jpg',
-            sizes: ['One Size'],
-          },
-          {
-            id: 'sg-009',
-            name: 'The Sherpa Jacket',
-            price: 80,
-            image: '/images/scenes/signature-beanie-4.jpg',
-            sizes: ['S', 'M', 'L', 'XL', '2XL', '3XL'],
-          },
-        ],
+        products: [],
       },
     ],
   },
@@ -303,26 +149,7 @@ export const COLLECTIONS: Record<CollectionSlug, CollectionConfig> = {
         name: 'The Playground',
         description: 'Vibrant colorblock sets for the next generation',
         backgroundImage: '/images/scenes/kids-capsule-hero.jpg',
-        products: [
-          {
-            id: 'kids-001',
-            name: 'Kids Colorblock Hoodie Set — Red/Black',
-            price: 65,
-            image: '/assets/images/products/kids-001-red-set.jpeg',
-            sizes: ['2T', '3T', '4T', '5', '6', '7'],
-            description:
-              'Bold red and black V-chevron colorblock hoodie and jogger set. Designed for young ones who wear luxury from the start.',
-          },
-          {
-            id: 'kids-002',
-            name: 'Kids Colorblock Hoodie Set — Purple/Black',
-            price: 65,
-            image: '/assets/images/products/kids-002-purple-set.jpeg',
-            sizes: ['2T', '3T', '4T', '5', '6', '7'],
-            description:
-              'Rich purple and black V-chevron colorblock hoodie and jogger set. Little ones deserve luxury too.',
-          },
-        ],
+        products: [],
       },
     ],
   },


### PR DESCRIPTION
## Summary
- `frontend/lib/collections.ts` was a full shadow catalog — hardcoded name/price per product across all 4 collections, pointing at `/images/scenes/*.jpg` paths that don't exist in `frontend/public/`. Confirmed at least one live drift (lh-004 "Varsity Jacket" vs the catalog's actual "Bomber Jacket") and a homepage "Pieces" count off by up to 9 per collection from the real published-product count.
- Stripped all hardcoded product data from `collections.ts` — only brand/scene metadata remains. Product data now flows exclusively through the existing `catalog-server.ts` enrichment layer, which was already correct but only wired into 2 of 5 consumer routes (`app/collections/page.tsx`, `app/collections/[slug]/page.tsx`). Wired the other two live surfaces: homepage (`app/page.tsx`) and pre-order (`app/pre-order/page.tsx`).
- Fixed a pre-existing bug found along the way: `ProductCard.tsx`, `ProductQuickView.tsx`, and `PreOrderPage.tsx`'s inline card all used `next/image` on the SOT's theme-relative paths, which throws synchronously (crashes the route, not just a broken `<img>`) since those assets are served by skyyrose.co, not the dashboard's own `public/`. `/collections/[slug]` was **already 500ing on main** before this PR — confirmed via local dev server. Swapped to a plain `<img>` + graceful `onError`, matching the exact pattern already established in `app/admin/catalog/page.tsx`'s `ImagePreview`.
- `personalization-analytics.tsx`'s "Top Products" demo widget hardcoded the same SKU→name/collection drift pattern; now resolves live via `/api/products` (heatScore itself stays simulated — no real behavioral-tracking backend exists yet, that's out of scope here).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` — 0 errors (234 pre-existing warnings elsewhere in the repo, none in touched files)
- [x] `npm run build` — succeeds, all static + SSG collection routes generate
- [x] Live dev server, all routes 200 with clean server log: `/`, `/pre-order`, `/collections`, `/collections/black-rose`, `/collections/love-hurts`, `/collections/signature`, `/collections/kids-capsule` (black-rose was 500 before this PR; pre-order briefly regressed mid-fix then was fixed by the same `next/image` change)
- [x] Homepage "Pieces" badges cross-checked against `skyyrose-catalog.csv` `published==1` counts: 14/5/12/2 for black-rose/love-hurts/signature/kids-capsule — exact match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cRq91b2aWi44ia2M841n2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all storefront product data through the catalog SOT and fixes product image rendering. Removes stale hardcoded products, prevents 500s on collection pages, and restores correct homepage “Pieces” counts.

- **Bug Fixes**
  - Replaced `next/image` with a plain <img> + onError in product cards, quick view, and pre-order card to handle SOT-hosted assets without crashing.
  - “Top Products” now resolves name/collection live via `/api/products`; only heat scores remain simulated.

- **Refactors**
  - Stripped all hardcoded products from `frontend/lib/collections.ts`; kept only brand/scene metadata.
  - Routed homepage and pre-order through `getAllEnrichedCollections` from `catalog-server.ts` and passed collections as props.
  - Ensured all storefront routes pull products exclusively from the enrichment layer.

<sup>Written for commit 8602a68796a777ccb7645fc7b2c2be6d8ab879db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product and collection pages now load live catalog data at render time, so displayed collections, names, and links stay in sync with the latest product data.
  * The dashboard’s top-product analytics now reflects the current catalog instead of fixed product labels.

* **Bug Fixes**
  * Improved product image rendering on storefront and pre-order views with a safer fallback, reducing broken image issues and showing a fallback avatar when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->