### PR TITLE
fix: eliminate macOS fork-path SIGSEGV in test subprocesses (bug-263/264)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,9 +23,50 @@ if sys.platform == "darwin":
     # PEP 446: Python-created fds are CLOEXEC/non-inheritable regardless.
     # Callers that pass close_fds/preexec_fn/pass_fds explicitly are untouched
     # (they opt into the fork path knowingly).
+    #
+    # Third layer (bug-263 follow-up): close_fds=False is necessary but NOT
+    # sufficient. CPython's own posix_spawn fast-path gate in
+    # subprocess.py:_execute_child additionally requires
+    # `os.path.dirname(executable)` to be non-empty — i.e. the executable must
+    # already be an absolute/relative PATH, not a bare command name. Every
+    # `subprocess.run(["git", ...])` / `["bash", ...])` call (the overwhelming
+    # majority in this repo — git, bash, npm, shellcheck) passes a bare name
+    # resolved via $PATH, so `os.path.dirname("git") == ""` and CPython
+    # silently falls through to the fork() path regardless of close_fds.
+    # Verified empirically: importing agents.analytics_agent (pulls in
+    # numpy/scipy/sklearn/torch transitively via ml_module) is enough to arm
+    # a fork-unsafe framework; a subsequent bare `["git", "--version"]` call
+    # then SIGSEGVs (-11) even with close_fds=False, while the identical call
+    # with `executable=shutil.which("git")` returns 0. Resolve bare names to
+    # an absolute path via shutil.which so the fast path actually engages;
+    # Popen still presents the original argv[0] to the child, so behavior is
+    # unchanged for callers. shell=True is left alone — CPython already
+    # defaults its `executable` to /bin/sh (absolute) in that case.
+    import shutil as _shutil
     import subprocess as _subprocess
 
     _orig_popen_init = _subprocess.Popen.__init__
+
+    def _resolve_bare_executable(args, kwargs):  # type: ignore[no-untyped-def]
+        if kwargs.get("shell") or kwargs.get("executable") is not None:
+            return
+        if len(args) >= 3:  # executable passed positionally (3rd positional arg)
+            return
+        cmd = kwargs["args"] if "args" in kwargs else (args[0] if args else None)
+        if isinstance(cmd, (list, tuple)) and cmd:
+            prog = cmd[0]
+        elif isinstance(cmd, (str, bytes, os.PathLike)):
+            prog = cmd
+        else:
+            return
+        prog = os.fspath(prog) if isinstance(prog, os.PathLike) else prog
+        if not isinstance(prog, str) or os.path.dirname(prog):
+            return  # already absolute/relative, or not a plain string name
+        env = kwargs.get("env")
+        search_path = env.get("PATH") if env is not None else None
+        resolved = _shutil.which(prog, path=search_path)
+        if resolved:
+            kwargs["executable"] = resolved
 
     def _spawn_friendly_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         if (
@@ -35,6 +76,7 @@ if sys.platform == "darwin":
             and not kwargs.get("pass_fds")
         ):
             kwargs["close_fds"] = False
+        _resolve_bare_executable(args, kwargs)
         _orig_popen_init(self, *args, **kwargs)
 
     _subprocess.Popen.__init__ = _spawn_friendly_init  # type: ignore[method-assign]

--- a/conftest.py
+++ b/conftest.py
@@ -63,7 +63,13 @@ if sys.platform == "darwin":
         if not isinstance(prog, str) or os.path.dirname(prog):
             return  # already absolute/relative, or not a plain string name
         env = kwargs.get("env")
-        search_path = env.get("PATH") if env is not None else None
+        if env is None:
+            search_path = None  # inherit parent PATH — matches exec behavior
+        else:
+            # execvpe semantics: a PATH-less env searches os.defpath, NOT the
+            # parent's PATH — shutil.which(path=None) would wrongly consult
+            # os.environ['PATH'] for callers that intentionally scrub PATH.
+            search_path = env.get("PATH", os.defpath)
         resolved = _shutil.which(prog, path=search_path)
         if resolved:
             kwargs["executable"] = resolved

--- a/tests/api/test_brand_assets.py
+++ b/tests/api/test_brand_assets.py
@@ -170,6 +170,7 @@ class TestBulkIngestion:
         assert data["total"] == 3
 
     @pytest.mark.asyncio
+    @pytest.mark.timeout(30)  # 100-asset ingest sits at ~10s; flakes at the global 10s cap
     async def test_bulk_ingest_max_100_assets(self, client: AsyncClient) -> None:
         """Should accept up to 100 assets."""
         assets = [

--- a/tests/scripts/test_check_catalog_duplicates.py
+++ b/tests/scripts/test_check_catalog_duplicates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -38,7 +39,7 @@ def test_cli_exits_zero_when_no_duplicates(tmp_path: Path) -> None:
         [sys.executable, str(SCRIPT), "--embeddings", str(embeds), "--threshold", "0.98"],
         capture_output=True,
         text=True,
-        cwd=str(REPO),
+        env={**os.environ, "PYTHONPATH": str(REPO)},
     )
     assert result.returncode == 0, result.stderr
     assert "no duplicates" in result.stdout.lower()
