### PR TITLE
security: close live anonymous-RCE + auth/SSRF/webhook hardening on hub API

### DIFF
--- a/agents/wordpress_bridge/mcp_server.py
+++ b/agents/wordpress_bridge/mcp_server.py
@@ -394,7 +394,10 @@ async def wp_create_page(args: dict[str, Any]) -> dict[str, Any]:
         title = args.get("title", "")
         slug = args.get("slug", "")
         content = args.get("content", "")
-        status = args.get("status", "draft")
+        # Clamp to draft — the autonomous agent must never publish arbitrary
+        # (possibly prompt-injected) HTML/JS live. Publishing is a separate,
+        # human-gated step, not something the SDK loop can trigger.
+        status = "draft"
 
         if not title or not slug:
             raise ValueError("'title' and 'slug' are required")

--- a/api/v1/brand_assets.py
+++ b/api/v1/brand_assets.py
@@ -23,7 +23,7 @@ from typing import Any
 from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from services.ml.visual_feature_extractor import (
     VisualFeatureExtractor,
     get_visual_feature_extractor,
@@ -35,6 +35,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from database.db import db_manager, get_db
 from database.models_brand_assets import BrandAssetRecord, IngestionJobRecord
 from security.jwt_oauth2_auth import TokenPayload, get_current_user
+from security.ssrf_protection import SSRFProtection
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +128,16 @@ class BrandAssetUpload(BaseModel):
     url: str = Field(..., description="URL of image to ingest")
     category: BrandAssetCategory
     metadata: BrandAssetMetadata = Field(default_factory=BrandAssetMetadata)
+
+    @field_validator("url")
+    @classmethod
+    def _validate_url(cls, v: str) -> str:
+        # SSRF guard at the ingest boundary — block internal hosts / cloud
+        # metadata before any fetch (upload_to_r2 + visual feature extraction).
+        # Block-internal-only: brand assets legitimately come from many domains.
+        if v.startswith(("http://", "https://")):
+            SSRFProtection().validate_url(v)
+        return v
 
 
 class BulkIngestionRequest(BaseModel):
@@ -467,8 +478,13 @@ async def upload_to_r2(
 
         # Generate key and upload
         from pathlib import Path
+        from urllib.parse import urlparse
 
-        ext = Path(image_url).suffix or ".jpg"
+        # Allowlist the extension derived from the (attacker-influenced) URL so
+        # it can't inject path-like segments into the R2 object key.
+        ext = Path(urlparse(image_url).path).suffix.lower()
+        if ext not in (".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif"):
+            ext = ".jpg"
         key = f"brand/{category.value}/{asset_id}{ext}"
 
         result = r2_client.upload_bytes(

--- a/api/v1/brand_assets.py
+++ b/api/v1/brand_assets.py
@@ -134,9 +134,13 @@ class BrandAssetUpload(BaseModel):
     def _validate_url(cls, v: str) -> str:
         # SSRF guard at the ingest boundary — block internal hosts / cloud
         # metadata before any fetch (upload_to_r2 + visual feature extraction).
-        # Block-internal-only: brand assets legitimately come from many domains.
-        if v.startswith(("http://", "https://")):
-            SSRFProtection().validate_url(v)
+        # Validate UNCONDITIONALLY: a case-variant scheme ("HTTP://…") or any
+        # non-http scheme must not slip past — urlparse/httpx lowercase the scheme,
+        # so a startswith("http://") gate was an SSRF bypass (HTTP://169.254.169.254
+        # reached the fetch). validate_url rejects any scheme outside {http, https}
+        # and any internal/metadata host. Block-internal-only: brand assets
+        # legitimately come from many public domains.
+        SSRFProtection().validate_url(v)
         return v
 
 

--- a/api/v1/catalog.py
+++ b/api/v1/catalog.py
@@ -7,14 +7,16 @@ Voyage `voyage-3-large` embeddings + Pinecone serverless
 Prefix:  /api/v1/catalog
 Auth:    public for read-only catalog data (/search, /products/*, /collections/*).
 
-         CAVEAT: /answer and /answer/stream invoke Claude (cost-bearing, ~$0.002/req)
-         and are currently UNAUTHENTICATED. Other LLM-backed endpoints in this API
-         (api/v1/rag_anything.py, api/v1/commerce.py) gate via Depends(get_current_user)
-         + entitlement checks. Before exposing publicly, either:
-           (a) add Depends(get_current_user) and bill against tier, OR
-           (b) add per-IP rate limiting via security.rate_limiting.rate_limiter.
-         The /answer cache (1h TTL, 128 slots) provides some natural backpressure
-         on identical queries but does not bound spend from a malicious caller.
+         /answer and /answer/stream invoke Claude (cost-bearing, ~$0.002/req) and
+         are intentionally PUBLIC (shopper-facing Q&A). Spend is bounded by option
+         (b) rather than a JWT gate — a deliberate product choice:
+           (b) per-IP endpoint rate limiting via security.rate_limiting — 20 req/min
+               per IP on /answer + /answer/stream (ENDPOINT_BASED rules), layered
+               over the global IP_BASED default. The /answer cache (1h TTL, 128
+               slots) adds backpressure on identical queries.
+         /cache/clear is admin-mutating and DOES require Depends(get_current_user).
+         To later gate /answer behind auth + tier billing, add Depends(get_current_user)
+         here (option (a)) — the seam other LLM endpoints use (rag_anything, commerce).
 
 Endpoints:
     GET  /search                            — semantic search across all SKUs

--- a/api/v1/catalog.py
+++ b/api/v1/catalog.py
@@ -37,11 +37,12 @@ from collections import OrderedDict
 from collections.abc import AsyncIterator
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from orchestration.catalog_retriever import CatalogAnswer, CatalogMatch, CatalogRetriever
+from security.jwt_oauth2_auth import TokenPayload, get_current_user
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/catalog", tags=["Catalog"])
@@ -635,7 +636,9 @@ async def cache_stats() -> CacheStatsResponse:
 
 
 @router.post("/cache/clear")
-async def cache_clear() -> dict[str, str]:
+async def cache_clear(
+    _current_user: TokenPayload = Depends(get_current_user),
+) -> dict[str, str]:
     """Drop all cached /answer responses. Use after re-indexing the catalog
     so stale answers don't linger past their TTL."""
     await _get_answer_cache().clear()

--- a/api/v1/claude_sdk.py
+++ b/api/v1/claude_sdk.py
@@ -17,11 +17,17 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+
+from security.jwt_oauth2_auth import RoleChecker, UserRole
 
 router = APIRouter(prefix="/claude-sdk", tags=["Claude Agent SDK"])
 
 logger = logging.getLogger(__name__)
+
+# Operator-only tooling — every route here can execute code, orchestrate agents,
+# or trigger production deploys/rollbacks. Gate the entire router behind ADMIN.
+require_admin = RoleChecker([UserRole.ADMIN])
 
 
 # ------------------------------------------------------------------
@@ -34,6 +40,7 @@ async def trigger_research(
     topic: str,
     subtopics: list[str] | None = None,
     model: str = "haiku",
+    _current_user: dict = Depends(require_admin),
 ):
     """Trigger a multi-agent research pipeline.
 
@@ -75,6 +82,7 @@ async def triage_email(
     mailbox: str = "INBOX",
     limit: int = 10,
     unread_only: bool = True,
+    _current_user: dict = Depends(require_admin),
 ):
     """Triage emails from IMAP with AI classification.
 
@@ -120,6 +128,7 @@ async def handle_excel(
     description: str,
     input_file: str | None = None,
     output_filename: str | None = None,
+    _current_user: dict = Depends(require_admin),
 ):
     """Create or analyze Excel spreadsheets with AI.
 
@@ -175,6 +184,7 @@ async def manage_session(
     session_id: str | None = None,
     model: str = "sonnet",
     system_prompt: str | None = None,
+    _current_user: dict = Depends(require_admin),
 ):
     """Create, resume, or execute one-shot V2 sessions.
 
@@ -248,6 +258,7 @@ async def manage_session(
 async def execute_dashboard_actions(
     actions: list[dict],
     parallel: bool = True,
+    _current_user: dict = Depends(require_admin),
 ):
     """Execute actions across SDK domain agents.
 
@@ -290,7 +301,7 @@ async def execute_dashboard_actions(
 
 
 @router.get("/dashboard/health")
-async def get_dashboard_health():
+async def get_dashboard_health(_current_user: dict = Depends(require_admin)):
     """Get health status of all registered SDK dashboard agents.
 
     Returns the list of all 27 SDK agents across 15 domains with
@@ -315,6 +326,7 @@ async def get_dashboard_health():
 @router.get("/dashboard/agents")
 async def list_dashboard_agents(
     domain: str | None = None,
+    _current_user: dict = Depends(require_admin),
 ):
     """List all registered SDK dashboard agents, optionally filtered by domain.
 
@@ -358,6 +370,7 @@ async def list_dashboard_agents(
 @router.post("/dashboard/find")
 async def find_agents_by_capability(
     capability: str,
+    _current_user: dict = Depends(require_admin),
 ):
     """Find SDK agents that have a specific capability.
 

--- a/api/v1/elite_studio.py
+++ b/api/v1/elite_studio.py
@@ -54,8 +54,14 @@ def _get_api_key_dependency():
     async def _check_api_key(x_api_key: str | None = Header(default=None, alias="X-API-Key")):
         expected = os.getenv("API_KEY", "")
         if not expected:
-            # No API_KEY configured — allow through (dev mode)
-            return None
+            # Fail closed: a missing API_KEY is a misconfiguration in any
+            # non-dev environment — reject rather than allow through (bug-230).
+            if os.getenv("ENVIRONMENT", "").lower() in ("development", "dev", "local", "test"):
+                return None
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="API_KEY not configured",
+            )
         if x_api_key != expected:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/api/v1/feature_flags.py
+++ b/api/v1/feature_flags.py
@@ -10,12 +10,17 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+
+from security.jwt_oauth2_auth import RoleChecker, UserRole
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/flags", tags=["feature-flags"])
+
+# Flags (including kill_switch) control live production behavior — admin only.
+require_admin = RoleChecker([UserRole.ADMIN])
 
 
 class FlagCreateRequest(BaseModel):
@@ -40,7 +45,7 @@ class RolloutRequest(BaseModel):
 
 
 @router.get("", response_model=list[FlagResponse])
-async def list_flags() -> list[FlagResponse]:
+async def list_flags(_current_user: dict = Depends(require_admin)) -> list[FlagResponse]:
     """List all feature flags."""
     from core.feature_flags.flag_manager import flag_manager
 
@@ -59,7 +64,11 @@ async def list_flags() -> list[FlagResponse]:
 
 
 @router.put("/{flag_name}", response_model=FlagResponse)
-async def upsert_flag(flag_name: str, request: FlagCreateRequest) -> FlagResponse:
+async def upsert_flag(
+    flag_name: str,
+    request: FlagCreateRequest,
+    _current_user: dict = Depends(require_admin),
+) -> FlagResponse:
     """Create or update a feature flag."""
     from core.feature_flags.flag_manager import FeatureFlag, flag_manager
 
@@ -83,7 +92,11 @@ async def upsert_flag(flag_name: str, request: FlagCreateRequest) -> FlagRespons
 
 
 @router.post("/{flag_name}/rollout", response_model=FlagResponse)
-async def update_rollout(flag_name: str, request: RolloutRequest) -> FlagResponse:
+async def update_rollout(
+    flag_name: str,
+    request: RolloutRequest,
+    _current_user: dict = Depends(require_admin),
+) -> FlagResponse:
     """Update rollout percentage for a flag."""
     from core.feature_flags.flag_manager import flag_manager
 
@@ -106,7 +119,10 @@ async def update_rollout(flag_name: str, request: RolloutRequest) -> FlagRespons
 
 
 @router.delete("/{flag_name}")
-async def delete_flag(flag_name: str) -> dict[str, str]:
+async def delete_flag(
+    flag_name: str,
+    _current_user: dict = Depends(require_admin),
+) -> dict[str, str]:
     """Delete a feature flag."""
     from core.feature_flags.flag_manager import flag_manager
 

--- a/api/v1/wordpress.py
+++ b/api/v1/wordpress.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from integrations.wordpress_com_client import create_wordpress_client
-from security.jwt_oauth2_auth import TokenPayload, get_current_user
+from security.jwt_oauth2_auth import service_or_user_auth
 
 router = APIRouter(tags=["wordpress"], prefix="/wordpress")
 
@@ -52,9 +52,13 @@ def _get_wp_creds() -> dict[str, str | None]:
 @router.post("/sync", response_model=WordPressSyncResponse, summary="Sync content to WordPress")
 async def sync_to_wordpress(
     request: WordPressSyncRequest,
-    _current_user: TokenPayload = Depends(get_current_user),
+    _principal=Depends(service_or_user_auth),
 ):
-    """Create a post/page on WordPress."""
+    """Create a post/page on WordPress.
+
+    Auth: a user JWT (dashboard) OR the X-Service-Token machine-to-machine token
+    (background queue worker). See security.jwt_oauth2_auth.service_or_user_auth.
+    """
     creds = _get_wp_creds()
     try:
         async with await create_wordpress_client(**creds) as client:

--- a/api/v1/wordpress.py
+++ b/api/v1/wordpress.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from integrations.wordpress_com_client import create_wordpress_client
+from security.jwt_oauth2_auth import TokenPayload, get_current_user
 
 router = APIRouter(tags=["wordpress"], prefix="/wordpress")
 
@@ -49,7 +50,10 @@ def _get_wp_creds() -> dict[str, str | None]:
 
 
 @router.post("/sync", response_model=WordPressSyncResponse, summary="Sync content to WordPress")
-async def sync_to_wordpress(request: WordPressSyncRequest):
+async def sync_to_wordpress(
+    request: WordPressSyncRequest,
+    _current_user: TokenPayload = Depends(get_current_user),
+):
     """Create a post/page on WordPress."""
     creds = _get_wp_creds()
     try:

--- a/api/v1/wordpress_integration.py
+++ b/api/v1/wordpress_integration.py
@@ -5,6 +5,7 @@ FastAPI endpoints for WordPress/WooCommerce integration.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import hmac
 import logging
@@ -18,6 +19,7 @@ from pydantic import BaseModel, Field
 
 from integrations.wordpress_com_client import create_wordpress_client
 from integrations.wordpress_product_sync import SkyyRoseProduct, WordPressProductSync
+from security.jwt_oauth2_auth import TokenPayload, get_current_user
 
 router = APIRouter(prefix="/wordpress", tags=["wordpress"])
 
@@ -82,12 +84,17 @@ def verify_webhook_signature(
     Returns:
         True if signature valid
     """
+    if not secret:
+        # Fail closed: an unset WC_WEBHOOK_SECRET makes the HMAC forgeable with
+        # an empty key, so reject every webhook rather than trust it (bug-230).
+        return False
     expected = hmac.new(
         secret.encode(),
         payload,
         hashlib.sha256,
     ).digest()
-    expected_b64 = expected.hex()
+    # WooCommerce sends X-WC-Webhook-Signature base64-encoded, not hex.
+    expected_b64 = base64.b64encode(expected).decode()
     return hmac.compare_digest(expected_b64, signature)
 
 
@@ -129,6 +136,7 @@ async def verify_webhook(
 async def sync_product(
     product: SkyyRoseProduct,
     settings: WordPressSettings = Depends(get_settings),
+    _current_user: TokenPayload = Depends(get_current_user),
 ) -> dict[str, Any]:
     """Sync single product to WooCommerce.
 
@@ -157,6 +165,7 @@ async def sync_collection(
     collection: str,
     products: list[SkyyRoseProduct],
     settings: WordPressSettings = Depends(get_settings),
+    _current_user: TokenPayload = Depends(get_current_user),
 ) -> dict[str, Any]:
     """Sync all products in a collection.
 

--- a/api/v2/assets.py
+++ b/api/v2/assets.py
@@ -43,7 +43,13 @@ def _get_api_key_dependency():
     async def _check_api_key(x_api_key: str | None = Header(default=None, alias="X-API-Key")):
         expected = os.getenv("API_KEY", "")
         if not expected:
-            return None
+            # Fail closed outside dev — a missing API_KEY must not allow through.
+            if os.getenv("ENVIRONMENT", "").lower() in ("development", "dev", "local", "test"):
+                return None
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="API_KEY not configured",
+            )
         if x_api_key != expected:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/api/v2/characters.py
+++ b/api/v2/characters.py
@@ -48,7 +48,13 @@ def _get_api_key_dependency():
     async def _check_api_key(x_api_key: str | None = Header(default=None, alias="X-API-Key")):
         expected = os.getenv("API_KEY", "")
         if not expected:
-            return None
+            # Fail closed outside dev — a missing API_KEY must not allow through.
+            if os.getenv("ENVIRONMENT", "").lower() in ("development", "dev", "local", "test"):
+                return None
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="API_KEY not configured",
+            )
         if x_api_key != expected:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/api/v2/creative.py
+++ b/api/v2/creative.py
@@ -77,7 +77,13 @@ def _get_api_key_dependency():
     async def _check_api_key(x_api_key: str | None = Header(default=None, alias="X-API-Key")):
         expected = os.getenv("API_KEY", "")
         if not expected:
-            return None
+            # Fail closed outside dev — a missing API_KEY must not allow through.
+            if os.getenv("ENVIRONMENT", "").lower() in ("development", "dev", "local", "test"):
+                return None
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="API_KEY not configured",
+            )
         if x_api_key != expected:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/api/v2/webhooks.py
+++ b/api/v2/webhooks.py
@@ -39,7 +39,13 @@ def _get_api_key_dependency():
     async def _check_api_key(x_api_key: str | None = Header(default=None, alias="X-API-Key")):
         expected = os.getenv("API_KEY", "")
         if not expected:
-            return None
+            # Fail closed outside dev — a missing API_KEY must not allow through.
+            if os.getenv("ENVIRONMENT", "").lower() in ("development", "dev", "local", "test"):
+                return None
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="API_KEY not configured",
+            )
         if x_api_key != expected:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/billing/webhooks.py
+++ b/billing/webhooks.py
@@ -73,14 +73,18 @@ def handle_stripe_webhook(payload: bytes, signature: str) -> dict[str, Any]:
     try:
         if webhook_secret:
             event = stripe_mod.Webhook.construct_event(payload, signature, webhook_secret)
-        else:
-            # Dev/test: parse without verification
+        elif os.getenv("ENVIRONMENT", "").lower() in ("development", "dev", "local", "test"):
+            # Dev/test only: parse without verification.
             import json
 
             logger.warning(
                 "STRIPE_WEBHOOK_SECRET not set — skipping signature verification (dev mode)"
             )
             event = stripe_mod.Event.construct_from(json.loads(payload), stripe_mod.api_key)
+        else:
+            # Fail closed: never process an unverified Stripe webhook in prod.
+            logger.error("STRIPE_WEBHOOK_SECRET not set — rejecting unverified webhook")
+            return {"event": "signature_missing", "processed": False}
     except stripe_mod.error.SignatureVerificationError as exc:
         logger.error("Webhook signature verification failed: %s", exc)
         return {"event": "signature_invalid", "processed": False}

--- a/frontend/lib/queue/worker.ts
+++ b/frontend/lib/queue/worker.ts
@@ -28,6 +28,12 @@ function parseRedisUrl(url: string) {
 
 const connection = parseRedisUrl(REDIS_URL);
 
+// Machine-to-machine credential for backend routes that require auth (e.g.
+// /api/v1/wordpress/sync). This worker has no user session, so it presents a
+// service token instead of a user JWT. Server-only env (NOT NEXT_PUBLIC_) — it
+// must never reach the browser. Unset => the header is omitted and the call 401s.
+const WP_SYNC_SERVICE_TOKEN = process.env.WORDPRESS_SYNC_SERVICE_TOKEN;
+
 // Job handlers
 async function handleGenerate3D(job: Job<JobData['generate-3d-asset']>) {
   const { productId, prompt, provider, outputFormat } = job.data;
@@ -76,7 +82,10 @@ async function handleSyncWordPress(job: Job<JobData['sync-wordpress']>) {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
   const response = await fetch(`${apiUrl}/api/v1/wordpress/sync`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(WP_SYNC_SERVICE_TOKEN ? { 'X-Service-Token': WP_SYNC_SERVICE_TOKEN } : {}),
+    },
     body: JSON.stringify({ action, productIds, force }),
   });
 

--- a/security/jwt_oauth2_auth.py
+++ b/security/jwt_oauth2_auth.py
@@ -998,6 +998,48 @@ def _create_role_checker_class():
 RoleChecker = _create_role_checker_class()
 
 
+def service_or_user_auth_dependency(service_token_env: str = "WORDPRESS_SYNC_SERVICE_TOKEN"):
+    """Dependency authorizing EITHER a valid Bearer JWT (any authenticated user)
+    OR a machine-to-machine service token.
+
+    Background workers (e.g. the BullMQ queue worker) call state-changing routes
+    with no user session — they present X-Service-Token, compared constant-time
+    against os.environ[service_token_env]. Fails closed: if the env token is unset
+    the service-token path is disabled and only a valid JWT is accepted; a caller
+    with neither always gets 401. Never reveals which path failed.
+    """
+    from fastapi import Header, HTTPException, status
+
+    async def _service_or_user(
+        authorization: str | None = Header(None, alias="Authorization"),
+        x_service_token: str | None = Header(None, alias="X-Service-Token"),
+    ) -> TokenPayload | dict[str, str]:
+        # Machine-to-machine path: constant-time match against the configured token.
+        expected = os.getenv(service_token_env, "")
+        if x_service_token and expected and secrets.compare_digest(x_service_token, expected):
+            return {"sub": "service", "auth": "service_token", "token_env": service_token_env}
+
+        # User path: a valid Bearer JWT.
+        token = _extract_token_from_header(authorization or "")
+        if token:
+            try:
+                return jwt_manager.validate_token(token)
+            except (ExpiredSignatureError, InvalidTokenError):
+                pass  # fall through to the generic 401 — never leak which path failed
+
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return _service_or_user
+
+
+# Create the dependency - this is what gets exported
+service_or_user_auth = service_or_user_auth_dependency()
+
+
 # =============================================================================
 # Module-level Instances
 # =============================================================================
@@ -1327,6 +1369,8 @@ __all__ = [
     # Dependencies
     "get_current_user",
     "require_roles",
+    "service_or_user_auth",
+    "service_or_user_auth_dependency",
     # Routers
     "auth_router",
     # Instances

--- a/security/rate_limiting.py
+++ b/security/rate_limiting.py
@@ -254,6 +254,23 @@ class AdvancedRateLimiter:
                 requests_per_hour=50,
                 burst_limit=10,
             ),
+            # Public, cost-bearing RAG Q&A (Voyage embed + Pinecone + Haiku).
+            # Tight per-endpoint cap so an anonymous caller can't run up LLM
+            # spend, but generous enough for real interactive shoppers.
+            "/api/v1/catalog/answer": RateLimitRule(
+                name="catalog_answer_endpoint",
+                limit_type=RateLimitType.ENDPOINT_BASED,
+                requests_per_minute=20,
+                requests_per_hour=300,
+                burst_limit=30,
+            ),
+            "/api/v1/catalog/answer/stream": RateLimitRule(
+                name="catalog_answer_stream_endpoint",
+                limit_type=RateLimitType.ENDPOINT_BASED,
+                requests_per_minute=20,
+                requests_per_hour=300,
+                burst_limit=30,
+            ),
         }
 
     def get_client_identifier(self, request: Request, limit_type: RateLimitType) -> str:

--- a/security/rate_limiting.py
+++ b/security/rate_limiting.py
@@ -255,8 +255,12 @@ class AdvancedRateLimiter:
                 burst_limit=10,
             ),
             # Public, cost-bearing RAG Q&A (Voyage embed + Pinecone + Haiku).
-            # Tight per-endpoint cap so an anonymous caller can't run up LLM
-            # spend, but generous enough for real interactive shoppers.
+            # Enforced as a per-IP sliding window (ENDPOINT_BASED keys on
+            # endpoint:path:ip): 20 req / 60s per IP. NOTE: for ENDPOINT_BASED
+            # rules only requests_per_minute is enforced — requests_per_hour and
+            # burst_limit are advisory metadata (kept for parity with the other
+            # rules, e.g. /auth/register), not a second window. Tight enough to
+            # cap an anonymous caller's LLM spend, generous enough for real shoppers.
             "/api/v1/catalog/answer": RateLimitRule(
                 name="catalog_answer_endpoint",
                 limit_type=RateLimitType.ENDPOINT_BASED,

--- a/services/ml/gemini_client.py
+++ b/services/ml/gemini_client.py
@@ -172,6 +172,14 @@ class ImageInput(BaseModel):
     @classmethod
     async def from_url(cls, url: str, timeout: float = 30.0) -> ImageInput:
         """Create ImageInput from URL by downloading and encoding."""
+        # SSRF guard: reject internal hosts / cloud-metadata IPs before fetching
+        # a caller-supplied URL. Shared primitive — this closes every call site
+        # (brand-assets ingest, creative/multimodal agents, 3D providers).
+        # Block-internal-only (empty allowlist) so legitimate public image URLs
+        # from any domain still resolve.
+        from security.ssrf_protection import SSRFProtection
+
+        SSRFProtection().validate_url(url)
         async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.get(url)
             response.raise_for_status()

--- a/tests/api/test_catalog_endpoint.py
+++ b/tests/api/test_catalog_endpoint.py
@@ -109,9 +109,12 @@ def client(fake_matches, monkeypatch):
 
     app = FastAPI()
     app.include_router(catalog_router, prefix="/api/v1")
-    # /answer, /answer/stream, and /cache/clear now require auth; override the
-    # dependency with a stub user so these tests exercise endpoint logic, not
-    # the 401 gate (the gate itself is covered by test_api_auth_hardening.py).
+    # /cache/clear requires auth (POST, admin-mutating); /answer + /answer/stream
+    # are intentionally PUBLIC (shopper Q&A, bounded by per-IP rate limits, not a
+    # JWT gate — see the module docstring). Override get_current_user with a stub
+    # so the /cache/clear test exercises endpoint logic, not the 401 gate (that
+    # gate is covered by test_api_auth_hardening.py). The override is a harmless
+    # no-op for the two public routes, which don't depend on get_current_user.
     from security.jwt_oauth2_auth import get_current_user
 
     app.dependency_overrides[get_current_user] = lambda: {"sub": "test-user", "role": "admin"}

--- a/tests/api/test_catalog_endpoint.py
+++ b/tests/api/test_catalog_endpoint.py
@@ -109,6 +109,12 @@ def client(fake_matches, monkeypatch):
 
     app = FastAPI()
     app.include_router(catalog_router, prefix="/api/v1")
+    # /answer, /answer/stream, and /cache/clear now require auth; override the
+    # dependency with a stub user so these tests exercise endpoint logic, not
+    # the 401 gate (the gate itself is covered by test_api_auth_hardening.py).
+    from security.jwt_oauth2_auth import get_current_user
+
+    app.dependency_overrides[get_current_user] = lambda: {"sub": "test-user", "role": "admin"}
     return TestClient(app)
 
 

--- a/tests/test_api_auth_hardening.py
+++ b/tests/test_api_auth_hardening.py
@@ -157,5 +157,52 @@ class TestBrandAssetSsrfGuard:
             BrandAssetUpload(url="file:///etc/passwd", category="product")
 
 
+class TestServiceTokenAuth:
+    """/wordpress/sync accepts a machine-to-machine X-Service-Token (queue worker
+    has no user session) as an alternative to a user JWT — constant-time matched,
+    fails closed when the env token is unset. No user JWT is required for the
+    service path, and no service path exists without the configured secret.
+    """
+
+    def test_valid_service_token_passes_auth(self, monkeypatch):
+        monkeypatch.setenv("WORDPRESS_SYNC_SERVICE_TOKEN", "s3cr3t-worker-token")
+        from api.v1.wordpress import router
+
+        c = _client(router, prefix="/api/v1")
+        r = c.post(
+            "/api/v1/wordpress/sync",
+            json={"title": "x", "content": "y"},
+            headers={"X-Service-Token": "s3cr3t-worker-token"},
+        )
+        # Auth passed → NOT 401/403 (downstream may 503 on missing WP creds / 200).
+        assert r.status_code not in _UNAUTH, r.status_code
+
+    def test_wrong_service_token_rejected(self, monkeypatch):
+        monkeypatch.setenv("WORDPRESS_SYNC_SERVICE_TOKEN", "s3cr3t-worker-token")
+        from api.v1.wordpress import router
+
+        c = _client(router, prefix="/api/v1")
+        r = c.post(
+            "/api/v1/wordpress/sync",
+            json={"title": "x", "content": "y"},
+            headers={"X-Service-Token": "WRONG"},
+        )
+        assert r.status_code in _UNAUTH, r.status_code
+
+    def test_service_token_path_disabled_when_env_unset(self, monkeypatch):
+        # No configured secret => the service-token path must not exist; a header
+        # (even non-empty) can't authenticate. Fails closed.
+        monkeypatch.delenv("WORDPRESS_SYNC_SERVICE_TOKEN", raising=False)
+        from api.v1.wordpress import router
+
+        c = _client(router, prefix="/api/v1")
+        r = c.post(
+            "/api/v1/wordpress/sync",
+            json={"title": "x", "content": "y"},
+            headers={"X-Service-Token": "anything"},
+        )
+        assert r.status_code in _UNAUTH, r.status_code
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_api_auth_hardening.py
+++ b/tests/test_api_auth_hardening.py
@@ -1,0 +1,123 @@
+"""Security regression tests for the auth-hardening pass (bug-252 sibling class).
+
+Proves that endpoints which were unauthenticated (and in claude_sdk's case,
+anonymous-RCE) now reject callers without valid credentials, and that the
+WooCommerce webhook verifier fails closed when the secret is unset.
+
+These are behavioral tests: mount each router on a minimal app and assert the
+HTTP status a credential-less caller sees.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_UNAUTH = (401, 403)  # missing/invalid creds → Unauthorized or Forbidden
+
+
+def _client(router, prefix: str = "") -> TestClient:
+    app = FastAPI()
+    if prefix:
+        app.include_router(router, prefix=prefix)
+    else:
+        app.include_router(router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestClaudeSdkNoAnonymousRce:
+    """claude_sdk routes gave anonymous Bash-capable agents — now ADMIN-only."""
+
+    def test_session_requires_auth(self):
+        from api.v1.claude_sdk import router
+
+        c = _client(router, prefix="/api/v1")
+        r = c.post("/api/v1/claude-sdk/session", params={"action": "create"})
+        assert r.status_code in _UNAUTH, r.status_code
+
+    def test_excel_requires_auth(self):
+        from api.v1.claude_sdk import router
+
+        c = _client(router, prefix="/api/v1")
+        r = c.post("/api/v1/claude-sdk/excel", params={"operation": "create", "description": "x"})
+        assert r.status_code in _UNAUTH, r.status_code
+
+    def test_dashboard_health_requires_auth(self):
+        from api.v1.claude_sdk import router
+
+        c = _client(router, prefix="/api/v1")
+        r = c.get("/api/v1/claude-sdk/dashboard/health")
+        assert r.status_code in _UNAUTH, r.status_code
+
+
+class TestWordPressWritesRequireAuth:
+    def test_content_sync_requires_auth(self):
+        from api.v1.wordpress import router
+
+        c = _client(router, prefix="/api/v1")
+        r = c.post("/api/v1/wordpress/sync", json={"title": "x", "content": "y"})
+        assert r.status_code in _UNAUTH, r.status_code
+
+    def test_product_sync_requires_auth(self, monkeypatch):
+        # Configure the site URL so the settings gate passes and auth becomes
+        # the effective gate (else get_settings 503s before auth resolves).
+        monkeypatch.setenv("WORDPRESS_SITE_URL", "https://skyyrose.co")
+
+        from api.v1.wordpress_integration import router
+
+        c = _client(router, prefix="/api/v1")
+        # Send a plausible product body; auth must reject before any live write.
+        r = c.post(
+            "/api/v1/wordpress/products/sync",
+            json={"sku": "test-001", "name": "Test", "price": 10, "collection": "signature"},
+        )
+        assert r.status_code in _UNAUTH, r.status_code
+
+
+class TestFeatureFlagsAdminOnly:
+    def test_upsert_flag_requires_auth(self):
+        from api.v1.feature_flags import router
+
+        c = _client(router)  # router already carries /api/v1/flags prefix
+        r = c.put("/api/v1/flags/test-flag", json={"name": "test-flag", "enabled": True})
+        assert r.status_code in _UNAUTH, r.status_code
+
+    def test_delete_flag_requires_auth(self):
+        from api.v1.feature_flags import router
+
+        c = _client(router)
+        r = c.delete("/api/v1/flags/test-flag")
+        assert r.status_code in _UNAUTH, r.status_code
+
+
+class TestWebhookFailsClosed:
+    """An unset WC_WEBHOOK_SECRET must reject webhooks, not trust empty-key HMAC."""
+
+    def test_empty_secret_rejects_webhook(self, monkeypatch):
+        monkeypatch.delenv("WC_WEBHOOK_SECRET", raising=False)
+        monkeypatch.setenv("WORDPRESS_SITE_URL", "https://skyyrose.co")
+
+        from api.v1.woocommerce_webhooks import router
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        body = b'{"id": 1, "price": "1.00"}'
+        # Forge the signature the way an attacker would with an empty key.
+        forged = base64.b64encode(hmac.new(b"", body, hashlib.sha256).digest()).decode()
+        r = client.post(
+            "/woocommerce/webhooks/product",
+            content=body,
+            headers={"X-WC-Webhook-Signature": forged, "Content-Type": "application/json"},
+        )
+        assert r.status_code == 401, r.status_code
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_api_auth_hardening.py
+++ b/tests/test_api_auth_hardening.py
@@ -119,5 +119,43 @@ class TestWebhookFailsClosed:
         assert r.status_code == 401, r.status_code
 
 
+class TestBrandAssetSsrfGuard:
+    """The bulk-ingest URL validator must reject internal / cloud-metadata targets
+    regardless of scheme case. `HTTP://…` was a bypass: str.startswith(("http://",
+    "https://")) is case-sensitive, but urlparse/httpx lowercase the scheme, so the
+    raw URL reached httpx.get() unvalidated (169.254.169.254 → IAM credential theft).
+    These assert the guard now runs unconditionally. All three targets are rejected
+    BEFORE any DNS resolution (blocked-domain / protocol checks), so no network.
+    """
+
+    def test_lowercase_metadata_ip_rejected(self):
+        from pydantic import ValidationError
+
+        from api.v1.brand_assets import BrandAssetUpload
+
+        with pytest.raises(ValidationError):
+            BrandAssetUpload(url="http://169.254.169.254/latest/meta-data/", category="product")
+
+    def test_uppercase_scheme_metadata_ip_rejected(self):
+        # The regression: "HTTP://" skipped the case-sensitive startswith gate.
+        from pydantic import ValidationError
+
+        from api.v1.brand_assets import BrandAssetUpload
+
+        with pytest.raises(ValidationError):
+            BrandAssetUpload(
+                url="HTTP://169.254.169.254/latest/meta-data/iam/security-credentials/",
+                category="product",
+            )
+
+    def test_non_http_scheme_rejected(self):
+        from pydantic import ValidationError
+
+        from api.v1.brand_assets import BrandAssetUpload
+
+        with pytest.raises(ValidationError):
+            BrandAssetUpload(url="file:///etc/passwd", category="product")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_woocommerce_webhooks.py
+++ b/tests/test_woocommerce_webhooks.py
@@ -6,6 +6,7 @@ Signature verification is delegated to api.v1.wordpress_integration.verify_webho
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import hmac
 import json
@@ -18,7 +19,8 @@ SECRET = "test-wc-webhook-secret"
 
 
 def _sign(body: bytes, secret: str = SECRET) -> str:
-    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    # WooCommerce sends X-WC-Webhook-Signature base64-encoded (not hex).
+    return base64.b64encode(hmac.new(secret.encode(), body, hashlib.sha256).digest()).decode()
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes a **live, anonymous RCE** on api.devskyy.app: `GET /api/v1/claude-sdk/dashboard/health` currently returns 200 unauthenticated and the sibling POST routes spawn Bash-capable agents. Plus a full sweep of auth/SSRF/webhook gaps on the internet-facing hub.

## Commits
- `1bc5e9c7f` — 20 verified auth/SSRF/webhook gaps (claude_sdk ADMIN gate, wordpress writes, feature_flags, webhook HMAC fail-closed + base64, SSRF on brand_assets+gemini, elite_studio/api-v2 fail-closed, Stripe fail-closed, catalog rate-limit).
- `5c1ff539a` — SSRF scheme-case bypass (`HTTP://169.254.169.254` skipped the case-sensitive `startswith` guard) + corrected misleading catalog `/answer` auth docs.
- `569ddc8b4` — service-token M2M auth for `/wordpress/sync` so the token-less queue worker isn't 401'd (bug-259 sibling class).

## Verification
- All affected suites green (auth-hardening + catalog + webhooks), frontend tsc + eslint clean, mypy 1501 files, ruff/black/isort.
- New regression tests: `tests/test_api_auth_hardening.py` (anonymous→401 per router, webhook fail-closed, SSRF scheme-case, service-token 3 paths).

## Deploy dependency
Set `WORDPRESS_SYNC_SERVICE_TOKEN` as a Fly secret on `devskyy-backend` AND (when run) in the queue worker's env — same value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes a live anonymous RCE and hardens the hub API across auth, SSRF, and webhooks. Adds admin gates, fail‑closed checks, per‑IP rate limits, and a service‑token path for the WordPress sync worker.

- **Bug Fixes**
  - Admin-gated high‑risk routes: all `api/v1/claude_sdk/*`, feature flags CRUD, and `POST /api/v1/catalog/cache/clear`.
  - Secured WordPress writes: `/api/v1/wordpress/sync` now uses `service_or_user_auth` (Bearer JWT or `X-Service-Token`); queue worker sends the header.
  - Webhooks hardened: WooCommerce HMAC verified as base64 and fail‑closed when `WC_WEBHOOK_SECRET` is unset; Stripe webhooks reject without `STRIPE_WEBHOOK_SECRET` outside dev.
  - SSRF closed: unconditional URL validation in brand asset ingest and shared `services/ml/gemini_client.py`; block internal/metadata hosts and non‑HTTP schemes; allowlist R2 object key extensions.
  - API key deps fail‑closed: `elite_studio` and `api/v2/*` reject when `API_KEY` is missing outside dev.
  - Catalog Q&A guarded: keep `/api/v1/catalog/answer` and `/answer/stream` public but rate‑limit per IP at 20 req/min; docs clarified. Also clamped WordPress MCP publishes to `draft`.

- **Migration**
  - Set `WORDPRESS_SYNC_SERVICE_TOKEN` in the backend (`devskyy-backend`) and the queue worker env (same value).

<sup>Written for commit 569ddc8b4754b7b175e8f6b4d0e69485b65f7175. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened authentication for administrative tools, feature flags, WordPress operations, and cache management.
  * Added secure service-token support for WordPress synchronization.
  * Improved API key and webhook validation, rejecting unconfigured credentials in production environments.
  * Added protection against unsafe image and asset URLs.
* **WordPress**
  * Pages created through the integration are now always saved as drafts.
  * Webhook signature verification now uses stricter validation.
* **Performance**
  * Added endpoint-specific rate limits for catalog question-and-answer requests.
* **Reliability**
  * Expanded automated coverage for authentication, webhooks, SSRF protection, and service-token access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->