### PR TITLE
fix(async): wrap blocking sync I/O in asyncio.to_thread (P1 #18)

### DIFF
--- a/monitoring/stream_processor.py
+++ b/monitoring/stream_processor.py
@@ -184,11 +184,11 @@ class StreamProcessor:
         last_flush = time.monotonic()
 
         while self._running:
-            # Yield to event loop to allow other tasks to run
-            await asyncio.sleep(0)
-
             try:
-                msg = self._consumer.poll(self.poll_timeout)
+                # consumer.poll() is synchronous and blocks for up to poll_timeout
+                # (default 1.0s). Dispatch to a thread pool so the event loop
+                # remains responsive to other coroutines during the wait.
+                msg = await asyncio.to_thread(self._consumer.poll, self.poll_timeout)
             except Exception as exc:
                 logger.error(f"Kafka poll error: {exc}")
                 await asyncio.sleep(1.0)

--- a/services/notifications/email_notifications.py
+++ b/services/notifications/email_notifications.py
@@ -15,6 +15,7 @@ Version: 1.0.0
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import smtplib
@@ -391,6 +392,18 @@ class EmailNotificationService:
         """Check if email service is properly configured."""
         return self._config.is_configured
 
+    def _send_smtp_sync(self, msg: MIMEMultipart, to: list[str]) -> None:
+        """Synchronous SMTP send — must only be called via asyncio.to_thread.
+
+        Raises:
+            smtplib.SMTPException: on connection or authentication failure.
+        """
+        with smtplib.SMTP(self._config.smtp_host, self._config.smtp_port) as server:
+            if self._config.use_tls:
+                server.starttls()
+            server.login(self._config.smtp_user, self._config.smtp_password)
+            server.sendmail(self._config.from_email, to, msg.as_string())
+
     async def send_email(
         self,
         to: list[str],
@@ -430,12 +443,9 @@ class EmailNotificationService:
             msg.attach(MIMEText(text_body, "plain"))
             msg.attach(MIMEText(html_body, "html"))
 
-            # Send
-            with smtplib.SMTP(self._config.smtp_host, self._config.smtp_port) as server:
-                if self._config.use_tls:
-                    server.starttls()
-                server.login(self._config.smtp_user, self._config.smtp_password)
-                server.sendmail(self._config.from_email, to, msg.as_string())
+            # Send — SMTP is synchronous; dispatch to thread pool to avoid
+            # blocking the event loop during connection + TLS + auth + send.
+            await asyncio.to_thread(self._send_smtp_sync, msg, to)
 
             logger.info(
                 f"Sent email to {len(to)} recipients: {subject}",

--- a/services/three_d/huggingface_provider.py
+++ b/services/three_d/huggingface_provider.py
@@ -16,6 +16,7 @@ Version: 1.0.0
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import shutil
@@ -183,7 +184,8 @@ class HuggingFaceProvider:
 
         client = Client(HUGGINGFACE_SPACES[HuggingFaceModel.TRELLIS])
 
-        result = client.predict(
+        result = await asyncio.to_thread(
+            client.predict,
             image=handle_file(image_path),
             multiimages=[],
             seed=self.config.seed,
@@ -232,7 +234,8 @@ class HuggingFaceProvider:
 
         client = Client(HUGGINGFACE_SPACES[HuggingFaceModel.TRIPOSR])
 
-        result = client.predict(
+        result = await asyncio.to_thread(
+            client.predict,
             image=handle_file(image_path),
             mc_resolution=256,
             api_name="/run",
@@ -272,7 +275,8 @@ class HuggingFaceProvider:
 
         client = Client(HUGGINGFACE_SPACES[HuggingFaceModel.SHAP_E])
 
-        result = client.predict(
+        result = await asyncio.to_thread(
+            client.predict,
             prompt=prompt,
             seed=self.config.seed,
             guidance_scale=15.0,

--- a/tests/analytics/test_stream_processor.py
+++ b/tests/analytics/test_stream_processor.py
@@ -6,6 +6,8 @@ Tests event dispatching and aggregation logic directly by calling
 process_event() — no Kafka connection required.
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from monitoring.stream_processor import AnalyticsState, StreamProcessor
@@ -192,3 +194,51 @@ class TestStreamProcessorAggregations:
         assert d["page_views"] == {"page1": 5}
         assert d["events_processed"] == 10
         assert isinstance(d, dict)
+
+
+# =============================================================================
+# Regression Tests: #18c — consumer.poll() blocks event loop for 1.0s default
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestStreamProcessorPollAsync:
+    """
+    Regression tests for P1 finding #18c.
+
+    StreamProcessor._run_loop calls consumer.poll(1.0) synchronously inside an
+    async method, blocking the event loop for up to 1 second per iteration.
+    The fix wraps consumer.poll() in asyncio.to_thread.
+    """
+
+    async def test_poll_dispatched_via_to_thread(self) -> None:
+        """consumer.poll() must be dispatched via asyncio.to_thread, not called inline."""
+        import asyncio
+
+        from monitoring.stream_processor import StreamProcessor
+
+        processor = StreamProcessor()
+        processor._running = True
+
+        # Mock consumer that returns None on poll (no messages)
+        mock_consumer = MagicMock()
+        mock_consumer.poll.return_value = None
+        processor._consumer = mock_consumer
+
+        run_count = 0
+        original_to_thread = asyncio.to_thread
+
+        async def _to_thread_spy(func, *args, **kwargs):
+            nonlocal run_count
+            run_count += 1
+            # Stop the loop after first iteration
+            processor._running = False
+            return await original_to_thread(func, *args, **kwargs)
+
+        with patch("monitoring.stream_processor.asyncio.to_thread", side_effect=_to_thread_spy):
+            await processor._run_loop()
+
+        assert run_count >= 1, (
+            "asyncio.to_thread was never called — consumer.poll() is still blocking the event loop"
+        )

--- a/tests/analytics/test_stream_processor.py
+++ b/tests/analytics/test_stream_processor.py
@@ -239,6 +239,6 @@ class TestStreamProcessorPollAsync:
         with patch("monitoring.stream_processor.asyncio.to_thread", side_effect=_to_thread_spy):
             await processor._run_loop()
 
-        assert run_count >= 1, (
-            "asyncio.to_thread was never called — consumer.poll() is still blocking the event loop"
-        )
+        assert (
+            run_count >= 1
+        ), "asyncio.to_thread was never called — consumer.poll() is still blocking the event loop"

--- a/tests/services/test_email_notifications.py
+++ b/tests/services/test_email_notifications.py
@@ -8,7 +8,7 @@ Target coverage: 70%+
 from __future__ import annotations
 
 import smtplib
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from services.notifications.email_notifications import (
@@ -727,3 +727,67 @@ class TestTemplateRendering:
         assert "20" in subject
         assert "20" in html
         assert "7" in html
+
+
+# =============================================================================
+# Regression Tests: #18b — smtplib sync I/O in async send_email
+# =============================================================================
+
+
+@pytest.mark.asyncio
+class TestSendEmailAsyncIO:
+    """
+    Regression tests for P1 finding #18b.
+
+    send_email() is async but used smtplib.SMTP synchronously, blocking the
+    event loop during every email send. The fix wraps the SMTP block in
+    asyncio.to_thread.
+    """
+
+    async def test_send_email_dispatches_smtp_via_to_thread(
+        self, email_config: EmailConfig
+    ) -> None:
+        """send_email must route the SMTP send through asyncio.to_thread."""
+        import asyncio
+
+        service = EmailNotificationService(email_config)
+
+        with (
+            patch(
+                "services.notifications.email_notifications.asyncio.to_thread",
+                new_callable=AsyncMock,
+            ) as mock_to_thread,
+        ):
+            mock_to_thread.return_value = None
+            result = await service.send_email(
+                to=["test@example.com"],
+                subject="Test Subject",
+                html_body="<p>Test</p>",
+                text_body="Test",
+            )
+
+        # to_thread must have been called once (for the SMTP dispatch)
+        mock_to_thread.assert_called_once()
+        assert result is True
+
+    async def test_send_email_smtp_error_via_to_thread_returns_false(
+        self, email_config: EmailConfig
+    ) -> None:
+        """Exceptions raised inside to_thread propagate and are caught, returning False."""
+        import asyncio
+
+        service = EmailNotificationService(email_config)
+
+        with patch(
+            "services.notifications.email_notifications.asyncio.to_thread",
+            new_callable=AsyncMock,
+            side_effect=smtplib.SMTPException("connection refused"),
+        ):
+            result = await service.send_email(
+                to=["test@example.com"],
+                subject="Test",
+                html_body="<p>body</p>",
+                text_body="body",
+            )
+
+        assert result is False

--- a/tests/services/test_email_notifications.py
+++ b/tests/services/test_email_notifications.py
@@ -748,8 +748,6 @@ class TestSendEmailAsyncIO:
         self, email_config: EmailConfig
     ) -> None:
         """send_email must route the SMTP send through asyncio.to_thread."""
-        import asyncio
-
         service = EmailNotificationService(email_config)
 
         with (
@@ -774,8 +772,6 @@ class TestSendEmailAsyncIO:
         self, email_config: EmailConfig
     ) -> None:
         """Exceptions raised inside to_thread propagate and are caught, returning False."""
-        import asyncio
-
         service = EmailNotificationService(email_config)
 
         with patch(

--- a/tests/services/test_three_d_providers.py
+++ b/tests/services/test_three_d_providers.py
@@ -1459,3 +1459,85 @@ class TestErrorClasses:
 
         assert error.timeout_seconds == 300.0
         assert error.retryable is True  # Timeouts are always retryable
+
+
+# =============================================================================
+# Regression Tests: #18a — Sync I/O in Async HuggingFace Methods
+# =============================================================================
+
+
+class TestHuggingFaceAsyncIO:
+    """
+    Regression tests for P1 finding #18a.
+
+    All three Gradio predict calls (_run_trellis, _run_triposr, _run_shap_e)
+    must be dispatched via asyncio.to_thread — not called synchronously in the
+    async method body, which would block the event loop for the full generation
+    duration (often 30-120 seconds).
+    """
+
+    @pytest.fixture
+    def provider(self, mock_huggingface_config):
+        from services.three_d.huggingface_provider import HuggingFaceProvider
+
+        return HuggingFaceProvider(mock_huggingface_config)
+
+    @pytest.mark.asyncio
+    async def test_run_trellis_dispatches_predict_via_to_thread(self, provider, tmp_path):
+        """_run_trellis must use asyncio.to_thread for client.predict()."""
+        import asyncio
+
+        fake_glb = tmp_path / "model.glb"
+        fake_glb.write_bytes(b"glb")
+
+        mock_client = MagicMock()
+        mock_client.predict.return_value = (
+            {"video": "info"},
+            str(fake_glb),
+            str(fake_glb),
+        )
+
+        with (
+            patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_to_thread,
+            patch("gradio_client.Client", return_value=mock_client),
+            patch("gradio_client.handle_file", return_value="handle"),
+        ):
+            await provider._run_trellis(str(fake_glb), "corr-001")
+            mock_to_thread.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_triposr_dispatches_predict_via_to_thread(self, provider, tmp_path):
+        """_run_triposr must use asyncio.to_thread for client.predict()."""
+        import asyncio
+
+        fake_mesh = tmp_path / "model.obj"
+        fake_mesh.write_bytes(b"obj")
+
+        mock_client = MagicMock()
+        mock_client.predict.return_value = (str(fake_mesh),)
+
+        with (
+            patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_to_thread,
+            patch("gradio_client.Client", return_value=mock_client),
+            patch("gradio_client.handle_file", return_value="handle"),
+        ):
+            await provider._run_triposr(str(fake_mesh), "corr-002")
+            mock_to_thread.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_shap_e_dispatches_predict_via_to_thread(self, provider, tmp_path):
+        """_run_shap_e must use asyncio.to_thread for client.predict()."""
+        import asyncio
+
+        fake_mesh = tmp_path / "model.obj"
+        fake_mesh.write_bytes(b"obj")
+
+        mock_client = MagicMock()
+        mock_client.predict.return_value = (str(fake_mesh),)
+
+        with (
+            patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_to_thread,
+            patch("gradio_client.Client", return_value=mock_client),
+        ):
+            await provider._run_shap_e("a 3D hooded sweatshirt", "corr-003")
+            mock_to_thread.assert_called_once()


### PR DESCRIPTION
## Summary

Wraps three blocking synchronous I/O calls in `asyncio.to_thread` so they no longer stall the event loop:

- `services/notifications/email_notifications.py` — SMTP send (`smtplib.SMTP` connect + STARTTLS + login + `sendmail`) was running synchronously inside an `async def`. Extracted into `_send_smtp_sync()` and dispatched via `await asyncio.to_thread(self._send_smtp_sync, msg, to)`.
- `services/three_d/huggingface_provider.py` — three `client.predict(...)` Gradio-client calls (image-to-3D, multiview, text-to-image generation) were synchronous blocking calls inside async methods. Each is now dispatched via `await asyncio.to_thread(client.predict, ...)`.
- `monitoring/stream_processor.py` — `self._consumer.poll(self.poll_timeout)` (Kafka consumer poll, blocks up to `poll_timeout`, default 1.0s) is now dispatched via `await asyncio.to_thread(...)` instead of a synchronous call preceded by an `asyncio.sleep(0)` yield.

Tests added/extended for each: `tests/services/test_email_notifications.py`, `tests/services/test_three_d_providers.py`, `tests/analytics/test_stream_processor.py` — each asserts `asyncio.to_thread` is actually invoked (not just that the call succeeds), so a regression back to inline blocking I/O would fail the test.

This recovers a verified P1 correctness fix (finding #18) that was implemented and tested on a local branch (`fix/p1-wave2-async-blocking-io`) but never opened as a PR and never merged — confirmed `origin/main` has zero `to_thread` usages in either source file prior to this PR. Also includes one style-only commit fixing an assert's formatting for the currently pinned `black==26.5.1` (the original commit was authored against an older black version).

## Test plan

- [x] `pytest tests/services/test_email_notifications.py tests/services/test_three_d_providers.py tests/analytics/test_stream_processor.py -v` — 130 passed
- [x] `ruff check` / `black --check` / `isort --check-only` on all 6 changed files — clean
- [x] `mypy` on the 3 changed source files — `Success: no issues found in 3 source files`
- [x] Repo pre-commit hook (full mypy across 1516 files + fast unit-test suite) — passed on commit
- [x] `bandit` security scan — 0 HIGH findings
- [ ] GitHub Actions CI — repo-wide Actions are billing-disabled; verified via local CI mirror (`scripts/ci-local.sh`) instead. Remaining `ci-local.sh` red items (whole-repo `black`/`mypy`/`pytest`/`pip-audit`) are pre-existing failures in files untouched by this PR (verified against `origin/main` content directly) — noted in PR thread if asked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents event loop stalls by moving blocking sync I/O to `asyncio.to_thread`. Keeps email sends, HuggingFace predictions, and Kafka polling non-blocking. Addresses P1 #18.

- **Bug Fixes**
  - Email: wrap `smtplib.SMTP` connect/TLS/login/send in `await asyncio.to_thread(self._send_smtp_sync, ...)`.
  - 3D provider: dispatch `gradio_client.Client.predict(...)` via `await asyncio.to_thread(...)` in Trellis, TRIPOSR, and Shap-E paths.
  - Monitoring: call Kafka `consumer.poll(self.poll_timeout)` via `await asyncio.to_thread(...)` and remove the no-op `await asyncio.sleep(0)`.
  - Tests: add regression tests that assert `asyncio.to_thread` is invoked for each site to prevent future blocking regressions.

<sup>Written for commit 632d0089ee1d32f698eed91629d13dfbfb2c73a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved responsiveness during Kafka message polling.
  * Prevented email delivery from blocking other application activity.
  * Improved responsiveness during 3D model generation.

* **Bug Fixes**
  * Reduced the risk of delays or stalls caused by long-running background operations.

* **Tests**
  * Added regression coverage to verify asynchronous processing and error handling across monitoring, email, and 3D generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->