### PR TITLE
fix(skills): sync .claude adversarial-planning wf.js to canonical (per-run mktemp)

### DIFF
--- a/.claude/skills/adversarial-planning/scripts/adversarial-planning.wf.js
+++ b/.claude/skills/adversarial-planning/scripts/adversarial-planning.wf.js
@@ -104,23 +104,24 @@ const REVIEW_SCHEMA = {
 // Prompt is written to a file and piped over stdin (never interpolated into the
 // shell command) so plan JSON with quotes can't break the call.
 function codexTurn(round, phase, sandbox, instruction, planObj, schema) {
-  const promptFile = `/tmp/codex-ap-${phase}-r${round}.txt`;
-  const outFile = `/tmp/codex-ap-${phase}-r${round}.json`;
-  // On the execution turn, capture the REAL diff (ground truth) — the skill's whole
-  // point is the planner reviews what actually changed, not Codex's self-report.
+  // Prompt + output live in a per-run mktemp dir (created by the relay subagent),
+  // piped over stdin so plan JSON with quotes can't break the shell command, and
+  // uniquely named so concurrent runs of this workflow never collide on /tmp.
   const diffStep =
     sandbox === "workspace-write"
-      ? `3b. Then run \`git diff --stat\` and append its output to codex_verbatim under a "--- git diff --stat ---" header, so the reviewer sees the real diff.\n`
+      ? `   Also run \`git diff --stat\` afterward and append its output to codex_verbatim under a "--- git diff --stat ---" header, so the reviewer sees the real diff.\n`
       : "";
   const relay =
     `You are a relay to a DIFFERENT model (Codex). Do exactly this, do not add your own judgment:\n` +
-    `1. Write this exact text to ${promptFile} (heredoc, no edits):\n` +
-    `<<<CODEX_PROMPT\n${instruction}\n\nPLAN (JSON):\n${JSON.stringify(planObj, null, 2)}\nCODEX_PROMPT\n` +
-    `2. Run: codex exec -m ${CODEX_MODEL} -s ${sandbox} --json -o ${outFile} < ${promptFile}\n` +
-    `3. Read ${outFile} (the -o file holds Codex's final message).\n` +
+    `1. Run the following as ONE Bash command so the same temp dir ("$d") is used throughout — a fresh dir per run, never a fixed /tmp path:\n` +
+    `   d="$(mktemp -d)"\n` +
+    `   cat > "$d/prompt.txt" <<'CODEX_PROMPT'\n${instruction}\n\nPLAN (JSON):\n${JSON.stringify(planObj, null, 2)}\nCODEX_PROMPT\n` +
+    `   codex exec -m ${CODEX_MODEL} -s ${sandbox} --json -o "$d/out.json" < "$d/prompt.txt"\n` +
+    `   cat "$d/out.json"\n` +
+    `2. The printed "$d/out.json" content is Codex's final message.\n` +
     diffStep +
-    `4. Return the structured fields, putting Codex's raw final message verbatim in codex_verbatim ` +
-    `and reading satisfied / specific_challenge from what CODEX actually said — not your opinion.\n` +
+    `3. Return the structured fields: put Codex's raw final message verbatim in codex_verbatim ` +
+    `and read satisfied / specific_challenge from what CODEX actually said — not your opinion.\n` +
     `If codex errors on the model string or reachability, put the exact error in codex_verbatim, ` +
     `set satisfied=false, and put the error in specific_challenge.`;
   return agent(relay, {


### PR DESCRIPTION
Closes the last drift in the adversarial-planning skill.

**Already on main** (via the skyyrose-suite plugin path): the dedupe (skill-root duplicate removed) + per-run `mktemp` temp-dir fix.

**Not on main until this PR**: the `.claude/skills/adversarial-planning/scripts/adversarial-planning.wf.js` copy was left stale (no per-run `mktemp` → `/tmp` path collision across concurrent workflow runs). This is the copy Claude Code actually loads for the project skill, so the bug was live there.

This PR byte-syncs it to the canonical `skyyrose-suite/plugins/skyyrose-core` scripts copy (identical blob `c624fac0`). One file, no other changes — built off `origin/main` (kept out of the diverged font-canon branch on purpose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the adversarial-planning workflow script under .claude to the canonical plugin version, adding per-run `mktemp` temp-dir isolation. Prevents /tmp collisions in concurrent runs and fixes the live bug in the script used by Claude Code.

- **Bug Fixes**
  - Replace fixed /tmp files with a per-run `mktemp` dir and single bash block; read output from "$d/out.json".
  - Aligns with the `skyyrose-suite/plugins/skyyrose-core` script; no other changes.

<sup>Written for commit e1667f65ea80bfbf6a60f0138be2348074ac6b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when relaying prompts and processing command output.
  * Prevented conflicts between concurrent runs by isolating temporary files.
  * Added a clear summary of workspace changes to the generated review output.
  * Ensured reported results accurately reflect the command’s actual response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->