### PR TITLE
chore(agents): re-land subagent model tiers (lost in chore-branch rebase)

### DIFF
--- a/.claude/agents/build-error-resolver.md
+++ b/.claude/agents/build-error-resolver.md
@@ -2,7 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist. Use PROACTIVELY when build fails or type errors occur. Fixes build/type errors only with minimal diffs, no architectural edits. Focuses on getting the build green quickly.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: sonnet
+model: haiku
 ---
 
 # Build Error Resolver

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Use this agent when you need to conduct comprehensive code reviews focusing on code quality, security vulnerabilities, and best practices.
 tools: Read, Write, Edit, Bash, Glob, Grep
+model: fable
 ---
 You are a senior code reviewer with expertise in identifying code quality issues, security vulnerabilities, and optimization opportunities across multiple programming languages. Your focus spans correctness, performance, maintainability, and security with emphasis on constructive feedback, best practices enforcement, and continuous improvement.
 

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -2,7 +2,7 @@
 name: security-reviewer
 description: Security vulnerability detection and remediation specialist. Use PROACTIVELY after writing code that handles user input, authentication, API endpoints, or sensitive data. Flags secrets, SSRF, injection, unsafe crypto, and OWASP Top 10 vulnerabilities.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: sonnet
+model: fable
 ---
 
 # Security Reviewer

--- a/skyyrose-suite/plugins/skyyrose-core/agents/build-error-resolver.md
+++ b/skyyrose-suite/plugins/skyyrose-core/agents/build-error-resolver.md
@@ -2,7 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist. Use PROACTIVELY when build fails or type errors occur. Fixes build/type errors only with minimal diffs, no architectural edits. Focuses on getting the build green quickly.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: sonnet
+model: haiku
 ---
 
 # Build Error Resolver

--- a/skyyrose-suite/plugins/skyyrose-qa/agents/code-reviewer.md
+++ b/skyyrose-suite/plugins/skyyrose-qa/agents/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Use this agent when you need to conduct comprehensive code reviews focusing on code quality, security vulnerabilities, and best practices.
 tools: Read, Write, Edit, Bash, Glob, Grep
+model: fable
 ---
 You are a senior code reviewer with expertise in identifying code quality issues, security vulnerabilities, and optimization opportunities across multiple programming languages. Your focus spans correctness, performance, maintainability, and security with emphasis on constructive feedback, best practices enforcement, and continuous improvement.
 

--- a/skyyrose-suite/plugins/skyyrose-qa/agents/security-reviewer.md
+++ b/skyyrose-suite/plugins/skyyrose-qa/agents/security-reviewer.md
@@ -2,7 +2,7 @@
 name: security-reviewer
 description: Security vulnerability detection and remediation specialist. Use PROACTIVELY after writing code that handles user input, authentication, API endpoints, or sensitive data. Flags secrets, SSRF, injection, unsafe crypto, and OWASP Top 10 vulnerabilities.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: sonnet
+model: fable
 ---
 
 # Security Reviewer


### PR DESCRIPTION
Recovers the agent model tiering dropped when `origin/chore/skill-font-canon-sync` was rebased by a concurrent session — #753 merged without commit `a69511712`, so on main `build-error-resolver` is still `sonnet` and the skyyrose-qa reviewers are unpinned.

Re-applied onto main's **current** file versions, **model line only** (nothing else touched):
- `code-reviewer`, `security-reviewer` → **fable** (project `.claude/agents` + `skyyrose-qa` plugin)
- `build-error-resolver` → **haiku** (project `.claude/agents` + `skyyrose-core` plugin)

6 files, +6/−4. (Global `~/.claude/agents` pins were never lost — they're local, not git-tracked. This restores the git-tracked plugin/project copies + cross-machine propagation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore agent model tiering lost during a rebase. Pins `code-reviewer` and `security-reviewer` to fable, and `build-error-resolver` to haiku, in `.claude/agents` and the `skyyrose-qa`/`skyyrose-core` plugin copies (model lines only).

<sup>Written for commit 2ab8e6acd5dcf37a34cb57a2c2139e9f843c3e40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, code review, and security review configurations to use revised AI models.
  * Applied these configuration updates consistently across the main project and plugin components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->