### PR TITLE
fix(about): real lookbook images in collection rows + audit false-positive refinements

### DIFF
--- a/scripts/structural_audit.py
+++ b/scripts/structural_audit.py
@@ -135,6 +135,10 @@ def is_hidden_or_allowed_after_footer(el: Tag) -> bool:
         return True
     if el.name == "dialog" and not el.has_attr("open"):
         return True
+    # Hidden form inputs (plugin nonces/config, e.g. CommerceKit) are never
+    # visible; html.parser can fold following text into the void tag.
+    if el.name == "input" and (el.get("type") or "").lower() == "hidden":
+        return True
     if el.has_attr("hidden") or el.get("aria-hidden") == "true":
         return True
     style = (el.get("style") or "").replace(" ", "").lower()
@@ -142,6 +146,10 @@ def is_hidden_or_allowed_after_footer(el: Tag) -> bool:
         return True
     idcls = " ".join([el.get("id") or ""] + (el.get("class") or [])).lower()
     if any(h in idcls for h in COOKIE_HINTS):
+        return True
+    # Plugin-injected overlays hidden via stylesheet, not inline (Jetpack
+    # Carousel's lightbox + comment form) — never visible page content.
+    if "jp-carousel" in idcls:
         return True
     # Empty structural wrappers (e.g. portal mount points) are fine.
     return not el.get_text(strip=True) and not el.find(("img", "video", "iframe"))
@@ -203,9 +211,22 @@ def check_shell(a: Audit) -> None:
         for marker in LEGACY_MARKERS:
             a.check(marker not in html, f"{path} no legacy marker {marker!r}")
 
-        headers = soup.find_all("header")
+        # HTML5 sectioning <header> inside cards/sections is valid — the shell
+        # contract is exactly one BANNER header (#masthead) and no stray
+        # top-level headers alongside it.
+        banner_headers = soup.select("header#masthead")
+        stray_top = [
+            h
+            for h in soup.find_all("header")
+            if h.get("id") != "masthead"
+            and not h.find_parent(("main", "section", "article", "aside", "dialog"))
+        ]
         footers = soup.find_all("footer")
-        a.check(len(headers) == 1, f"{path} exactly one <header>", f"found {len(headers)}")
+        a.check(
+            len(banner_headers) == 1 and not stray_top,
+            f"{path} exactly one banner <header#masthead>",
+            f"banner={len(banner_headers)}, stray top-level={len(stray_top)}",
+        )
         a.check(len(footers) == 1, f"{path} exactly one <footer>", f"found {len(footers)}")
 
 
@@ -338,9 +359,25 @@ def check_commerce(a: Audit) -> None:
             not re.search(r'href="[^"]*add-to-cart=', html),
             f"{path} no GET add-to-cart hrefs",
         )
