### PR TITLE
fix(catalog): regenerate v7-cards.json + close CI path-filter gap

### DIFF
--- a/.github/workflows/catalog-validate.yml
+++ b/.github/workflows/catalog-validate.yml
@@ -11,6 +11,10 @@ on:
       - "scripts/sync_catalog_downstream.py"
       - "skyyrose/elite_studio/tests/test_catalog_consistency.py"
       - "skyyrose/elite_studio/tests/conftest.py"
+      - "scripts/build_v7_cards.py"
+      - "skyyrose/core/catalog_loader.py"
+      - "wordpress-theme/skyyrose-flagship/assets/images/products/v7/**"
+      - "tests/test_v7_cards_generator.py"
   push:
     branches: [main]
     paths:
@@ -18,6 +22,9 @@ on:
       - "skyyrose/elite_studio/sku_resolver.py"
       - "skyyrose/elite_studio/logo_registry.py"
       - "scripts/validate_catalog_consistency.py"
+      - "scripts/build_v7_cards.py"
+      - "skyyrose/core/catalog_loader.py"
+      - "wordpress-theme/skyyrose-flagship/assets/images/products/v7/**"
 
 jobs:
   validate:

--- a/wordpress-theme/skyyrose-flagship/data/v7-cards.json
+++ b/wordpress-theme/skyyrose-flagship/data/v7-cards.json
@@ -48,7 +48,7 @@
     },
     {
      "face": "alt",
-     "uri": "assets/images/products/v7/br-004/alt.webp"
+     "uri": "assets/images/products/v7/br-004/alt.png"
     }
    ]
   },
@@ -67,7 +67,7 @@
     },
     {
      "face": "alt",
-     "uri": "assets/images/products/v7/br-006/alt.webp"
+     "uri": "assets/images/products/v7/br-006/alt.png"
     }
    ]
   },
@@ -82,7 +82,7 @@
    "shots": [
     {
      "face": "front",
-     "uri": "assets/images/products/v7/br-007/front.webp"
+     "uri": "assets/images/products/v7/br-007/front.png"
     },
     {
      "face": "back",
@@ -105,7 +105,7 @@
     },
     {
      "face": "alt",
-     "uri": "assets/images/products/v7/br-008/alt.webp"
+     "uri": "assets/images/products/v7/br-008/alt.png"
     }
    ]
   },
@@ -124,7 +124,7 @@
     },
     {
      "face": "alt",
-     "uri": "assets/images/products/v7/br-010/alt.webp"
+     "uri": "assets/images/products/v7/br-010/alt.png"
     }
    ]
   },
@@ -143,7 +143,7 @@
     },
     {
      "face": "alt",
-     "uri": "assets/images/products/v7/br-011/alt.webp"
+     "uri": "assets/images/products/v7/br-011/alt.png"
     },
     {
      "face": "back",
@@ -185,7 +185,7 @@
     },
     {
      "face": "alt",
-     "uri": "assets/images/products/v7/br-015/alt.webp"
+     "uri": "assets/images/products/v7/br-015/alt.png"
     }
    ]
   },
@@ -238,7 +238,7 @@
     },
     {
      "face": "alt",
-     "uri": "assets/images/products/v7/lh-002/alt.webp"
+     "uri": "assets/images/products/v7/lh-002/alt.png"
     }
    ]
   },
@@ -355,7 +355,7 @@
    "shots": [
     {
      "face": "front",
-     "uri": "assets/images/products/v7/sg-003/front.webp"
+     "uri": "assets/images/products/v7/sg-003/front.png"
     }
    ]
   },
@@ -480,7 +480,7 @@
    "shots": [
     {
      "face": "front",
-     "uri": "assets/images/products/v7/sg-014/front.webp"
+     "uri": "assets/images/products/v7/sg-014/front.png"
     }
    ]
   },
@@ -495,7 +495,7 @@
    "shots": [
     {
      "face": "front",
-     "uri": "assets/images/products/v7/sg-015/front.webp"
+     "uri": "assets/images/products/v7/sg-015/front.png"
     }
    ]
   }


### PR DESCRIPTION
## Summary
- `v7-cards.json` (a generated view) had drifted: 11 image URIs were hand-edited `.png`→`.webp` in #704 (commit `1c6ad3428`, "v7 webp bases (11)") without the corresponding `.webp` files ever being added to the served tree — a violation of the file's own `DO NOT EDIT` header. Regenerated via `python scripts/build_v7_cards.py`; validator's `v7_cards_current` check now passes (18/18).
- Closed a real CI path-filter gap: `catalog-validate.yml` covered the CSV and the JSON output but not the served v7 image tree (`assets/images/products/v7/**`), the generator script itself, or its `catalog_loader.py` dependency — an image-only repoint (no CSV touch) would silently go unchecked. Added all three (+ the generator's test file to `pull_request` only) to both `push` and `pull_request` filters.
- **Correction to the linked report**: PR #724 (`e7dfe662a`) did NOT cause this drift — its only file changes are `data/sot-images.json`, `data/collections/black-rose/sot.json`, and `data/skyyrose-catalog.csv` catalog columns, none of which `build_v7_cards.py` reads for imagery (it globs the served `assets/images/products/v7/<sku>/` tree). The drift traces entirely to commit `1c6ad3428` (#704). Separately confirmed via `gh api .../commits/e7dfe662a.../check-runs` that Catalog Consistency never ran at all on PR #724's commit (`{"total_count":0}`), despite the CSV already matching the pre-existing `data/**` filter — a bot-merge/event-type issue outside this fix's surgical scope, flagged here for follow-up, not fixed.

## Test plan
- [x] `python scripts/validate_catalog_consistency.py` → 18/18 checks passed (was 17/18, `[FAIL] v7_cards_current`)
- [x] `pytest tests/test_v7_cards_generator.py -v --timeout=10` → 13 passed
- [x] `pytest tests/ -x --timeout=10 -q -k catalog` → 183 passed, 0 failed, 2 pre-existing skips (missing `torchvision`/`pyotp`, unrelated to this change)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/catalog-validate.yml'))"` → parses clean, no duplicate path entries

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated `v7-cards.json` to fix broken image URIs and aligned CI to validate the v7 image tree and generator. This removes drift and ensures image-only changes are checked.

- **Bug Fixes**
  - Regenerated `wordpress-theme/skyyrose-flagship/data/v7-cards.json` to replace 11 `.webp` URIs with existing `.png` paths; catalog validator now passes.
  - Updated `.github/workflows/catalog-validate.yml` path filters: include `scripts/build_v7_cards.py`, `skyyrose/core/catalog_loader.py`, and `wordpress-theme/skyyrose-flagship/assets/images/products/v7/**` for both `push` and `pull_request`; include `tests/test_v7_cards_generator.py` on `pull_request` only.

<sup>Written for commit 65aa5821b9ad87b43575e390d60c7ad1b1f06ac5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

