### PR TITLE
fix(audit): guard hex matcher against HTML entities

### DIFF
--- a/scripts/structural_audit.py
+++ b/scripts/structural_audit.py
@@ -162,7 +162,9 @@ def blue_dominant_hexes(css_text: str) -> list[str]:
     proven in the repo's brand-law tooling.
     """
     found: list[str] = []
-    for m in re.finditer(r"#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})\b", css_text):
+    # (?<!&) — HTML entities like &#039; (escaped apostrophe) are not colors;
+    # without the guard, #039 expands to a phantom #003399 finding.
+    for m in re.finditer(r"(?<!&)#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})\b", css_text):
         h = m.group(1)
         if len(h) == 3:
             h = "".join(c * 2 for c in h)


### PR DESCRIPTION
&#039; entity apostrophes matched as #039 → phantom #003399 blue findings. Negative lookbehind fixes it. Live audit now: 256 passes, only Ally skip links remain (HG-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWnUmzTutLBSQYq8wu2ir3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard the hex color matcher in the audit to ignore HTML entities like `&#039;` that were misread as `#039` and expanded to a phantom `#003399` finding. The regex in `blue_dominant_hexes` now uses `(?<!&)` to remove these false positives; live audit shows 256 passes, with only Ally skip links remaining (HG-5).

<sup>Written for commit 46e230787ad95cd8b486e65577a05ad992f8baee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

