### PR TITLE
perf(wp): anon-cache-guard MU-plugin — unblock edge caching (TTFB 1.8s → edge)

### DIFF
--- a/scripts/deploy-mu-plugin.sh
+++ b/scripts/deploy-mu-plugin.sh
@@ -58,8 +58,9 @@ MU_DIR="$WP_CONTENT/mu-plugins"
 echo "==> ensuring $MU_DIR exists"
 "${SSH[@]}" "${SSH_USER}@${SSH_HOST}" "mkdir -p '$MU_DIR'"
 
-echo "==> uploading skyyrose-ally-ajax-guard.php"
-"${SCP[@]}" "$SRC" "${SSH_USER}@${SSH_HOST}:$MU_DIR/skyyrose-ally-ajax-guard.php"
+DEST="$(basename "$SRC")"
+echo "==> uploading $DEST"
+"${SCP[@]}" "$SRC" "${SSH_USER}@${SSH_HOST}:$MU_DIR/$DEST"
 
 echo "==> flushing cache"
 "${SSH[@]}" "${SSH_USER}@${SSH_HOST}" "wp cache flush" >/dev/null 2>&1 || true

--- a/scripts/deploy-mu-plugin.sh
+++ b/scripts/deploy-mu-plugin.sh
@@ -21,7 +21,8 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(dirname "$SCRIPT_DIR")"
 ENV_FILE="${ENV_FILE:-$ROOT/.env.wordpress}"
-SRC="$ROOT/wordpress/mu-plugins/skyyrose-ally-ajax-guard.php"
+# Override with MU_SRC=<path> to deploy a different MU-plugin from wordpress/mu-plugins/.
+SRC="${MU_SRC:-$ROOT/wordpress/mu-plugins/skyyrose-ally-ajax-guard.php}"
 
 [ -f "$ENV_FILE" ] || { echo "FATAL: $ENV_FILE missing" >&2; exit 1; }
 [ -f "$SRC" ]      || { echo "FATAL: $SRC missing" >&2; exit 1; }

--- a/wordpress/mu-plugins/skyyrose-anon-cache-guard.php
+++ b/wordpress/mu-plugins/skyyrose-anon-cache-guard.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Plugin Name: SkyyRose — Keep anonymous page views edge-cacheable
+ * Description: WooCommerce (triggered by CommerceKit's session-bound nonce)
+ *   starts a session and emits `Set-Cookie: wp_woocommerce_session_*` on
+ *   EVERY anonymous front-end page view. The Atomic/Batcache edge refuses to
+ *   cache any response that sets cookies, so every visitor pays the full
+ *   ~1.6s PHP render (measured: `x-ac: MISS`,
+ *   `server-timing: cache;desc=MISS;dur=1603`, TTFB 1.8-2.5s = 81% of LCP).
+ *   This guard swaps in a session handler that refuses to SEND the session
+ *   cookie on anonymous cacheable GET page views, and suppresses the cart
+ *   count/hash cookies for the same views. Sessions still start the moment
+ *   they matter: wc-ajax calls (add-to-cart POSTs), commercekit-ajax nonce
+ *   fetches, cart/checkout/account pages, logged-in users, and visitors
+ *   already holding a session cookie are all exempt.
+ * Version: 1.0.0
+ * Author: SkyyRose Dev Team
+ *
+ * Why an MU-plugin: the cookie comes from WooCommerce core session handling
+ * triggered by plugin code — the theme has no seam. The supported seams are
+ * `woocommerce_session_handler` (handler class swap) and
+ * `woocommerce_set_cart_cookies`.
+ *
+ * CommerceKit interaction (verified): its nonce is fetched client-side via
+ * `?commercekit-ajax=commercekit_get_nonce` (see skyyrose-ally-ajax-guard),
+ * which is exempt here — the session it needs is created on that request,
+ * not on the cached page HTML.
+ *
+ * @package SkyyRose
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Whether the current request is an anonymous, cacheable front-end GET
+ * page view. Evaluated lazily (at cookie-send time), so WP conditionals
+ * are safe to use.
+ *
+ * @return bool
+ */
+function skyyrose_is_cacheable_anon_pageview() {
+	if ( is_admin() || wp_doing_ajax() || wp_doing_cron() ) {
+		return false;
+	}
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return false;
+	}
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		return false;
+	}
+	if ( isset( $_GET['wc-ajax'] ) || isset( $_GET['commercekit-ajax'] ) || isset( $_GET['rest_route'] ) ) {
+		return false;
+	}
+	if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
+		return false;
+	}
+	if ( is_user_logged_in() ) {
+		return false;
+	}
+	// A visitor already holding a WooCommerce session keeps it (active cart).
+	foreach ( array_keys( $_COOKIE ) as $cookie_name ) {
+		if ( 0 === strpos( (string) $cookie_name, 'wp_woocommerce_session_' ) ) {
+			return false;
+		}
+	}
+	if ( function_exists( 'is_cart' ) && did_action( 'wp' ) && ( is_cart() || is_checkout() || is_account_page() ) ) {
+		return false;
+	}
+	if ( function_exists( 'WC' ) && null !== WC()->cart && ! WC()->cart->is_empty() ) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Swap in a session handler whose cookie setter no-ops on cacheable
+ * anonymous views. Session DATA still saves server-side; only the
+ * cache-busting Set-Cookie header is withheld.
+ */
+add_filter(
+	'woocommerce_session_handler',
+	static function ( $handler ) {
+		if ( ! class_exists( 'WC_Session_Handler' ) ) {
+			return $handler;
+		}
+		if ( ! class_exists( 'SkyyRose_Cacheable_Session_Handler' ) ) {
+			/**
+			 * WC_Session_Handler that withholds the session cookie on
+			 * anonymous cacheable page views.
+			 */
+			class SkyyRose_Cacheable_Session_Handler extends WC_Session_Handler {
+				/**
+				 * Set the session cookie unless this view must stay cacheable.
+				 *
+				 * @param bool $set Whether the cookie should be set.
+				 */
+				public function set_customer_session_cookie( $set ) {
+					if ( $set && skyyrose_is_cacheable_anon_pageview() ) {
+						return;
+					}
+					parent::set_customer_session_cookie( $set );
+				}
+			}
+		}
+		return 'SkyyRose_Cacheable_Session_Handler';
+	}
+);
+
+/**
+ * Suppress woocommerce_items_in_cart / woocommerce_cart_hash cookies on the
+ * same views (WC core already routes these through this filter).
+ */
+add_filter(
+	'woocommerce_set_cart_cookies',
+	static function ( $set ) {
+		return skyyrose_is_cacheable_anon_pageview() ? false : $set;
+	}
+);