+        # Placeholder srcs inside hidden/inert dialog templates (e.g. the
+        # product-panel slide-up, whose thumb JS swaps before reveal) are
+        # never user-visible — only flag placeholders in rendered content.
+        soup_r = a.soup(path)
+        visible_placeholders = [
+            img
+            for img in soup_r.find_all(
+                "img", src=re.compile(r"placeholder[^\"]*\.(jpg|png|webp|gif)")
+            )
+            if not any(
+                isinstance(p, Tag)
+                and (p.has_attr("hidden") or p.has_attr("inert") or p.get("aria-hidden") == "true")
+                for p in [img, *img.parents]
+            )
+        ]
         a.check(
-            not re.search(r'src="[^"]*placeholder[^"]*\.(jpg|png|webp|gif)', html),
-            f"{path} no placeholder images",
+            not visible_placeholders,
+            f"{path} no visible placeholder images",
+            f"{len(visible_placeholders)} in rendered content",
         )
         a.check(
             not re.search(r"countdown|data-timer|\b\d{2}:\d{2}:\d{2}:\d{2}\b", html, re.IGNORECASE),

--- a/wordpress-theme/skyyrose-flagship/template-parts/about/collections-grid.php
+++ b/wordpress-theme/skyyrose-flagship/template-parts/about/collections-grid.php
@@ -20,28 +20,28 @@ $collection_data = array(
 		'tag'   => 'The Origin',
 		'desc'  => 'The first rose, the first script. Where SkyyRose began — gold-accented luxury streetwear, gender-neutral by default.',
 		'link'  => '/collections/signature/',
-		'img'   => '',
+		'img'   => 'assets/images/lookbook/lb-rose-hoodie-beanie-960w.webp',
 	),
 	'black-rose'   => array(
 		'title' => 'Black Rose',
 		'tag'   => 'The Refusal',
 		'desc'  => 'Dark, powerful, unapologetic. Silver-on-black, gothic restraint. Streetwear armor for everyone who refused to apologize first.',
 		'link'  => '/collections/black-rose/',
-		'img'   => '',
+		'img'   => 'assets/images/lookbook/lb-black-rose-football-960w.webp',
 	),
 	'love-hurts'   => array(
 		'title' => 'Love Hurts',
 		'tag'   => 'The Grief',
 		'desc'  => 'A collection named after grief, made to be worn anyway. Crimson and deep red, Beauty &amp; the Beast cadence — luxury or witchcraft, take your pick.',
 		'link'  => '/collections/love-hurts/',
-		'img'   => '',
+		'img'   => 'assets/images/lookbook/lb-love-hurts-varsity-960w.webp',
 	),
 	'kids-capsule' => array(
 		'title' => 'Kids Capsule',
 		'tag'   => 'The Heir',
 		'desc'  => 'Rose gold and soft pink. The fourth chapter, smaller silhouettes, same craftsmanship. Passing the torch on the same terms that built the brand.',
 		'link'  => '/collections/kids-capsule/',
-		'img'   => '',
+		'img'   => 'assets/images/lookbook/lb-kid-black-rose-960w.webp',
 	),
 );
 
@@ -81,7 +81,12 @@ foreach ( $catalog as $product ) {
 		foreach ( $collection_data as $slug => $data ) :
 			++$i;
 			$index   = str_pad( (string) $i, 2, '0', STR_PAD_LEFT );
-			$img_url = ! empty( $data['img'] ) ? $data['img'] : get_theme_file_uri( 'assets/images/placeholder-product.jpg' );
+			// Theme-relative paths (curated lookbook defaults) resolve via
+			// get_theme_file_uri; catalog overrides arrive as full URLs.
+			$img_url = get_theme_file_uri( 'assets/images/placeholder-product.jpg' );
+			if ( ! empty( $data['img'] ) ) {
+				$img_url = ( 0 === strpos( $data['img'], 'http' ) ) ? $data['img'] : get_theme_file_uri( $data['img'] );
+			}
 			?>
 			<li class="abt-coll-row" data-collection="<?php echo esc_attr( $slug ); ?>" role="listitem">
 				<a href="<?php echo esc_url( home_url( $data['link'] ) ); ?>" class="abt-coll-row__link">


### PR DESCRIPTION
About-page collection rows rendered placeholder-product.jpg ×4 (dead catalog override key) — now curated lookbook defaults. Audit script: three verified false-positive classes exempted (sectioning headers, hidden dialog-template placeholders, hidden plugin inputs/carousel overlays). Details in commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWnUmzTutLBSQYq8wu2ir3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show real lookbook images in About page collection rows and reduce false positives in the structural audit for cleaner, accurate checks.

- **Bug Fixes**
  - About page: display curated lookbook images for all four collections; resolve theme-relative paths via get_theme_file_uri; still supports absolute catalog URLs.
  - Structural audit: require exactly one banner header `header#masthead` and allow section-level headers; only flag placeholder images in visible content (ignore hidden/inert/aria-hidden); allow hidden inputs and `jp-carousel` overlays after the footer.

<sup>Written for commit b0bf1c3d76bb83aba26d86f0cf0ec3548e89dcbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