@@ -50,7 +51,7 @@ def test_cli_exits_one_when_duplicates_found(tmp_path: Path) -> None:
         [sys.executable, str(SCRIPT), "--embeddings", str(embeds), "--threshold", "0.98"],
         capture_output=True,
         text=True,
-        cwd=str(REPO),
+        env={**os.environ, "PYTHONPATH": str(REPO)},
     )
     assert result.returncode == 1, result.stderr
     assert "x-1" in result.stdout and "x-2" in result.stdout

--- a/tests/scripts/test_nano_banana_alignment.py
+++ b/tests/scripts/test_nano_banana_alignment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -14,7 +15,9 @@ def test_help_lists_score_alignment_flag() -> None:
         [sys.executable, str(REPO / "scripts" / "nano-banana-run.py"), "generate", "--help"],
         capture_output=True,
         text=True,
-        cwd=str(REPO),
+        # no cwd= — it forces macOS subprocess onto the crash-prone fork()
+        # path (bug-263); the script is invoked by absolute path.
+        env={**os.environ, "PYTHONPATH": str(REPO)},
     )
     assert result.returncode == 0, result.stderr
     assert "--score-alignment" in result.stdout

--- a/tests/test_asset_hub.py
+++ b/tests/test_asset_hub.py
@@ -289,9 +289,9 @@ def test_pending_none_in_resolve():
         sku = entry.get("sku")
         face = entry.get("face", "front")
         if sku:
-            assert hub.resolve(sku, face) is None, (
-                f"Pending entry {entry['_id']} incorrectly resolved to a path"
-            )
+            assert (
+                hub.resolve(sku, face) is None
+            ), f"Pending entry {entry['_id']} incorrectly resolved to a path"
 
 
 # ---------------------------------------------------------------------------
@@ -315,9 +315,9 @@ def test_verify_integrity_problem_count_matches_unpromoted():
         and (not e.get("path") or not (hub.HUB_DIR / e["path"]).exists())
     )
     problems = hub.verify_integrity()
-    assert len(problems) == expected, (
-        f"Expected {expected} integrity problems, got {len(problems)}:\n" + "\n".join(problems)
-    )
+    assert (
+        len(problems) == expected
+    ), f"Expected {expected} integrity problems, got {len(problems)}:\n" + "\n".join(problems)
 
 
 def test_verify_integrity_problems_are_strings():