### PR DESCRIPTION
## The measured problem
`/optimize skyyrose.co` trace (mobile, Fast 4G, 4× CPU): **LCP 2232ms, of which TTFB = 1811ms (81%)**. CLS 0.00, render-blocking ≈0, hero AVIF downloads in 1ms — the theme is already tight. The HTML itself is never edge-cached: every anonymous hit shows `x-ac: MISS` + `server-timing: cache;desc=MISS;dur=1603` because WooCommerce emits `Set-Cookie: wp_woocommerce_session_*` on every anonymous page view (triggered by CommerceKit's session-bound nonce), and the Atomic edge won't cache cookie-setting responses.

## Fix
MU-plugin `skyyrose-anon-cache-guard.php`: `WC_Session_Handler` subclass withholds the session cookie ONLY on anonymous cacheable GETs (session data still persists); cart count/hash cookies suppressed via the supported `woocommerce_set_cart_cookies` filter. Exempt: wc-ajax, commercekit-ajax (its nonce fetch creates the session there — verified against skyyrose-ally-ajax-guard's documented endpoint), REST, POSTs, logged-in, cart/checkout/account, existing session holders, non-empty carts.

## Post-deploy verification plan
1. curl ×3: expect no `set-cookie` on anon GET; second hit `x-ac: HIT`; TTFB < 500ms
2. **Clean-session add-to-cart test** (Playwright incognito: PDP → add → cart count 1) — the CommerceKit nonce regression class
3. Rollback = delete one file over SSH

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks edge caching for anonymous page views by withholding WooCommerce session/cart cookies on cacheable GETs. HTML should now cache at the edge (`x-ac: HIT`) and TTFB drop from ~1.8s to edge.

- **New Features**
  - Added `wordpress/mu-plugins/skyyrose-anon-cache-guard.php` to swap `WC_Session_Handler` and withhold `wp_woocommerce_session_*` plus cart cookies on anonymous cacheable GETs while keeping session data server-side.
  - Exemptions: logged-in users, POST/REST, `wc-ajax`, `commercekit-ajax`, cart/checkout/account pages, existing session holders, non-empty carts.

- **Bug Fixes**
  - Updated `scripts/deploy-mu-plugin.sh` to support `MU_SRC` and upload using its basename, preventing overwriting other MU-plugins (e.g., `skyyrose-ally-ajax-guard.php`).

<sup>Written for commit 3475fb90a68c60514c3f70302f4e636d6f2a7702. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an anonymous cache-guard MU-plugin that reduces session and cart cookie setting for eligible front-end GET page views, helping more pages remain cacheable.
* **Chores**
  * Updated the MU-plugin deployment script to allow switching which MU-plugin is deployed via an override variable, uploading it under its own filename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->