### PR TITLE
feat(ci): ci-sim.sh — simulated CI clone for local PR gating

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -2695,6 +2695,8 @@ WS7 wiring core — typed WordPress↔dashboard client. `auth-policy.ts`/`signat
 
 ## scripts/
 
+- `ci-local.sh` — scripts/ci-local.sh -- Offline mirror of ci.yml's six gating jobs (lint/python-tests/security/frontend/threejs/wordpress-theme); CI_LOCAL_ROOT overridable (~3500 tok)
+- `ci-sim.sh` — scripts/ci-sim.sh -- Simulated CI clone: fetches a PR's merge preview (refs/pull/N/merge) or any ref into a disposable worktree and runs ci-local.sh there; PASS/FAIL verdict (~1200 tok)
 - `__init__.py` (~0 tok)
 - `3D_GENERATION_STATUS.md` — 3D Generation Status - READY (API Key Required) (~1003 tok)
 - `add_love_hurts_and_logos_to_lora.py` — luxury_post_process, upscale_with_lanczos, detect_garment_type, generate_training_caption + 2 more (~3988 tok)

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -152,15 +152,31 @@ job_security() {
     _skip "security: bandit" "not installed — pip install bandit"
   fi
   if _have pip-audit; then
-    # Mirror ci.yml: same documented no-fix-available ignores. Add
-    # --skip-editable: the editable devskyy package isn't on PyPI and
-    # aborts --strict before any vulns are even reported.
+    # Mirror ci.yml's documented no-fix-available ignores. Keep this list in
+    # sync with .github/workflows/ci.yml's IGNORE (single source of truth lives
+    # there; this is the offline mirror).
     local ignore="--ignore-vuln CVE-2026-45829 --ignore-vuln PYSEC-2026-139 --ignore-vuln CVE-2025-3000 --ignore-vuln PYSEC-2025-217"
+    # No --strict: the dev venv carries local path-installed packages (devskyy,
+    # cli-anything-*) not on PyPI; --strict aborts on them before auditing any
+    # real dependency. But dropping --strict alone would fail OPEN for any OTHER
+    # uncollectable package (git pin, malformed req, yanked release) — the exact
+    # fail-open pattern bug-230 forbids. So: run non-strict + --skip-editable,
+    # then re-assert fail-closed ourselves — any package pip-audit skipped that
+    # ISN'T one of the 3 known local dists fails the job, just as --strict would.
+    local audit_ok=1
     # shellcheck disable=SC2086
-    # No --strict: the dev venv carries local path-installed packages
-    # (devskyy, cli-anything-*) that aren't on PyPI; strict aborts on them
-    # before auditing. Non-strict still exits 1 on any real vulnerability.
-    if pip-audit $ignore --skip-editable >/tmp/ci-pipaudit.log 2>&1; then _pass "security: pip-audit"; else _fail "security: pip-audit (dependency vulns)"; fi
+    pip-audit $ignore --skip-editable >/tmp/ci-pipaudit.log 2>&1 || audit_ok=0
+    local unexpected_skips
+    unexpected_skips=$(grep -oE 'Skipping [A-Za-z0-9._-]+' /tmp/ci-pipaudit.log 2>/dev/null \
+      | awk '{print $2}' \
+      | grep -vxE 'devskyy|cli-anything-blender|cli-anything-gimp' || true)
+    if [ -n "$unexpected_skips" ]; then
+      _fail "security: pip-audit (unaudited package(s): $(echo "$unexpected_skips" | tr '\n' ' '))"
+    elif [ "$audit_ok" = "1" ]; then
+      _pass "security: pip-audit"
+    else
+      _fail "security: pip-audit (dependency vulns)"
+    fi
   else
     _skip "security: pip-audit" "not installed — pip install pip-audit"
   fi

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -157,7 +157,10 @@ job_security() {
     # aborts --strict before any vulns are even reported.
     local ignore="--ignore-vuln CVE-2026-45829 --ignore-vuln PYSEC-2026-139 --ignore-vuln CVE-2025-3000 --ignore-vuln PYSEC-2025-217"
     # shellcheck disable=SC2086
-    if pip-audit $ignore --skip-editable --strict >/tmp/ci-pipaudit.log 2>&1; then _pass "security: pip-audit"; else _fail "security: pip-audit (dependency vulns)"; fi
+    # No --strict: the dev venv carries local path-installed packages
+    # (devskyy, cli-anything-*) that aren't on PyPI; strict aborts on them
+    # before auditing. Non-strict still exits 1 on any real vulnerability.
+    if pip-audit $ignore --skip-editable >/tmp/ci-pipaudit.log 2>&1; then _pass "security: pip-audit"; else _fail "security: pip-audit (dependency vulns)"; fi
   else
     _skip "security: pip-audit" "not installed — pip install pip-audit"
   fi

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -164,14 +164,23 @@ job_security() {
     # then re-assert fail-closed ourselves — any package pip-audit skipped that
     # ISN'T one of the 3 known local dists fails the job, just as --strict would.
     local audit_ok=1
+    # Parse the JSON report, NOT the text log: pip-audit's "Skipping <pkg>" lines
+    # come only from the rich progress spinner, which writes nothing when stdout
+    # is redirected to a file (non-TTY) unless FORCE_COLOR is set — so grepping
+    # the log is fail-OPEN in a normal shell. The JSON marks every uncollectable
+    # dep with a non-null skip_reason regardless of TTY.
     # shellcheck disable=SC2086
-    pip-audit $ignore --skip-editable >/tmp/ci-pipaudit.log 2>&1 || audit_ok=0
-    local unexpected_skips
-    unexpected_skips=$(grep -oE 'Skipping [A-Za-z0-9._-]+' /tmp/ci-pipaudit.log 2>/dev/null \
-      | awk '{print $2}' \
-      | grep -vxE 'devskyy|cli-anything-blender|cli-anything-gimp' || true)
-    if [ -n "$unexpected_skips" ]; then
-      _fail "security: pip-audit (unaudited package(s): $(echo "$unexpected_skips" | tr '\n' ' '))"
+    pip-audit $ignore --skip-editable -f json -o /tmp/ci-pipaudit.json >/tmp/ci-pipaudit.log 2>&1 || audit_ok=0
+    local skips unexpected_skips
+    skips=$(jq -r '(.dependencies // .) | .[] | select(.skip_reason != null and .skip_reason != "") | .name' /tmp/ci-pipaudit.json 2>/dev/null | sort -u)
+    unexpected_skips=$(printf '%s\n' "$skips" | grep -vxE 'devskyy|cli-anything-blender|cli-anything-gimp' | grep -v '^$' || true)
+    if [ -z "$skips" ]; then
+      # devskyy is always installed editable → there is ALWAYS ≥1 skip. An empty
+      # set means the JSON parse failed or pip-audit changed format: fail closed,
+      # never trust an unverifiable gate (bug-230).
+      _fail "security: pip-audit (no editable skips parsed — guard cannot self-verify; see /tmp/ci-pipaudit.json)"
+    elif [ -n "$unexpected_skips" ]; then
+      _fail "security: pip-audit (unaudited package(s): $(printf '%s' "$unexpected_skips" | tr '\n' ' '))"
     elif [ "$audit_ok" = "1" ]; then
       _pass "security: pip-audit"
     else

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -177,7 +177,14 @@ job_threejs_tests() {
     _skip "threejs-tests" "no test:collections script in root package.json"; return
   fi
   if [ "$FAST" = "1" ] && [ ! -d node_modules ]; then _skip "threejs-tests" "FAST=1 and node_modules absent"; return; fi
-  [ -d node_modules ] || _run "root npm ci" npm ci
+  # Root has no committed package-lock.json (gitignored), so `npm ci` cannot
+  # work in a clean checkout — ci.yml's threejs job uses `npm install` for the
+  # same reason. Mirror it, and fail the job if the install itself fails.
+  if [ ! -d node_modules ]; then
+    if ! _run "root npm install" npm install --no-audit --no-fund; then
+      _fail "threejs-tests: npm install"; return
+    fi
+  fi
   if npm run test:collections >/tmp/ci-threejs.log 2>&1; then _pass "threejs-tests"; else _fail "threejs-tests"; tail -n 20 /tmp/ci-threejs.log | sed 's/^/      /'; fi
 }
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -152,7 +152,12 @@ job_security() {
     _skip "security: bandit" "not installed — pip install bandit"
   fi
   if _have pip-audit; then
-    if pip-audit --strict >/tmp/ci-pipaudit.log 2>&1; then _pass "security: pip-audit"; else _fail "security: pip-audit (dependency vulns)"; fi
+    # Mirror ci.yml: same documented no-fix-available ignores. Add
+    # --skip-editable: the editable devskyy package isn't on PyPI and
+    # aborts --strict before any vulns are even reported.
+    local ignore="--ignore-vuln CVE-2026-45829 --ignore-vuln PYSEC-2026-139 --ignore-vuln CVE-2025-3000 --ignore-vuln PYSEC-2025-217"
+    # shellcheck disable=SC2086
+    if pip-audit $ignore --skip-editable --strict >/tmp/ci-pipaudit.log 2>&1; then _pass "security: pip-audit"; else _fail "security: pip-audit (dependency vulns)"; fi
   else
     _skip "security: pip-audit" "not installed — pip install pip-audit"
   fi

--- a/scripts/ci-sim.sh
+++ b/scripts/ci-sim.sh
@@ -29,6 +29,14 @@
 #   FAST=1 scripts/ci-sim.sh --pr 788               # skip heavy installs
 #   KEEP=1 scripts/ci-sim.sh --pr 788               # keep worktree for debug
 #
+# SECURITY / trust boundary: --pr checks out an arbitrary PR ref and RUNS it
+#   (pytest collection imports every conftest/test module; `npm install`/`npm
+#   ci` run package.json lifecycle scripts) using this machine's interpreter,
+#   npm, and filesystem — NOT a sandbox. This repo is public, so any PR is
+#   untrusted. This is the same exposure as a manual `gh pr checkout N &&
+#   pytest`, made one command. Only gate PRs you are actively reviewing; for
+#   unknown/untrusted authors, run inside a container or throwaway VM.
+#
 # Exit code: ci-local.sh's (0 = every non-skipped check passed).
 # =============================================================================
 set -u
