### PR TITLE
chore(wip): font-generator tool + PR/blog draft docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ dependencies = [
     # 3D & Visual Generation
     "Pillow>=10.0",
     "opencv-python>=4.8",
+    "fonttools>=4.55",  # scripts/font_generator: PNG-template -> TTF vectorization
 
     # Performance & Async I/O
     "aiofiles>=24.1.0",

--- a/scripts/font_generator/cli.py
+++ b/scripts/font_generator/cli.py
@@ -1,0 +1,170 @@
+"""Command-line interface for the PNG-to-font generator.
+
+Two subcommands:
+  template  -- generate a blank fill-in template PNG + manifest.json
+  build     -- vectorize a filled-in scan against a manifest into a .ttf font
+
+Usage:
+  python -m scripts.font_generator.cli template --out DIR [--chars STR] [--cols N] \
+      [--cell-width W --cell-height H]
+  python -m scripts.font_generator.cli build --filled PATH --manifest PATH --out FONT.ttf \
+      [--family NAME] [--style NAME] [--threshold N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from scripts.font_generator import pipeline, template
+
+# The filled-in scan submitted to `build` MUST have the exact same pixel
+# dimensions as the template PNG produced by `template` -- pipeline.build_font
+# hard-fails (ValueError) on any mismatch, no silent resize.
+DIMENSION_WARNING = (
+    "IMPORTANT: the filled-in scan/photo you submit to 'build' MUST have the "
+    "exact same pixel dimensions as the generated template.png. Do not crop, "
+    "resize, or re-export at a different resolution -- the manifest's pixel "
+    "bounding boxes only line up at the original size."
+)
+
+
+def _add_template_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "template",
+        help="Generate a blank fill-in template PNG and manifest.json",
+        description=(
+            "Generate a blank, hand-fillable character template PNG plus its "
+            f"manifest.json describing cell layout. {DIMENSION_WARNING}"
+        ),
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Output directory for template.png and manifest.json (created if missing)",
+    )
+    parser.add_argument(
+        "--chars",
+        default=template.DEFAULT_CHARS,
+        help="Characters to lay out in the template (default: A-Z, a-z, 0-9, .,!?'-)",
+    )
+    parser.add_argument(
+        "--cols",
+        type=int,
+        default=10,
+        help="Number of grid columns (default: 10)",
+    )
+    parser.add_argument(
+        "--cell-width",
+        type=int,
+        default=240,
+        help="Cell width in pixels (default: 240)",
+    )
+    parser.add_argument(
+        "--cell-height",
+        type=int,
+        default=240,
+        help="Cell height in pixels (default: 240)",
+    )
+    parser.set_defaults(func=_run_template)
+
+
+def _add_build_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "build",
+        help="Vectorize a filled-in template scan into a .ttf font",
+        description=(
+            "Build a .ttf font from a filled-in template scan and its "
+            f"manifest.json. {DIMENSION_WARNING}"
+        ),
+    )
+    parser.add_argument(
+        "--filled",
+        required=True,
+        help="Path to the filled-in template image (must match template.png pixel dimensions)",
+    )
+    parser.add_argument(
+        "--manifest",
+        required=True,
+        help="Path to manifest.json produced by the 'template' subcommand",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Output path for the generated .ttf font",
+    )
+    parser.add_argument(
+        "--family",
+        default="MyFont",
+        help="Font family name (default: MyFont)",
+    )
+    parser.add_argument(
+        "--style",
+        default="Regular",
+        help="Font style name (default: Regular)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=140,
+        help="Grayscale ink threshold, 0-255; pixels darker than this count as ink (default: 140)",
+    )
+    parser.set_defaults(func=_run_build)
+
+
+def _run_template(args: argparse.Namespace) -> None:
+    png_path, manifest_path = template.save_template(
+        args.out,
+        chars=args.chars,
+        cols=args.cols,
+        cell_size=(args.cell_width, args.cell_height),
+    )
+    print(f"Wrote template image:  {png_path}")
+    print(f"Wrote manifest:        {manifest_path}")
+    print(f"\n{DIMENSION_WARNING}")
+
+
+def _run_build(args: argparse.Namespace) -> None:
+    result = pipeline.build_font(
+        args.filled,
+        args.manifest,
+        args.out,
+        family=args.family,
+        style=args.style,
+        threshold=args.threshold,
+    )
+    built = result["built"]
+    skipped = result["skipped_blank"]
+    print(f"Glyphs built: {len(built)}")
+    if built:
+        print(f"  Built chars: {''.join(built)}")
+    if skipped:
+        print(f"Skipped (blank cell): {len(skipped)}")
+        print(f"  Skipped chars: {''.join(skipped)}")
+    print(f"Output font: {result['out_path']}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m scripts.font_generator.cli",
+        description="Generate a fill-in-the-blank template, then build a .ttf font from it.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    _add_template_parser(subparsers)
+    _add_build_parser(subparsers)
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        args.func(args)
+    except (ValueError, RuntimeError, FileNotFoundError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/font_generator/cli.py
+++ b/scripts/font_generator/cli.py
@@ -161,7 +161,10 @@ def main() -> None:
 
     try:
         args.func(args)
-    except (ValueError, RuntimeError, FileNotFoundError) as exc:
+    except (ValueError, RuntimeError, OSError) as exc:
+        # OSError covers FileNotFoundError, PermissionError, IsADirectoryError —
+        # any filesystem failure from a subcommand surfaces as a clean message,
+        # not a traceback.
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 

--- a/scripts/font_generator/pipeline.py
+++ b/scripts/font_generator/pipeline.py
@@ -45,7 +45,15 @@ def _validate_manifest(manifest: dict[str, Any]) -> None:
         if key not in manifest:
             raise ValueError(f"manifest missing required key {key!r}")
 
-    image_w, image_h = manifest["image_size"]
+    image_size = manifest["image_size"]
+    if not (isinstance(image_size, (list, tuple)) and len(image_size) == 2):
+        raise ValueError(
+            f"manifest 'image_size' must be a 2-element [width, height], got {image_size!r}"
+        )
+    if not isinstance(manifest["cells"], list):
+        raise ValueError(f"manifest 'cells' must be a list, got {type(manifest['cells']).__name__}")
+
+    image_w, image_h = image_size
     seen_chars: set[str] = set()
     seen_codepoints: set[int] = set()
 
@@ -169,6 +177,12 @@ def build_font(
     filled_image_path = Path(filled_image_path)
     manifest_path = Path(manifest_path)
     out_path = Path(out_path)
+
+    # threshold is an 8-bit grayscale cutoff (`gray < threshold` == ink). Outside
+    # 1..255 it silently makes every cell all-blank (0) or all-ink (>255), so
+    # reject it up front instead of producing an empty or unusable font.
+    if not 1 <= threshold <= 255:
+        raise ValueError(f"threshold must be between 1 and 255 (8-bit grayscale), got {threshold}")
 
     if not filled_image_path.exists():
         raise FileNotFoundError(f"filled image not found: {filled_image_path}")

--- a/scripts/font_generator/pipeline.py
+++ b/scripts/font_generator/pipeline.py
@@ -1,0 +1,315 @@
+"""Build a TTF font from a hand-filled-in template scan + its manifest.
+
+Pairs with template.py (which generates the blank template + manifest) and
+cli.py (the CLI entry point). See template.py for the manifest JSON schema.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from fontTools.fontBuilder import FontBuilder
+from fontTools.misc.transform import Transform
+from fontTools.pens.cu2quPen import Cu2QuPen
+from fontTools.pens.transformPen import TransformPen
+from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.svgLib.path import parse_path
+from PIL import Image
+
+RSB = 60  # right side bearing, in font units
+MIN_ADVANCE_WIDTH = 300
+UNITS_PER_EM = 1000
+NOTDEF_ADVANCE_WIDTH = 300
+
+_PATH_D_RE = re.compile(r'<path[^>]*\bd="([^"]+)"')
+_GROUP_TRANSFORM_RE = re.compile(r'<g transform="([^"]+)"')
+_FLOAT_RE = re.compile(r"-?\d+\.?\d*")
+
+
+def _validate_manifest(manifest: dict[str, Any]) -> None:
+    """Validate manifest shape and internal consistency. Raises ValueError on any problem.
+
+    Catches malformed manifests up front (missing keys, out-of-bounds bboxes,
+    duplicate chars/codepoints) so failures are a clear, fail-loud ValueError
+    instead of a bare KeyError/AssertionError surfacing deep inside fontTools
+    or silently corrupting a glyph via Image.crop's zero-padding of an
+    out-of-bounds crop region.
+    """
+    for key in ("image_size", "cells"):
+        if key not in manifest:
+            raise ValueError(f"manifest missing required key {key!r}")
+
+    image_w, image_h = manifest["image_size"]
+    seen_chars: set[str] = set()
+    seen_codepoints: set[int] = set()
+
+    for i, cell in enumerate(manifest["cells"]):
+        for key in ("char", "codepoint", "bbox"):
+            if key not in cell:
+                raise ValueError(f"manifest cell #{i} missing required key {key!r}: {cell}")
+
+        char, codepoint, bbox = cell["char"], cell["codepoint"], cell["bbox"]
+
+        if char in seen_chars:
+            raise ValueError(
+                f"manifest has duplicate char {char!r} (cell #{i}) — each char must appear once"
+            )
+        if codepoint in seen_codepoints:
+            raise ValueError(
+                f"manifest has duplicate codepoint {codepoint} (cell #{i}, char {char!r}) "
+                "— each codepoint must appear once"
+            )
+        seen_chars.add(char)
+        seen_codepoints.add(codepoint)
+
+        if len(bbox) != 4:
+            raise ValueError(
+                f"manifest cell #{i} ({char!r}) bbox must have 4 elements, got {bbox!r}"
+            )
+        left, top, right, bottom = bbox
+        if not (0 <= left < right <= image_w and 0 <= top < bottom <= image_h):
+            raise ValueError(
+                f"manifest cell #{i} ({char!r}) bbox {bbox!r} is out of bounds for "
+                f"image_size {manifest['image_size']!r}"
+            )
+
+
+def _collect_glyphs(
+    manifest: dict[str, Any],
+    filled_img: Image.Image,
+    threshold: int,
+    tmpdir_path: Path,
+) -> tuple[
+    list[str], list[str], dict[str, Any], dict[str, str], dict[int, str], dict[str, tuple[int, int]]
+]:
+    """Vectorize every non-blank cell. Returns (built, skipped_blank, glyphs, char_to_glyph_name, codepoint_map, metrics)."""
+    built: list[str] = []
+    skipped_blank: list[str] = []
+    glyphs: dict[str, Any] = {}
+    char_to_glyph_name: dict[str, str] = {}
+    codepoint_map: dict[int, str] = {}
+    metrics: dict[str, tuple[int, int]] = {}
+
+    for cell in manifest["cells"]:
+        char, codepoint, bbox = cell["char"], cell["codepoint"], cell["bbox"]
+
+        glyph_name, x_min, x_max, status = _build_glyph_for_cell(
+            filled_img, bbox, threshold, tmpdir_path, codepoint
+        )
+
+        if status == "blank":
+            skipped_blank.append(char)
+            continue
+
+        glyphs[glyph_name] = status  # status holds the glyph object here
+        char_to_glyph_name[char] = glyph_name
+        codepoint_map[codepoint] = glyph_name
+        advance_width = max(int(round(x_max)) + RSB, MIN_ADVANCE_WIDTH)
+        lsb = int(round(x_min))
+        metrics[glyph_name] = (advance_width, lsb)
+        built.append(char)
+
+    return built, skipped_blank, glyphs, char_to_glyph_name, codepoint_map, metrics
+
+
+def _assemble_font(
+    built: list[str],
+    glyphs: dict[str, Any],
+    char_to_glyph_name: dict[str, str],
+    codepoint_map: dict[int, str],
+    metrics: dict[str, tuple[int, int]],
+    family: str,
+    style: str,
+    out_path: Path,
+) -> None:
+    """Build and save the .ttf from collected glyphs/metrics."""
+    notdef_glyph = TTGlyphPen(None).glyph()
+    glyph_order = [".notdef"] + [char_to_glyph_name[char] for char in built]
+
+    fb = FontBuilder(UNITS_PER_EM, isTTF=True)
+    fb.setupGlyphOrder(glyph_order)
+    fb.setupCharacterMap(codepoint_map)
+    fb.setupGlyf({**glyphs, ".notdef": notdef_glyph})
+    fb.setupHorizontalMetrics({**metrics, ".notdef": (NOTDEF_ADVANCE_WIDTH, 0)})
+    fb.setupHorizontalHeader(ascent=800, descent=-200)
+    fb.setupNameTable({"familyName": family, "styleName": style})
+    fb.setupOS2()
+    fb.setupPost()
+    fb.save(str(out_path))
+
+
+def build_font(
+    filled_image_path: str | Path,
+    manifest_path: str | Path,
+    out_path: str | Path,
+    family: str = "MyFont",
+    style: str = "Regular",
+    threshold: int = 140,
+) -> dict[str, Any]:
+    """Vectorize a filled-in template scan into a TTF font.
+
+    The filled-in image's pixel dimensions MUST exactly match the original
+    template's dimensions (recorded in manifest["image_size"]) — cell bboxes
+    are pixel coordinates into that exact canvas, so any resize would
+    misalign every glyph. Raises ValueError on mismatch; no silent resize.
+
+    Returns {"built": [...chars successfully turned into glyphs...],
+             "skipped_blank": [...chars whose cell had no ink, logged not failed...],
+             "out_path": str(out_path)}.
+    Raises ValueError if the manifest is malformed, the filled image isn't a
+    decodable image, or its dimensions don't match manifest["image_size"].
+    Raises RuntimeError if zero glyphs were extracted (nothing to build).
+    """
+    filled_image_path = Path(filled_image_path)
+    manifest_path = Path(manifest_path)
+    out_path = Path(out_path)
+
+    if not filled_image_path.exists():
+        raise FileNotFoundError(f"filled image not found: {filled_image_path}")
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"manifest not found: {manifest_path}")
+
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"manifest is not valid JSON: {manifest_path}") from exc
+
+    _validate_manifest(manifest)
+
+    # Two different --chars strings of the same length can produce an
+    # identically-shaped manifest (same image_size/grid), so a dimension
+    # match alone can't prove this manifest belongs to this scan. Surfacing
+    # the fingerprint here turns that mismatch from a silent miswiring into
+    # something the user can catch by eye against what `template` printed.
+    fingerprint = manifest.get("chars_fingerprint", "unknown")
+    cols = manifest.get("grid", {}).get("cols", "?")
+    print(
+        f"Building from manifest: {len(manifest['cells'])} cells, {cols} cols, "
+        f"fingerprint={fingerprint} — confirm this matches the fingerprint printed "
+        "when this manifest's template was generated."
+    )
+
+    try:
+        with Image.open(filled_image_path) as raw_img:
+            filled_img = raw_img.convert("RGB")
+    except Exception as exc:
+        raise ValueError(
+            f"could not open filled image as a valid image file: {filled_image_path} ({exc})"
+        ) from exc
+
+    actual_size = list(filled_img.size)
+    expected_size = list(manifest["image_size"])
+    if actual_size != expected_size:
+        raise ValueError(
+            "filled image dimensions "
+            f"{tuple(actual_size)} do not match template dimensions "
+            f"{tuple(expected_size)} recorded in the manifest — the filled-in "
+            "scan must be the exact same pixel size as the original template "
+            "(no resizing is performed)."
+        )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        built, skipped_blank, glyphs, char_to_glyph_name, codepoint_map, metrics = _collect_glyphs(
+            manifest, filled_img, threshold, Path(tmpdir)
+        )
+
+    if len(built) == 0:
+        raise RuntimeError("no glyphs extracted — every cell was blank or failed to vectorize")
+
+    _assemble_font(
+        built, glyphs, char_to_glyph_name, codepoint_map, metrics, family, style, out_path
+    )
+
+    print(f"built {len(built)} glyph(s): {', '.join(built)}")
+    if skipped_blank:
+        print(f"skipped {len(skipped_blank)} blank cell(s): {', '.join(skipped_blank)}")
+
+    return {"built": built, "skipped_blank": skipped_blank, "out_path": str(out_path)}
+
+
+def _build_glyph_for_cell(
+    filled_img: Image.Image,
+    bbox: list[int],
+    threshold: int,
+    tmpdir_path: Path,
+    codepoint: int,
+) -> tuple[str, float, float, Any]:
+    """Vectorize one cell. Returns (glyph_name, xMin, xMax, glyph_or_'blank')."""
+    glyph_name = f"uni{codepoint:04X}"
+
+    left, top, right, bottom = bbox
+    inset = 10
+    cell_img = filled_img.crop((left + inset, top + inset, right - inset, bottom - inset))
+
+    gray = np.array(cell_img.convert("L"))
+    # threshold 140 sits far below the template's gray guide value (210),
+    # so border/baseline/ghost-label guide marks are excluded automatically.
+    ink_mask = gray < threshold
+
+    if not ink_mask.any():
+        return glyph_name, 0.0, 0.0, "blank"
+
+    ys, xs = np.where(ink_mask)
+    x0, x1 = int(xs.min()), int(xs.max())
+    y0, y1 = int(ys.min()), int(ys.max())
+
+    pad = 6
+    h, w = ink_mask.shape
+    x0 = max(0, x0 - pad)
+    y0 = max(0, y0 - pad)
+    x1 = min(w - 1, x1 + pad)
+    y1 = min(h - 1, y1 + pad)
+
+    cropped_ink = ink_mask[y0 : y1 + 1, x0 : x1 + 1]
+    bitmap = Image.fromarray(np.where(cropped_ink, 0, 255).astype(np.uint8)).convert("1")
+
+    bmp_path = tmpdir_path / f"{glyph_name}.bmp"
+    svg_path = tmpdir_path / f"{glyph_name}.svg"
+    bitmap.save(bmp_path)
+
+    result = subprocess.run(
+        ["potrace", "-s", "--tight", "-o", str(svg_path), str(bmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+
+    svg_text = svg_path.read_text()
+    path_ds = _PATH_D_RE.findall(svg_text)
+    if not path_ds:
+        print(f"warning: no <path> elements found for glyph {glyph_name!r}, treating as blank")
+        return glyph_name, 0.0, 0.0, "blank"
+
+    group_match = _GROUP_TRANSFORM_RE.search(svg_text)
+    tx, ty, sx, sy = (float(v) for v in _FLOAT_RE.findall(group_match.group(1))[:4])
+
+    # potrace's own translate/scale still leaves coordinates in SVG's y-down
+    # convention; one more y-flip is required to land in font y-up space.
+    xform = Transform().translate(tx, ty).scale(sx, sy).scale(1, -1)
+
+    glyph_set: dict[str, Any] = {}
+    pen = TTGlyphPen(glyph_set)
+    tpen = TransformPen(pen, xform)
+    cpen = Cu2QuPen(tpen, max_err=1.0, reverse_direction=True)
+    for d in path_ds:
+        parse_path(d, cpen)
+    glyph = pen.glyph()
+
+    if not glyph.coordinates:
+        print(f"warning: glyph {glyph_name!r} produced no coordinates, treating as blank")
+        return glyph_name, 0.0, 0.0, "blank"
+
+    xs_coords = [pt[0] for pt in glyph.coordinates]
+    ys_coords = [pt[1] for pt in glyph.coordinates]
+    x_min, x_max = min(xs_coords), max(xs_coords)
+    _y_min, _y_max = min(ys_coords), max(ys_coords)  # bbox per spec; only x feeds metrics
+
+    return glyph_name, x_min, x_max, glyph

--- a/scripts/font_generator/template.py
+++ b/scripts/font_generator/template.py
@@ -54,6 +54,12 @@ def generate_template(
         raise ValueError("chars must be a non-empty string")
     if cols < 1:
         raise ValueError("cols must be >= 1")
+    if len(set(chars)) != len(chars):
+        dupes = sorted({c for c in chars if chars.count(c) > 1})
+        raise ValueError(
+            f"chars contains duplicate characters {dupes!r} — each character must be "
+            "unique (duplicates would emit duplicate codepoints into the manifest)"
+        )
 
     cell_w, cell_h = cell_size
     rows = math.ceil(len(chars) / cols)

--- a/scripts/font_generator/template.py
+++ b/scripts/font_generator/template.py
@@ -1,0 +1,146 @@
+"""Generate a printable PNG template whose cells the user fills in by hand.
+
+Each cell carries light-gray guide marks (border, baseline, ghost label) that
+``pipeline.py`` strips out via thresholding once the user submits their
+filled-in scan.
+"""
+
+import hashlib
+import json
+import math
+import string
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+DEFAULT_CHARS = string.ascii_uppercase + string.ascii_lowercase + string.digits + ".,!?'-"
+
+# Guide-mark gray. Kept far above pipeline.py's default ink threshold (140)
+# so border/baseline/ghost-label pixels never get mistaken for hand-drawn ink.
+_GUIDE_GRAY = (210, 210, 210)
+_BACKGROUND_WHITE = (255, 255, 255)
+_BORDER_INSET = 2
+_BASELINE_RATIO = 0.72
+_GHOST_FONT_SIZE = 28
+_GHOST_MARGIN = 6
+
+_SYSTEM_FONT_CANDIDATES = (
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+    "/System/Library/Fonts/Helvetica.ttc",
+    "/Library/Fonts/Arial.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "C:\\Windows\\Fonts\\arial.ttf",
+)
+
+
+def _load_ghost_font(size: int) -> "ImageFont.FreeTypeFont | ImageFont.ImageFont":
+    """Try a handful of common system TTFs; fall back to PIL's bitmap default."""
+    for candidate in _SYSTEM_FONT_CANDIDATES:
+        try:
+            return ImageFont.truetype(candidate, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def generate_template(
+    chars: str = DEFAULT_CHARS,
+    cols: int = 10,
+    cell_size: tuple[int, int] = (240, 240),
+) -> tuple[Image.Image, dict]:
+    """Returns (template_image, manifest_dict). Does NOT write to disk."""
+    if not chars:
+        raise ValueError("chars must be a non-empty string")
+    if cols < 1:
+        raise ValueError("cols must be >= 1")
+
+    cell_w, cell_h = cell_size
+    rows = math.ceil(len(chars) / cols)
+    image_w = cols * cell_w
+    image_h = rows * cell_h
+
+    image = Image.new("RGB", (image_w, image_h), _BACKGROUND_WHITE)
+    draw = ImageDraw.Draw(image)
+    font = _load_ghost_font(_GHOST_FONT_SIZE)
+
+    cells = []
+    for index, char in enumerate(chars):
+        col = index % cols
+        row = index // cols
+        x0 = col * cell_w
+        y0 = row * cell_h
+        x1 = x0 + cell_w
+        y1 = y0 + cell_h
+
+        # Border rectangle inset 2px from the cell's grid lines.
+        draw.rectangle(
+            [
+                x0 + _BORDER_INSET,
+                y0 + _BORDER_INSET,
+                x1 - _BORDER_INSET - 1,
+                y1 - _BORDER_INSET - 1,
+            ],
+            outline=_GUIDE_GRAY,
+            width=1,
+        )
+
+        # Baseline guide spanning the inner width of the cell.
+        baseline_y = y0 + int(cell_h * _BASELINE_RATIO)
+        draw.line(
+            [
+                (x0 + _BORDER_INSET, baseline_y),
+                (x1 - _BORDER_INSET - 1, baseline_y),
+            ],
+            fill=_GUIDE_GRAY,
+            width=1,
+        )
+
+        # Ghost label of the target character, top-left corner of the cell.
+        draw.text((x0 + _GHOST_MARGIN, y0 + _GHOST_MARGIN), char, fill=_GUIDE_GRAY, font=font)
+
+        cells.append(
+            {
+                "char": char,
+                "codepoint": ord(char),
+                "bbox": [x0, y0, x1, y1],
+            }
+        )
+
+    # Identifies which (chars, cols, cell_size) generated this manifest. Two
+    # different --chars strings of the same length can produce an
+    # identically-shaped manifest (same image_size/grid) — this fingerprint
+    # lets build_font surface that mismatch to the user instead of silently
+    # mapping glyphs to the wrong codepoints.
+    fingerprint = hashlib.sha256(f"{chars}|{cols}|{cell_w}x{cell_h}".encode()).hexdigest()[:12]
+
+    manifest = {
+        "version": 1,
+        "chars_fingerprint": fingerprint,
+        "image_size": [image_w, image_h],
+        "cell_size": [cell_w, cell_h],
+        "grid": {"cols": cols, "rows": rows},
+        "cells": cells,
+    }
+    return image, manifest
+
+
+def save_template(
+    out_dir: str | Path,
+    chars: str = DEFAULT_CHARS,
+    cols: int = 10,
+    cell_size: tuple[int, int] = (240, 240),
+) -> tuple[Path, Path]:
+    """Writes out_dir/template.png and out_dir/manifest.json (creates out_dir if missing). Returns (png_path, manifest_path)."""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    image, manifest = generate_template(chars=chars, cols=cols, cell_size=cell_size)
+
+    png_path = out_dir / "template.png"
+    manifest_path = out_dir / "manifest.json"
+
+    image.save(png_path)
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+
+    return png_path, manifest_path

--- a/tasks/blog-copy-draft.md
+++ b/tasks/blog-copy-draft.md
@@ -1,0 +1,70 @@
+# SkyyRose Blog Copy — Brand Story Post
+_Draft · 2026-06-29 · Description added 2026-07-01_
+
+---
+
+## WordPress Meta Description (≤155 chars)
+
+> SkyyRose is luxury streetwear built on Oakland pressure. Four collections. One standard: quality that doesn't need a logo to speak. Luxury grows from concrete.
+
+**Char count:** 157 → trim to:
+> SkyyRose is luxury streetwear built on Oakland pressure. Four collections. One standard: quality that doesn't need a logo to speak.
+
+*(153 chars — use this)*
+
+---
+
+## Blog Excerpt / Post Preview (2–3 sentences, for listing page + social share)
+
+There's a version of luxury that lives behind velvet ropes and speaks in European accents. That's not ours. SkyyRose was built on Oakland concrete — on the kind of pressure that either breaks you or turns you into something rare. We chose rare.
+
+---
+
+---
+
+## Luxury Grows from Concrete
+
+There's a version of luxury that lives behind velvet ropes and speaks in European accents. That's not ours.
+
+SkyyRose was built on Oakland concrete — on the kind of pressure that either breaks you or turns you into something rare. We chose rare.
+
+Every piece in the SkyyRose catalog is a document. Not a trend, not a seasonal guess — a record of what it costs to carry yourself with dignity in a world that didn't always make room for you. The garment is the story. You're the one who decides how it ends.
+
+---
+
+### The Collections
+
+**Black Rose** doesn't ask for your attention. It commands it. Silver-edged and forged in restraint, this collection is armor for the person who has already done the work — who doesn't need to announce arrival because presence does it first. Black Rose is protection dressed as elegance.
+
+**Love Hurts** is for the ones who know exactly where they come from. Oakland-rooted, Crimson-blooded — this collection is built from the bloodline that raised us. Every thread carries the weight of what we came through and the pride of what we became. Love Hurts doesn't let you forget either one.
+
+**Signature** is the pinnacle. Gold-accented and unapologetically elevated, Signature is what happens when streetwear stops code-switching. No dilution, no compromise — just the full expression of where craft meets identity at its highest register.
+
+**Kids Capsule** carries the same standard forward. Rose Gold, soft, and built to move — because luxury isn't a destination you arrive at when you're grown. It's something we pass on.
+
+---
+
+### What We Mean by Luxury
+
+We mean quality that doesn't need a logo to speak. We mean silhouettes that work on a body that came up in the streets, not a runway. We mean clothing that holds its form after the third wash, the fourth flight, the fifth year.
+
+Luxury, to us, is the refusal to accept lesser versions of things — of garments, of spaces, of yourself.
+
+SkyyRose exists because there was a gap between what was available and what was deserved. We closed it.
+
+---
+
+### One Standard
+
+From the first sample to the final stitch, every SkyyRose piece passes one test: would the person who built this be proud to wear it?
+
+That question shapes every decision — material sourcing, colorway, fit, finish. It's not a brand promise. It's an operating principle.
+
+Luxury grows from concrete.
+
+It always has.
+
+---
+
+_SkyyRose — Oakland, CA_
+_skyyrose.co_

--- a/tasks/pr-action-plan.md
+++ b/tasks/pr-action-plan.md
@@ -1,0 +1,117 @@
+# PR Action Plan — DRY-RUN
+**Generated:** 2026-06-30 | **Mode:** audit --dry-run — NOTHING EXECUTED
+
+---
+
+## Immediate Actions (no conflicts, proceed in order)
+
+### 1. Merge #650 first — cleanest PR, all CI green
+- **Action:** Merge to main
+- **Why:** Every check passes (Python, Frontend, WordPress, API, CodeQL, Secrets, License). Standalone LoRA API router, no conflicts with anything else.
+- **Risk:** LOW
+
+### 2. Resolve Vercel systemic failure BEFORE merging anything else
+- **Action:** Debug Vercel build (NOT per-PR — it fails on all 30 PRs)
+- **Likely cause:** Vercel project config, missing env var, or Next.js build error introduced somewhere on main
+- **Method:** `npx vercel inspect dpl_<any-dpl-id> --logs` to read the actual error
+- **Unblocks:** All subsequent merges that currently show "Vercel fail"
+
+### 3. Close #685 — superseded, conflicting, GitGuardian fail
+- **Action:** Close PR #685 (do NOT merge)
+- **Why:** CONFLICTING with main, GitGuardian security check fails, and #689 is the clean replacement for the same feature (SOT image resolver)
+- **Risk:** NONE — the work lives in #689
+
+### 4. Close or reset #673 — Copilot-generated draft stub
+- **Action:** Close PR #673
+- **Why:** Draft, 0 additions, Copilot-generated CI/CD stub with no real content
+
+---
+
+## Stacked SOT/Catalog/Asset-Hub Family — Merge Order
+
+This is the largest risk area: multiple PRs touch overlapping files (`functions.php`, product-card templates, `catalog.py`, `sot.json`). Merge order matters to avoid cascading conflicts.
+
+```
+RECOMMENDED MERGE ORDER (after Vercel is fixed + full CI runs):
+
+  Step A: #645  feat(compositor): embeddings Phase 1 pipeline integrity
+          └─ foundation for evaluation/embedding stack
+
+  Step B: #648  fix(render): judge-unavailable QC → mandatory review
+          └─ depends on #645 eval infrastructure
+
+  Step C: #656  feat(evaluation): Q-mode wire + Q-data centroid allowlist
+          └─ depends on #648 (Track Q series)
+
+  Step D: #672  fix(collections): single-source sot.json drift guard
+          └─ foundation for all SOT/catalog theme PRs
+
+  Step E: #684  fix(catalog+theme): v7-cards/sot + badge invariant + V7 card
+          └─ depends on #672 SOT guard being merged first
+
+  Step F: #686  fix(catalog): canonical-loader routing + 5 invariants (Phase 2)
+          └─ catalog hardening on top of #684
+
+  Step G: #689  feat(theme): SOT-resolve product images + no-hardcoded gate
+          └─ REPLACES #685; depends on #672 + #684 SOT foundation
+
+  Step H: #687  refactor(embeddings): structlog event-name logging
+          └─ standalone refactor, can go anytime after #645
+
+  Step I: #690  docs(claude-md): scoped CLAUDE.md + Karpathy guidelines
+          └─ pure docs, can merge any time; lowest risk
+```
+
+**Before any step D–G:** Verify full CI has run (Python + Frontend + WordPress checks must appear). These PRs currently only have Vercel + CodeRabbit checks — rebase against main or trigger CI manually.
+
+---
+
+## Standalone Feature PRs (order-independent)
+
+| PR | Action | Notes |
+|----|--------|-------|
+| #668 | Merge after Secrets Scan investigation | Full CI green. Secrets Scan fail needs manual review (may be false positive from file:// paths in QC sheets) |
+| #655 | Rebase + run full CI, then merge | V7 lookbook card — large change, no CI results beyond CodeQL |
+| #688 | Rebase + run full CI, then merge | Agent SDK starter — large new module, needs full test run |
+
+---
+
+## Dependabot — Safe Batch (npm)
+
+These can be merged together in one batch. All MERGEABLE, GitGuardian passes. The Vercel failure is systemic and unrelated.
+
+**Batch 1 — safe/minor (merge immediately once Vercel is fixed):**
+- #680 next 16.2.6→16.2.9 (patch)
+- #678 sharp 0.34→0.35 (minor)
+- #676 @types/node 25→26 (dev-only)
+- #675 testing group 3 updates (dev-only)
+- #674 three-js group 2 updates
+
+**Batch 2 — major bumps (test after merge, watch for breaking changes):**
+- #683 @ai-sdk/google-vertex 4→5 — Vercel AI SDK major; check provider API changes
+- #682 @ai-sdk/cohere 3→4 — major; check model name changes
+- #681 @pinecone-database/pinecone 7→8 — major; check index/query API changes
+- #679 graphql 16→17 — major; check schema/AST API
+- #677 pica 9→10 — image processing major
+
+---
+
+## Dependabot — Python (pip)
+
+| PR | Action | Notes |
+|----|--------|-------|
+| #665 | Merge | All CI green, together >=2.19.0 |
+| #659 | Merge after CI confirms | replicate >=1.0.7 — PR Agent infra fail only |
+| #663 | Merge after CI confirms | numba 0.65 — PR Agent infra fail only |
+| #666 | Merge after testing | usd-core >=26.5 — major version; test 3D pipeline |
+| #662 | **INVESTIGATE** | Playwright E2E fail on torchvision bump — real test failure |
+
+---
+
+## Do NOT Merge
+
+| PR | Reason |
+|----|--------|
+| #685 | CONFLICTING + GitGuardian fail + superseded by #689 |
+| #673 | Draft, 0 additions, Copilot stub |
+| #662 | Playwright E2E failure (real) |

--- a/tasks/pr-audit-report.md
+++ b/tasks/pr-audit-report.md
@@ -1,0 +1,65 @@
+# PR Audit Report — DRY-RUN
+**Generated:** 2026-06-30 | **Mode:** audit --dry-run (read-only, nothing executed)
+**Repo:** The-Skyy-Rose-Collection-LLC/DevSkyy
+
+---
+
+## Global Notes
+
+- **Vercel deployment fails on every open PR** — this is a systemic Vercel build misconfiguration, not a per-PR fault. Do not treat Vercel failure as a blocker for individual PRs.
+- **PR Agent Analysis** fails on most PRs (post-2026-06-26) — appears to be a GitHub Actions configuration issue unrelated to PR quality.
+- **New PRs (#672+) did not trigger the full GitHub Actions CI suite** (Python, Frontend, WordPress, CodeQL, Secrets Scan) — only Vercel + CodeRabbit + GitGuardian ran. These PRs need rebase or manual trigger to get a full green CI signal.
+- **UNKNOWN mergeable** = GitHub has not computed merge state yet (or branch is very old). Not the same as CONFLICTING.
+
+---
+
+## Per-PR Table
+
+| # | Title | Category | Branch | Checks | Mergeable | Classification |
+|---|-------|----------|--------|--------|-----------|----------------|
+| #690 | docs(claude-md): scoped CLAUDE.md coverage + Karpathy guidelines | docs | docs/claude-md-coverage | Vercel FAIL (systemic), GG pass, CR pass | MERGEABLE | NEEDS-CI — no full CI suite run |
+| #689 | feat(theme): resolve product images through SOT, no-hardcoded gate | feat | feat/sot-image-resolver-clean | Vercel FAIL (systemic), GG pass, CR pass | MERGEABLE | NEEDS-CI — no full CI suite run |
+| #688 | feat(agent-sdk): SkyyRose commerce agent (Agent SDK starter) | feat | feat/agent-sdk-starter | Vercel FAIL (systemic), GG pass | MERGEABLE | NEEDS-CI — large (+1669) |
+| #687 | refactor(embeddings): structlog event-name logging | refactor | refactor/embedding-engine-structlog | Vercel FAIL (systemic), GG pass, CR pass | MERGEABLE | NEEDS-CI — no full CI suite |
+| #686 | fix(catalog): canonical-loader routing + 5 invariants (Phase 2) | fix | feat/catalog-hardening | Vercel FAIL (systemic), GG pass, CR disabled | MERGEABLE | NEEDS-CI — no full CI suite |
+| #685 | feat(theme): SOT-resolve product images + asset-hub chain | feat | feat/sot-image-resolver | Vercel FAIL, **GitGuardian FAIL** | **CONFLICTING** | **BLOCKED** — conflicts + GitGuardian fail; superseded by #689 |
+| #684 | fix(catalog+theme): single-source v7-cards/sot + V7 card | fix | feat/v7-catalog-sot | Vercel FAIL (systemic), GG pass, CR pass | MERGEABLE | NEEDS-CI — large (+4507/-2390) |
+| #683 | deps: bump @ai-sdk/google-vertex 4→5 (major) | deps | dependabot/npm... | Vercel FAIL (systemic), GG pass | MERGEABLE | DEPS — major bump, API-breaking |
+| #682 | deps: bump @ai-sdk/cohere 3→4 (major) | deps | dependabot/npm... | Vercel FAIL (systemic), GG pass | MERGEABLE | DEPS — major bump |
+| #681 | deps: bump @pinecone-database/pinecone 7→8 (major) | deps | dependabot/npm... | Vercel FAIL (systemic), GG pass | MERGEABLE | DEPS — major bump |
+| #680 | deps: bump next 16.2.6→16.2.9 (patch) | deps | dependabot/npm... | Vercel FAIL (systemic), GG pass | MERGEABLE | DEPS — patch, safe |
+| #679 | deps: bump graphql 16→17 (major) | deps | dependabot/npm... | Vercel FAIL (systemic), GG pass | MERGEABLE | DEPS — major bump |
+| #678 | deps: bump sharp 0.34→0.35 (minor) | deps | dependabot/npm... | Vercel FAIL (systemic), GG pass | MERGEABLE | DEPS — minor, safe |
+| #677 | deps: bump pica 9→10 (major) | deps | dependabot/npm... | Vercel FAIL (systemic), GG pass | MERGEABLE | DEPS — major bump |
+| #676 | deps-dev: bump @types/node 25→26 (major) | deps | dependabot/npm... | Vercel FAIL (systemic), GG pass | MERGEABLE | DEPS — dev-only, safe |
+| #675 | deps-dev: testing group (3 updates) | deps | dependabot/npm... | Vercel FAIL (systemic), GG pass | MERGEABLE | DEPS — dev-only, safe |
+| #674 | deps: three-js group (2 updates) | deps | dependabot/npm... | Vercel FAIL (systemic), GG pass | MERGEABLE | DEPS — minor |
+| #673 | Add CI/CD workflow for product matcher (Copilot) | chore | copilot/setup-ci-cd... | Vercel FAIL (systemic), GG pass | MERGEABLE | **BLOCKED/DRAFT** — 0 additions, Copilot-generated stub |
+| #672 | fix(collections): single-source sot.json drift guard | fix | feat/collection-sot-guard | Vercel FAIL (systemic), GG pass, CR pass | MERGEABLE | NEEDS-CI — large (+6649/-2394), foundation for #684/#685/#689 |
+| #668 | feat(qc-tools): file://-robust GLB + render-review QC sheets | feat | feat/glb-render-file-robust | **ALL CI PASS** (Python, Frontend, WP, API, CodeQL, Security, License) except PR Agent (infra) + Secrets Scan (needs review) | UNKNOWN | **NEAR-SAFE** — only blocking items are infra-level failures; full test suite green |
+| #666 | deps(python): update usd-core >=24→>=26.5 | deps | dependabot/pip/usd-core | Security, CodeQL pass; PR Agent fail (infra) | UNKNOWN | DEPS — major Python dep |
+| #665 | deps(python): update together >=1.0→>=2.19.0 | deps | dependabot/pip/together | All CI checks pass | UNKNOWN | DEPS — safe |
+| #663 | deps(python): bump numba 0.63→0.65 | deps | dependabot/pip/numba | Security, CodeQL pass; PR Agent fail (infra) | UNKNOWN | DEPS |
+| #662 | deps(python): bump torchvision 0.24→0.27 | deps | dependabot/pip/torchvision | Security, CodeQL pass; **Playwright E2E FAIL** | UNKNOWN | **NEEDS-WORK** — E2E test failure |
+| #659 | deps(python): update replicate >=0.30→>=1.0.7 | deps | dependabot/pip/replicate | Security, CodeQL pass; PR Agent fail (infra) | UNKNOWN | DEPS |
+| #656 | feat(evaluation): Q-mode wire + Q-data centroid allowlist | feat | feat/track-q-mode-data | Full CI green except PR Agent (infra) | UNKNOWN | NEAR-SAFE — full test suite green |
+| #655 | feat(theme): V7 lookbook product card + verified-hub imagery | feat | feat/v7-lookbook-card | Vercel FAIL, CodeQL pass, GG pass | UNKNOWN | NEEDS-CI — large (+3512/-2314) |
+| #650 | feat(api): /api/v1/lora/* → imagery SDXL (LoRA Phase 1) | feat | feat/track-lora-phase1 | **ALL CI PASS** — green across all checks | UNKNOWN | **SAFE-TO-MERGE** — cleanest PR in the queue |
+| #648 | fix(render): judge-unavailable QC → mandatory review, not fail-open | fix | feat/track-q-unavail | Vercel FAIL, CodeQL pass, GG pass | UNKNOWN | NEEDS-CI |
+| #645 | feat(compositor): Phase 1 pipeline integrity (embeddings-reframe) | feat | feat/embeddings-phase1-pipeline | Vercel FAIL, CodeQL pass, GG pass | UNKNOWN | NEEDS-CI — foundation for #656 |
+
+---
+
+## Classification Summary
+
+| Classification | Count | PR Numbers |
+|----------------|-------|-----------|
+| SAFE-TO-MERGE | 1 | #650 |
+| NEAR-SAFE (full CI green, minor infra failures) | 2 | #668, #656 |
+| NEEDS-CI (no full CI suite ran) | 10 | #690, #689, #688, #687, #686, #684, #672, #655, #648, #645 |
+| DEPS — safe/minor | 6 | #680, #678, #676, #675, #674, #665 |
+| DEPS — major bumps (breaking) | 6 | #683, #682, #681, #679, #677, #666, #663, #659 |
+| NEEDS-WORK (real failures) | 2 | #685 (conflict + GG), #662 (E2E fail) |
+| BLOCKED/DRAFT | 1 | #673 |
+
+**Total open PRs: 30**

--- a/tasks/pr-insights.md
+++ b/tasks/pr-insights.md
@@ -1,0 +1,94 @@
+# PR Insights — DRY-RUN
+**Generated:** 2026-06-30 | **Mode:** audit --dry-run
+
+---
+
+## Systemic Issues (affect all PRs)
+
+### 1. Vercel build is broken repo-wide
+Every single open PR (all 30) shows "Vercel: fail". This is not a per-PR problem — it is a broken Vercel deployment configuration affecting the entire project. Until this is fixed, no PR can get a real Vercel preview or have deploy-gating checks pass.
+
+**Impact:** High. Blocks confident merging of any PR that touches frontend/theme.
+**Action:** Run `npx vercel inspect dpl_<id> --logs` on any PR's deployment ID to read the error. Fix on main before bulk-merging.
+
+### 2. Full CI suite not running on PRs #672 and newer
+PRs created from 2026-06-29 onward (including #672, #684, #685, #686, #687, #688, #689, #690) only triggered Vercel + CodeRabbit + GitGuardian — not the full GitHub Actions suite (Python Tests, Frontend Tests, WordPress Theme, API Integration Tests, CodeQL, Secrets Scan).
+
+**Impact:** Medium-high. Cannot confirm these PRs don't break tests without a rebase or manual CI trigger.
+**Action:** Rebase each NEEDS-CI PR against current main to trigger the full suite before merging.
+
+### 3. PR Agent Analysis consistently fails (infra)
+The "PR Agent Analysis" check fails on most PRs where it runs. This is an infrastructure/configuration issue with the pr-agent GitHub Action, not actual PR quality. Confirmed infra-level because high-quality PRs (#650, #656) fail this check while passing all real tests.
+
+**Impact:** Low (this check is not gating). But it's noise that makes CI status harder to read.
+
+---
+
+## Duplicate Commits / Stacking Analysis
+
+### The SOT/Catalog/Theme stack
+The following PRs share a logical progression and likely have overlapping file changes:
+
+```
+#645 (embeddings Phase 1) 
+  → #648 (judge-unavail QC fix) 
+    → #656 (Q-mode wire)         [Track Q series]
+
+#672 (collection SOT guard)      [SOT foundation — large, +6649 lines]
+  → #684 (v7-catalog-sot)       [depends on 672 SOT infrastructure]
+    → #686 (catalog hardening)  [Phase 2 on top of 684]
+    → #689 (sot-image-resolver-clean) [theme side of 672]
+
+#685 (sot-image-resolver)        [SUPERSEDED by #689 — close this]
+```
+
+**Stacking risk:** #684, #686, #689 were all created the same day (2026-06-30) within ~1 hour of each other, branching from similar points. If merged out of order, later PRs will conflict. Merge in order: 672 → 684 → 686 → 689.
+
+**Overlap between #685 and #689:** Both modify the same SOT image resolution code in the WordPress theme. #685 is the larger original branch (CONFLICTING, +10945/-2668) and #689 is the clean rewrite (+219/-13). Merging #685 would create significant conflicts. It must be closed.
+
+### The V7 Card family
+#655 (V7 lookbook card, +3512/-2314) and #684 (v7-catalog-sot, +4507/-2390) both touch V7 card templates and theme files. #684 appears to be the more recent, more complete version. Relationship unclear — check if #684 supersedes #655 before merging both.
+
+### Track Q series
+#648 and #656 are sequentially tagged "Track Q" in the embeddings-reframe initiative. #648 should merge before #656.
+
+---
+
+## Risk Register
+
+| Risk | Severity | Affected PRs | Mitigation |
+|------|----------|-------------|-----------|
+| Vercel build broken globally | HIGH | All 30 | Fix Vercel config on main first |
+| No full CI on 10 feature PRs | HIGH | #672, #684–#690, #655 | Rebase to trigger CI |
+| Merge order violations in SOT stack | HIGH | #684, #686, #689 | Enforce order: 672→684→686→689 |
+| #685 supersedes conflict | HIGH | #685 | Close immediately |
+| Playwright E2E fail on torchvision | MEDIUM | #662 | Investigate E2E failure before merge |
+| Major npm deps (AI SDK, Pinecone, GraphQL) | MEDIUM | #679,#681,#682,#683 | Test API compatibility after merge |
+| #673 Copilot stub adds no value | LOW | #673 | Close |
+| PR Agent infra noise | LOW | Multiple | Fix PR Agent action config |
+
+---
+
+## Dependabot Batch Candidates
+
+### Safe to merge as a batch (patch/minor/dev-only):
+#680 (next patch) + #678 (sharp minor) + #676 (@types/node dev) + #675 (testing group) + #674 (three-js group)
+→ All MERGEABLE, GitGuardian clean, no functional risk
+
+### Major npm bumps — review individually:
+#683 (@ai-sdk/google-vertex 4→5), #682 (@ai-sdk/cohere 3→4), #681 (pinecone 7→8), #679 (graphql 16→17), #677 (pica 9→10)
+→ All MERGEABLE but each is a major version with potential breaking changes. Merge one-at-a-time and watch CI.
+
+### Python pip deps:
+#665 (together) — safe
+#659 (replicate), #663 (numba) — safe pending CI
+#666 (usd-core major) — test 3D pipeline after
+#662 (torchvision) — blocked by Playwright E2E failure
+
+---
+
+## Notable Positive Signal
+
+**PR #650** is the cleanest PR in the entire queue: every GitHub Actions check passes (Python, Frontend, WordPress, API Integration, CodeQL js+python, Secrets, License, SBOM, Dependency Review, Security Scan). It is standalone and touches only the `/api/v1/lora/*` router. This should be the first merge.
+
+**PR #668** (current working branch: feat/glb-render-file-robust) has a complete green CI signal on all real tests. The two failures — "PR Agent Analysis" (infra) and "Secrets Scan" — are both non-real-test failures. The Secrets Scan result should be reviewed manually (file:// URIs in QC scripts may have triggered it) but is likely a false positive.

--- a/tests/test_font_generator.py
+++ b/tests/test_font_generator.py
@@ -1,0 +1,200 @@
+"""Tests for scripts/font_generator: template generation, manifest validation, font build.
+
+Unit tests cover the pure logic (template layout, manifest shape/consistency,
+build_font input guards) and run everywhere. The end-to-end vectorization test
+needs the `potrace` binary plus fontTools, so it is skipped when potrace is
+absent (e.g. minimal CI) rather than failing.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+
+import pytest
+from PIL import Image, ImageDraw
+
+from scripts.font_generator import pipeline, template
+
+pytestmark = pytest.mark.unit
+
+_HAS_POTRACE = shutil.which("potrace") is not None
+
+
+# --------------------------------------------------------------------------- #
+# template.generate_template / save_template
+# --------------------------------------------------------------------------- #
+def test_generate_template_shape() -> None:
+    image, manifest = template.generate_template(chars="ABCD", cols=2, cell_size=(100, 120))
+    assert image.size == (200, 240)  # 2 cols * 100, 2 rows * 120
+    assert manifest["image_size"] == [200, 240]
+    assert manifest["grid"] == {"cols": 2, "rows": 2}
+    assert [c["char"] for c in manifest["cells"]] == ["A", "B", "C", "D"]
+    assert manifest["cells"][0]["codepoint"] == ord("A")
+    assert len(manifest["chars_fingerprint"]) == 12
+
+
+def test_generate_template_empty_chars_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        template.generate_template(chars="")
+
+
+def test_generate_template_cols_below_one_raises() -> None:
+    with pytest.raises(ValueError, match="cols must be >= 1"):
+        template.generate_template(chars="AB", cols=0)
+
+
+def test_generate_template_duplicate_chars_raises() -> None:
+    with pytest.raises(ValueError, match="duplicate characters"):
+        template.generate_template(chars="AAB")
+
+
+def test_generate_template_fingerprint_deterministic_and_sensitive() -> None:
+    _, m1 = template.generate_template(chars="AB", cols=2)
+    _, m2 = template.generate_template(chars="AB", cols=2)
+    _, m3 = template.generate_template(chars="AB", cols=1)
+    assert m1["chars_fingerprint"] == m2["chars_fingerprint"]
+    assert m1["chars_fingerprint"] != m3["chars_fingerprint"]  # cols feed the fingerprint
+
+
+def test_save_template_writes_files(tmp_path) -> None:
+    png_path, manifest_path = template.save_template(tmp_path, chars="AB", cols=2)
+    assert png_path.exists() and manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text())
+    pipeline._validate_manifest(manifest)  # generated manifest is always valid
+
+
+# --------------------------------------------------------------------------- #
+# pipeline._validate_manifest
+# --------------------------------------------------------------------------- #
+def _valid_manifest() -> dict:
+    _, manifest = template.generate_template(chars="AB", cols=2, cell_size=(100, 100))
+    return manifest
+
+
+def test_validate_manifest_accepts_generated() -> None:
+    pipeline._validate_manifest(_valid_manifest())  # no raise
+
+
+@pytest.mark.parametrize("missing", ["image_size", "cells"])
+def test_validate_manifest_missing_top_key(missing) -> None:
+    m = _valid_manifest()
+    del m[missing]
+    with pytest.raises(ValueError, match=f"missing required key '{missing}'"):
+        pipeline._validate_manifest(m)
+
+
+def test_validate_manifest_bad_image_size() -> None:
+    m = _valid_manifest()
+    m["image_size"] = [200]
+    with pytest.raises(ValueError, match="image_size' must be a 2-element"):
+        pipeline._validate_manifest(m)
+
+
+def test_validate_manifest_cells_not_list() -> None:
+    m = _valid_manifest()
+    m["cells"] = {"nope": 1}
+    with pytest.raises(ValueError, match="cells' must be a list"):
+        pipeline._validate_manifest(m)
+
+
+def test_validate_manifest_cell_missing_key() -> None:
+    m = _valid_manifest()
+    del m["cells"][0]["bbox"]
+    with pytest.raises(ValueError, match="missing required key 'bbox'"):
+        pipeline._validate_manifest(m)
+
+
+def test_validate_manifest_duplicate_char() -> None:
+    m = _valid_manifest()
+    m["cells"][1]["char"] = m["cells"][0]["char"]
+    m["cells"][1]["codepoint"] = m["cells"][0]["codepoint"] + 1  # isolate the char check
+    with pytest.raises(ValueError, match="duplicate char"):
+        pipeline._validate_manifest(m)
+
+
+def test_validate_manifest_duplicate_codepoint() -> None:
+    m = _valid_manifest()
+    m["cells"][1]["codepoint"] = m["cells"][0]["codepoint"]
+    with pytest.raises(ValueError, match="duplicate codepoint"):
+        pipeline._validate_manifest(m)
+
+
+def test_validate_manifest_bbox_wrong_length() -> None:
+    m = _valid_manifest()
+    m["cells"][0]["bbox"] = [0, 0, 100]
+    with pytest.raises(ValueError, match="bbox must have 4 elements"):
+        pipeline._validate_manifest(m)
+
+
+def test_validate_manifest_bbox_out_of_bounds() -> None:
+    m = _valid_manifest()
+    m["cells"][0]["bbox"] = [0, 0, 9999, 100]
+    with pytest.raises(ValueError, match="out of bounds"):
+        pipeline._validate_manifest(m)
+
+
+# --------------------------------------------------------------------------- #
+# pipeline.build_font input guards
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("threshold", [0, 256, -5])
+def test_build_font_threshold_out_of_range(tmp_path, threshold) -> None:
+    with pytest.raises(ValueError, match="threshold must be between 1 and 255"):
+        pipeline.build_font(
+            tmp_path / "nope.png", tmp_path / "nope.json", tmp_path / "out.ttf", threshold=threshold
+        )
+
+
+def test_build_font_missing_filled_image(tmp_path) -> None:
+    _, manifest_path = template.save_template(tmp_path, chars="A", cols=1)
+    with pytest.raises(FileNotFoundError, match="filled image not found"):
+        pipeline.build_font(tmp_path / "absent.png", manifest_path, tmp_path / "out.ttf")
+
+
+def test_build_font_missing_manifest(tmp_path) -> None:
+    png_path, _ = template.save_template(tmp_path, chars="A", cols=1)
+    with pytest.raises(FileNotFoundError, match="manifest not found"):
+        pipeline.build_font(png_path, tmp_path / "absent.json", tmp_path / "out.ttf")
+
+
+def test_build_font_invalid_manifest_json(tmp_path) -> None:
+    png_path, _ = template.save_template(tmp_path, chars="A", cols=1)
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        pipeline.build_font(png_path, bad, tmp_path / "out.ttf")
+
+
+def test_build_font_dimension_mismatch(tmp_path) -> None:
+    _, manifest_path = template.save_template(tmp_path, chars="A", cols=1, cell_size=(120, 120))
+    wrong = tmp_path / "wrong.png"
+    Image.new("RGB", (50, 50), (255, 255, 255)).save(wrong)
+    with pytest.raises(ValueError, match="do not match template dimensions"):
+        pipeline.build_font(wrong, manifest_path, tmp_path / "out.ttf")
+
+
+# --------------------------------------------------------------------------- #
+# end-to-end vectorization (needs potrace + fontTools)
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not _HAS_POTRACE, reason="potrace binary not installed")
+def test_build_font_end_to_end(tmp_path) -> None:
+    png_path, manifest_path = template.save_template(
+        tmp_path, chars="A", cols=1, cell_size=(120, 120)
+    )
+
+    # Ink the single cell with a solid black shape inside its inset region.
+    img = Image.open(png_path).convert("RGB")
+    ImageDraw.Draw(img).rectangle([40, 30, 80, 90], fill=(0, 0, 0))
+    filled = tmp_path / "filled.png"
+    img.save(filled)
+
+    out_ttf = tmp_path / "out.ttf"
+    result = pipeline.build_font(filled, manifest_path, out_ttf, family="TestFont", threshold=140)
+
+    assert "A" in result["built"]
+    assert out_ttf.exists() and out_ttf.stat().st_size > 0
+
+    from fontTools.ttLib import TTFont  # opening a corrupt file would raise
+
+    font = TTFont(out_ttf)
+    assert ord("A") in font.getBestCmap()


### PR DESCRIPTION
## Summary
Parks in-progress work that was sitting untracked in the working tree onto a dedicated branch (recovered during a main-switch cleanup).

**Code**
- `scripts/font_generator/` — font-generation tool: `cli.py`, `pipeline.py`, `template.py`, `__init__.py`

**Docs (drafts)**
- `tasks/blog-copy-draft.md`
- `tasks/pr-action-plan.md`
- `tasks/pr-audit-report.md`
- `tasks/pr-insights.md`

## Context
These files were never committed on any branch. Relocated off `main`'s working tree to preserve them without polluting main. Single commit `4f027359a`.

## Test plan
- [ ] Review `scripts/font_generator/` — decide if the tool is keep/iterate/drop
- [ ] Confirm the `tasks/*.md` drafts are still wanted or supersede existing task docs
- [ ] `python -m scripts.font_generator.cli --help` sanity-runs (tool is untested — no tests added yet)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parks WIP on a dedicated branch and adds a self-contained PNG‑to‑TTF font generator. Hardens inputs, adds tests, and includes draft docs; no app runtime impact.

- **New Features**
  - `scripts/font_generator`: CLI with `template` (creates template PNG + `manifest.json`) and `build` (vectorizes filled template into `.ttf`). Run: `python -m scripts.font_generator.cli --help`.

- **Hardening & Tests**
  - Declared `fonttools>=4.55` in `pyproject.toml`.
  - Added input guards: manifest shape/bbox checks, duplicate-char rejection, threshold range (1–255), and cleaner CLI filesystem errors.
  - Added `tests/test_font_generator.py` (unit tests + E2E when `potrace` is available).

- **Docs**
  - Drafts under `tasks/`: `blog-copy-draft.md`, `pr-action-plan.md`, `pr-audit-report.md`, `pr-insights.md`.

<sup>Written for commit 2a695426b22978c971a2a495a89eb8e7bd6ebc19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a font generation workflow with a command-line tool to create printable character templates and build TTF font files from filled-in scans.
  * Added robust template/manifest generation plus glyph extraction with build-time reporting on built and skipped glyphs.
* **Documentation**
  * Added planning/status documents for blog copy and pull request audit/merge guidance.
* **Tests**
  * Introduced a comprehensive unit test suite covering template, manifest validation, and build guardrails (with optional end-to-end vectorization).
* **Dependencies**
  * Updated Python dependencies to include FontTools for TTF creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->