### PR TITLE
fix(mypy): exclude devskyy-sdk-app — resolve duplicate-module 'tools' error

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -42,6 +42,7 @@ exclude = (?x)(
     | vendor/.*
     | prototypes/.*
     | agents/devskyy-a2a/.*
+    | devskyy-sdk-app/.*  # MCP server example app — conflicts with tools/ package
   )
 
 # Relaxed mode for non-production code


### PR DESCRIPTION
One-line `mypy.ini` exclude that removes the recurring `Duplicate module named "tools" (also at ./devskyy-sdk-app/tools.py)` error hit on every whole-repo mypy run this cycle. Verified: reproduced on main (1 error), gone with this change (0). Recovered from the stranded `feat/collection-sot-guard` branch. No code touched — config only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Excludes `devskyy-sdk-app` from `mypy` in `mypy.ini` to fix the “Duplicate module named 'tools'” error from `devskyy-sdk-app/tools.py` colliding with the top-level `tools` package. Config-only change that removes noisy failures in whole-repo type checks.

<sup>Written for commit 2516eaa24f5b7b354d0fd64c14f353dc57ae365b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static type-checking configuration to exclude a conflicting application path.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->