@@ -43,29 +51,16 @@ case "${1:-}" in
   *) echo "usage: ci-sim.sh (--pr N | --ref REF) [jobs...]" >&2; exit 2 ;;
 esac
 
-SHA="" DESC=""
-if [ "$MODE" = "pr" ]; then
-  # Merge preview first — the commit GitHub CI actually validates.
-  if git fetch --quiet origin "pull/${TARGET}/merge" 2>/dev/null; then
-    SHA=$(git rev-parse FETCH_HEAD)
-    DESC="PR #${TARGET} (merge preview)"
-  elif git fetch --quiet origin "pull/${TARGET}/head" 2>/dev/null; then
-    SHA=$(git rev-parse FETCH_HEAD)
-    DESC="PR #${TARGET} (HEAD — no merge ref; PR likely conflicts with main)"
-    echo "ci-sim: WARNING: no merge preview for PR #${TARGET}; gating its head instead" >&2
-  else
-    echo "ci-sim: cannot fetch PR #${TARGET} (neither merge nor head ref)" >&2
-    exit 2
-  fi
-else
-  git fetch --quiet origin 2>/dev/null || true
-  SHA=$(git rev-parse --verify "${TARGET}^{commit}" 2>/dev/null) || {
-    echo "ci-sim: cannot resolve ref '${TARGET}'" >&2; exit 2; }
-  DESC="ref ${TARGET}"
-fi
-
-WT="${ROOT}/.claude/worktrees/ci-sim-${MODE}-${TARGET//\//-}"
+# Unified teardown, armed BEFORE any resource is created so every early-exit
+# path cleans up: the private fetch ref, the stderr temp, and the worktree.
+TMPREF="refs/ci-sim/tmp-$$"
+FETCH_ERR="$(mktemp "${TMPDIR:-/tmp}/ci-sim-fetch-XXXXXX")"
+WT=""
+# shellcheck disable=SC2329  # invoked indirectly via `trap cleanup EXIT`
 cleanup() {
+  git update-ref -d "$TMPREF" 2>/dev/null || true
+  rm -f "$FETCH_ERR"
+  [ -n "$WT" ] || return 0
   if [ "${KEEP:-0}" = "1" ]; then
     echo "ci-sim: KEEP=1 — worktree left at ${WT}"
   else
@@ -73,7 +68,49 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
-git worktree remove --force "$WT" 2>/dev/null || true
+
+# Resolve the commit to gate WITHOUT reading the shared FETCH_HEAD. FETCH_HEAD
+# is a single file in the common git dir; a concurrent `git fetch` (a second
+# ci-sim run, a manual fetch in another terminal) can overwrite it between our
+# fetch and rev-parse, silently gating the WRONG commit. Fetch the PR ref into
+# a private per-process ref and read that instead — no shared state, no race.
+SHA="" DESC=""
+if [ "$MODE" = "pr" ]; then
+  # Merge preview first — the commit GitHub CI actually validates.
+  if git fetch --quiet origin "+pull/${TARGET}/merge:${TMPREF}" 2>"$FETCH_ERR"; then
+    SHA=$(git rev-parse --verify "${TMPREF}")
+    DESC="PR #${TARGET} (merge preview)"
+  elif git fetch --quiet origin "+pull/${TARGET}/head:${TMPREF}" 2>"$FETCH_ERR"; then
+    SHA=$(git rev-parse --verify "${TMPREF}")
+    DESC="PR #${TARGET} (HEAD — no merge ref; PR likely conflicts with main)"
+    echo "ci-sim: WARNING: no merge preview for PR #${TARGET}; gating its head instead" >&2
+  else
+    echo "ci-sim: cannot fetch PR #${TARGET} (neither merge nor head ref):" >&2
+    sed 's/^/  /' "$FETCH_ERR" >&2
+    exit 2
+  fi
+  # SECURITY: --pr checks out and RUNS unreviewed PR code (pytest collection,
+  # npm lifecycle scripts) with this machine's interpreter and filesystem, and
+  # this repo is public — so any PR is untrusted. Same trust boundary as a
+  # manual `gh pr checkout N && pytest`; only gate PRs you are reviewing, and
+  # for unknown authors prefer a sandbox/container (see the header note).
+  echo "ci-sim: NOTE: running unreviewed PR code locally — treat PR #${TARGET} as untrusted" >&2
+else
+  # Ref mode resolves TARGET directly (not via FETCH_HEAD), so no shared-ref
+  # race — refresh remote-tracking refs so origin/* targets resolve fresh.
+  git fetch --quiet origin 2>"$FETCH_ERR" || true
+  SHA=$(git rev-parse --verify "${TARGET}^{commit}" 2>/dev/null) || {
+    echo "ci-sim: cannot resolve ref '${TARGET}':" >&2
+    sed 's/^/  /' "$FETCH_ERR" >&2
+    exit 2; }
+  DESC="ref ${TARGET}"
+fi
+
+# Per-process worktree path: a purely target-derived path would let a second
+# run for the same PR/ref force-remove this run's worktree mid-job. $$ makes it
+# unique; prune reaps registrations left by any crashed prior run.
+git worktree prune 2>/dev/null || true
+WT="${ROOT}/.claude/worktrees/ci-sim-${MODE}-${TARGET//\//-}-$$"
 git worktree add --detach --quiet "$WT" "$SHA" || {
   echo "ci-sim: worktree add failed for ${SHA}" >&2; exit 2; }
 

--- a/scripts/ci-sim.sh
+++ b/scripts/ci-sim.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# =============================================================================
+# ci-sim.sh — simulated CI clone: run the offline gate against a PR or ref
+# =============================================================================
+# GitHub Actions is disabled repo-level (since 2026-06-29), so nothing gates
+# the PR queue. This wrapper reproduces what the Actions runner would do:
+#
+#   1. Resolve the commit CI would test:
+#        --pr N   → refs/pull/N/merge (GitHub's merge preview — the exact
+#                   commit a pull_request run validates), falling back to
+#                   pull/N/head when no merge ref exists (conflicting PR)
+#        --ref R  → any local/remote ref or SHA
+#   2. Check it out into a clean disposable worktree (clone-equivalent:
+#        tracked files only, no dirty local state, no gitignored riders)
+#   3. Run scripts/ci-local.sh there — the offline mirror of ci.yml's six
+#      gating jobs (lint · python-tests · security · frontend-tests ·
+#      threejs-tests · wordpress-theme, aggregated upstream as the
+#      "Pipeline Summary" check)
+#   4. Tear the worktree down and report a single PASS/FAIL verdict
+#
+# The canonical ci-local.sh from THIS checkout is used (CI_LOCAL_ROOT
+# override, same pattern as the pre-push hook), so PRs whose branches
+# predate the gate script are still checkable.
+#
+# Usage:
+#   scripts/ci-sim.sh --pr 788                      # full gate on PR #788
+#   scripts/ci-sim.sh --pr 788 lint python-tests    # subset of jobs
+#   scripts/ci-sim.sh --ref origin/main             # gate a branch/SHA
+#   FAST=1 scripts/ci-sim.sh --pr 788               # skip heavy installs
+#   KEEP=1 scripts/ci-sim.sh --pr 788               # keep worktree for debug
+#
+# Exit code: ci-local.sh's (0 = every non-skipped check passed).
+# =============================================================================
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 2
+
+MODE="" TARGET=""
+case "${1:-}" in
+  --pr)  MODE="pr";  TARGET="${2:?usage: ci-sim.sh --pr N [jobs...]}";  shift 2 ;;
+  --ref) MODE="ref"; TARGET="${2:?usage: ci-sim.sh --ref REF [jobs...]}"; shift 2 ;;
+  *) echo "usage: ci-sim.sh (--pr N | --ref REF) [jobs...]" >&2; exit 2 ;;
+esac
+
+SHA="" DESC=""
+if [ "$MODE" = "pr" ]; then
+  # Merge preview first — the commit GitHub CI actually validates.
+  if git fetch --quiet origin "pull/${TARGET}/merge" 2>/dev/null; then
+    SHA=$(git rev-parse FETCH_HEAD)
+    DESC="PR #${TARGET} (merge preview)"
+  elif git fetch --quiet origin "pull/${TARGET}/head" 2>/dev/null; then
+    SHA=$(git rev-parse FETCH_HEAD)
+    DESC="PR #${TARGET} (HEAD — no merge ref; PR likely conflicts with main)"
+    echo "ci-sim: WARNING: no merge preview for PR #${TARGET}; gating its head instead" >&2
+  else
+    echo "ci-sim: cannot fetch PR #${TARGET} (neither merge nor head ref)" >&2
+    exit 2
+  fi
+else
+  git fetch --quiet origin 2>/dev/null || true
+  SHA=$(git rev-parse --verify "${TARGET}^{commit}" 2>/dev/null) || {
+    echo "ci-sim: cannot resolve ref '${TARGET}'" >&2; exit 2; }
+  DESC="ref ${TARGET}"
+fi
+
+WT="${ROOT}/.claude/worktrees/ci-sim-${MODE}-${TARGET//\//-}"
+cleanup() {
+  if [ "${KEEP:-0}" = "1" ]; then
+    echo "ci-sim: KEEP=1 — worktree left at ${WT}"
+  else
+    git worktree remove --force "$WT" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+git worktree remove --force "$WT" 2>/dev/null || true
+git worktree add --detach --quiet "$WT" "$SHA" || {
+  echo "ci-sim: worktree add failed for ${SHA}" >&2; exit 2; }
+
+# Gate tooling: prefer the isolated CI toolchain, fall back to the project venv.
+if [ -f "${ROOT}/ci-env/.venv/bin/activate" ]; then
+  # shellcheck disable=SC1091
+  . "${ROOT}/ci-env/.venv/bin/activate"
+elif [ -f "${ROOT}/.venv/bin/activate" ]; then
+  # shellcheck disable=SC1091
+  . "${ROOT}/.venv/bin/activate"
+fi
+
+echo "ci-sim: gating ${DESC} @ ${SHA:0:12}"
+echo "ci-sim: clean worktree ${WT}"
+
+CI_LOCAL_ROOT="$WT" bash "${ROOT}/scripts/ci-local.sh" "$@"
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  echo "ci-sim: VERDICT ${DESC} @ ${SHA:0:8} — PASS"
+else
+  echo "ci-sim: VERDICT ${DESC} @ ${SHA:0:8} — FAIL (rc=${rc})"
+fi
+exit "$rc"


### PR DESCRIPTION
## Why

GitHub Actions is **disabled at the repo level** (`actions/permissions → enabled:false`, since 2026-06-29). The gating `Pipeline Summary` check has not run on any PR or main push in 3 weeks — the entire 28-PR queue is unverified.

## What

`scripts/ci-sim.sh` — a local simulation of the CI clone:

1. Resolves the commit CI would actually test: `--pr N` fetches **`refs/pull/N/merge`** (GitHub's merge preview — identical to what a `pull_request` run validates), falling back to PR head with a warning when no merge ref exists; `--ref R` gates any branch/SHA
2. Checks it out into a clean disposable worktree — clone-equivalent: tracked files only, no dirty local state
3. Runs the existing `scripts/ci-local.sh` six-job gate there (lint · python-tests · security · frontend-tests · threejs-tests · wordpress-theme) via the `CI_LOCAL_ROOT` override, so PR branches that predate the gate script are still checkable
4. Prints a single `VERDICT … PASS/FAIL` line, tears down the worktree (`KEEP=1` retains it)

Also documents both scripts in `.wolf/anatomy.md`.

## Verification

- `shellcheck`: clean (2 suppressed false positives: literal assign, trap-invoked function)
- Live smoke: `scripts/ci-sim.sh --pr 788 wordpress-theme` → fetched merge preview `f80795b8`, `php -l` all theme files PASS, worktree auto-removed
- Full six-job run against PR #788 in flight (results will be posted here)

## Notes

- `bandit`/`pip-audit` absent from the local venv → those security steps SKIP honestly (install to activate them)
- Heavy JS jobs (frontend build, threejs) do a real `npm ci` in the clean worktree — slow but true-to-CI; `FAST=1` skips when node_modules absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rzUpwLDLKxuNfqgs9taz5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `scripts/ci-sim.sh` to simulate CI locally by gating a PR’s merge-preview commit in a clean worktree using the six-job `ci-local` gate. Hardens fetch/worktree handling and keeps `pip-audit` fail-closed.

- **New Features**
  - Resolves and gates the exact commit CI would test (`--pr N` merge preview with head fallback; `--ref` any ref/SHA), runs in a disposable worktree via `CI_LOCAL_ROOT`, and prints a single PASS/FAIL verdict (`KEEP=1` keeps it). Docs in `.wolf/anatomy.md`.

- **Bug Fixes**
  - `threejs-tests`: use `npm install` (root lockfile is ignored) and fail the job if install fails.
  - Security: `pip-audit` mirrors CI (documented ignores, `--skip-editable`, non-strict) and re-asserts fail-closed by parsing the JSON report (TTY-independent); fails on any unexpected skipped package and when parsing cannot self-verify.
  - ci-sim hardening: fetches PR refs into a private per-process ref (no `FETCH_HEAD` race), uses a per-PID worktree path with prune (no collision), surfaces fetch errors, and notes the `--pr` trust boundary per run.

<sup>Written for commit 7a6bb38095466ea7a4e7b5f5cd02faec077ccdd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Skyy-Rose-Collection-LLC/DevSkyy/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

