### PR TITLE
fix(deploy): kill+reap theme-deploy subprocess on timeout

### DIFF
--- a/api/v1/wordpress_theme.py
+++ b/api/v1/wordpress_theme.py
@@ -85,12 +85,21 @@ async def deploy_theme(
             proc.communicate(), timeout=_DEPLOY_TIMEOUT_S
         )
     except TimeoutError:
-        logger.error("Theme deploy timed out after %ds", _DEPLOY_TIMEOUT_S)
+        logger.error("Theme deploy timed out after %ds; killing subprocess", _DEPLOY_TIMEOUT_S)
+        # wait_for cancelled communicate(): the pipe readers are in an
+        # indeterminate state, so kill + reap with wait() — never a second
+        # communicate() (can deadlock). Guard the race where the process
+        # already exited between the timeout and the kill.
+        try:
+            proc.kill()
+            await proc.wait()
+        except ProcessLookupError:
+            pass
         return {
             "success": False,
-            "returncode": -1,
+            "returncode": proc.returncode if proc.returncode is not None else -1,
             "environment": request.environment,
-            "message": f"deploy timed out after {_DEPLOY_TIMEOUT_S}s",
+            "message": f"deploy timed out after {_DEPLOY_TIMEOUT_S}s (subprocess killed)",
             "log_tail": [],
         }
     except FileNotFoundError as exc:

--- a/tests/api/test_wordpress_theme_wire.py
+++ b/tests/api/test_wordpress_theme_wire.py
@@ -135,3 +135,30 @@ class TestDeployThemeWire:
         # log_tail should contain lines from stdout/stderr
         assert isinstance(body["log_tail"], list)
         assert len(body["log_tail"]) > 0
+
+    def test_deploy_timeout_kills_and_reaps_subprocess(self) -> None:
+        """On timeout the subprocess is killed + reaped (no orphan); returncode from proc."""
+        fake_proc = _make_fake_proc(returncode=-9, stdout=b"")
+        fake_proc.kill = MagicMock()
+        fake_proc.wait = AsyncMock(return_value=-9)
+
+        # communicate() raises TimeoutError → exercises the handler's timeout
+        # branch without patching wait_for (avoids a dangling unawaited coroutine).
+        fake_proc.communicate = AsyncMock(side_effect=TimeoutError)
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = fake_proc
+
+            client = _build_client()
+            resp = client.post(
+                "/wordpress/theme/deploy",
+                json={"environment": "production", "backup_first": True},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+        assert body["returncode"] == -9
+        assert "killed" in body["message"].lower()
+        # The subprocess MUST be killed + reaped, not left orphaned
+        fake_proc.kill.assert_called_once()
+        fake_proc.wait.assert_awaited_once()


### PR DESCRIPTION
## Summary

The `/wordpress/theme/deploy` endpoint's timeout handler (`api/v1/wordpress_theme.py`) logged the timeout and returned an error response, but never killed or reaped the subprocess. `asyncio.wait_for` only cancels the *await* on `proc.communicate()` — the underlying subprocess (and its pipe readers, left in an indeterminate state) keeps running, risking a zombie/orphan process and a deadlock if anything later tries a second `communicate()`.

This kills + reaps the subprocess on timeout:
- `proc.kill()` + `await proc.wait()` (never a second `communicate()`, which can deadlock on an already-cancelled read)
- Guards `ProcessLookupError` for the race where the process already exited between the timeout firing and the kill call
- Reports the real `proc.returncode` (falling back to `-1` only if still `None`) instead of a hardcoded `-1`
- Message now notes the subprocess was killed

Includes the matched regression test (`test_deploy_timeout_kills_and_reaps_subprocess`) asserting `proc.kill()` is called and `proc.wait()` is awaited on the timeout path.

This recovers a verified fix that was stranded on a stale local branch (`feat/collection-sot-guard`) — that branch's unrelated content (SOT-guard test wires) already landed on `main` separately; only this subprocess-cleanup fix + its test were novel and are extracted here.

## Test plan

- [x] `black --check` / `isort --check-only` / `ruff check` on both changed files — clean
- [x] `mypy api/v1/wordpress_theme.py` — no issues
- [x] `pytest tests/api/test_wordpress_theme_wire.py -v` — 4/4 passed (3 existing + new timeout regression test)
- [x] `pytest tests/scripts/test_deploy_theme.py -v` — 31/31 passed (unaffected, no regression)
- [x] `scripts/ci-local.sh lint python-tests security` — passes on this diff; whole-repo `black`/`isort`/`mypy`/`pip-audit` failures are pre-existing (unrelated files last touched 2026-06-30 and 2026-04-29, not part of this diff) — GitHub Actions is billing-disabled repo-wide so this local mirror is the gate
- [x] No production deploy was executed — the deploy script itself is fully mocked in tests, never invoked

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `/wordpress/theme/deploy` timeout path by killing and reaping the subprocess to prevent zombies and deadlocks. Also returns the real `returncode` and clarifies the error message.

- **Bug Fixes**
  - On timeout: call `proc.kill()` then `await proc.wait()`; never call `communicate()` again.
  - Guard `ProcessLookupError` if the process exits between timeout and kill.
  - Return `proc.returncode` (fallback `-1`); message notes the subprocess was killed.
  - Adds regression test `test_deploy_timeout_kills_and_reaps_subprocess`.

<sup>Written for commit 1a4a1e9e062ca656e1ec8772af9f8f4eba3f08c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment timeout handling by terminating and reaping timed-out processes.
  * Timeout responses now include the actual process return code when available and a clearer status message.
  * Prevented orphaned deployment processes after timeouts.

* **Tests**
  * Added coverage verifying process termination and cleanup during deployment timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->