--- a/tests/test_gitignore_claude_tracking.py
+++ b/tests/test_gitignore_claude_tracking.py
@@ -61,8 +61,9 @@ def test_critical_claude_path_is_not_gitignored(relative_path: str) -> None:
     match this path — otherwise a fresh worktree or clone would never see
     it, even though the currently-checked-out copy is tracked fine."""
     result = subprocess.run(
-        ["git", "check-ignore", "--no-index", "-q", relative_path],
-        cwd=ROOT,
+        # git -C instead of cwd=: cwd= forces the fork() path on macOS, where
+        # fork after Network.framework arming SIGSEGVs the child (bug-263).
+        ["git", "-C", str(ROOT), "check-ignore", "--no-index", "-q", relative_path],
         capture_output=True,
         check=False,
     )
@@ -79,8 +80,7 @@ def test_critical_claude_path_is_tracked(relative_path: str) -> None:
     """The path must actually be committed to git — existing only on disk
     in this worktree is exactly what made the engine invisible elsewhere."""
     result = subprocess.run(
-        ["git", "ls-files", "--error-unmatch", relative_path],
-        cwd=ROOT,
+        ["git", "-C", str(ROOT), "ls-files", "--error-unmatch", relative_path],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/test_ml_optional.py
+++ b/tests/test_ml_optional.py
@@ -8,6 +8,7 @@ with an empty sys.modules, so the blocker is authoritative there.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -85,7 +86,10 @@ def test_main_enterprise_imports_without_ml_libs() -> None:
     """`import main_enterprise` must succeed with zero torch-class ML libs importable."""
     result = subprocess.run(
         [sys.executable, "-c", _BLOCKER_SCRIPT],
-        cwd=REPO_ROOT,
+        # PYTHONPATH instead of cwd: cwd= forces subprocess onto the fork()
+        # path on macOS, where fork after Network.framework arming SIGSEGVs
+        # the child (bug-263); posix_spawn requires cwd=None.
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
         capture_output=True,
         text=True,
         timeout=60,
@@ -105,7 +109,7 @@ def test_encoders_fail_loud_with_ml_extra_message() -> None:
     use time)."""
     result = subprocess.run(
         [sys.executable, "-c", _FAIL_LOUD_SCRIPT],
-        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
         capture_output=True,
         text=True,
         timeout=60,

--- a/tests/test_sot_assets_tracked.py
+++ b/tests/test_sot_assets_tracked.py
@@ -20,7 +20,7 @@ IMG_RE = re.compile(r"assets/images/[^\"',|\s]+\.(?:webp|avif|jpe?g|png|gif|svg)
 
 def _tracked_files() -> set[str]:
     out = subprocess.run(
-        ["git", "ls-files", "-z"], cwd=REPO, capture_output=True, text=True, check=True
+        ["git", "-C", str(REPO), "ls-files", "-z"], capture_output=True, text=True, check=True
     ).stdout
     return {p for p in out.split("\0") if p}
 

--- a/tests/test_sot_no_adhoc_imagery.py
+++ b/tests/test_sot_no_adhoc_imagery.py
@@ -52,8 +52,9 @@ ALLOWLIST: set[str] = set()
 @functools.lru_cache(maxsize=1)
 def _tracked_files() -> tuple[str, ...]:
     out = subprocess.run(
-        ["git", "ls-files", "*.ts", "*.tsx", "*.js", "*.jsx"],
-        cwd=REPO,
+        # git -C instead of cwd= — cwd forces macOS subprocess onto the
+        # crash-prone fork() path (bug-263).
+        ["git", "-C", str(REPO), "ls-files", "*.ts", "*.tsx", "*.js", "*.jsx"],
         capture_output=True,
         text=True,
         check=True,


### PR DESCRIPTION
## Problem

Fork children of the multi-threaded pytest parent die pre-exec with SIGSEGV in Apple's Network.framework atfork handler (`nw_settings_child_has_forked → NEFlowDirectorDestroy → _os_log_preferences_refresh`) on macOS 26.4 + CPython 3.14.3. 33 crash reports across 2026-07-15/16, all with the identical `subprocess_fork_exec` mechanism. Apple DTS position (dev forums thread 737464): `fork()` after any higher-level framework arming is unsupported — `posix_spawn` is the only reliable fix, since it is a syscall and atfork handlers never run in the child.

PR #750 shipped the `close_fds=False` conftest default, but CPython's posix_spawn fast-path gate (`subprocess.py:1859-1873`, 15 clauses) still fell through to `fork()` for two dominant call shapes:

1. **`cwd=` kwarg** — macOS CPython cannot chdir via posix_spawn; any `cwd=` forces fork.
2. **Bare $PATH executables** — `os.path.dirname("git") == ""` fails the gate, so `subprocess.run(["git", ...])` (the overwhelming majority of calls) forked regardless of close_fds.

## Fix

- **`cwd=` removal** (6 test files): git invocations → `git -C <root>`; python-script invocations → absolute script path + `PYTHONPATH` env.
- **Bare-executable resolution** (conftest): resolve bare argv[0] via `shutil.which` into `kwargs['executable']` — argv presented to the child is unchanged; `shell=True` and explicit `executable=`/`preexec_fn`/`pass_fds`/`close_fds` callers untouched.

## Verification

- Bare `["git", "--version"]` routes through `Popen._posix_spawn` (instrumented, on this branch).
- 21/21 tests across the six edited files pass.
- Full-suite instrumented audit (`subprocess._fork_exec` wrapped to log every fork): **zero fork-path calls across the entire suite**; no new crash reports during the run.
- Crash-rate timeline across fix layers: 16.3/hr → 2.75/hr → isolated cluster → silence.

## Test plan
- [x] 21/21 affected tests green
- [x] Instrumented full-suite run: 0 fork-path calls
- [x] `mypy` + `ruff` + `black` clean (pre-commit gauntlet)
- [ ] Post-merge: new agent worktrees inherit the fix (tonight's recurring-crasher class ends)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forces `posix_spawn` for test subprocesses on macOS to eliminate fork-path SIGSEGVs (bugs 263/264). Removes `cwd=` usage and resolves bare executables so CPython’s fast path always runs.

- **Bug Fixes**
  - conftest: resolve bare `argv[0]` via `shutil.which` into `kwargs['executable']`; match `execvpe` PATH semantics when `env` is provided; skip when `shell=True` or `executable` is set; keep `close_fds=False`.
  - tests: replace `cwd=` with `git -C <repo>`; call Python scripts by absolute path and set `PYTHONPATH` in `env`.
  - tests: add `@pytest.mark.timeout(30)` to the 100-asset bulk-ingest case.
  - result: full suite takes the `posix_spawn` path only; affected tests pass; no new macOS crashes.

- **Refactors**
  - style: black-format `tests/test_asset_hub.py` to pass the `black --check` gate.

<sup>Written for commit 108a986723145d987f96fb2ea51ad3adf1ba8f68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

