### PR TITLE
fix(compositor): fail closed on QA rejection

### DIFF
--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -5498,4 +5498,25 @@
     "occurrences": 1,
     "last_seen": "2026-08-01T00:00:00Z"
   }
+,
+  {
+    "id": "bug-319",
+    "timestamp": "2026-08-03T15:53:39-07:00",
+    "error_message": "CompositorAgent reported qa_status=\"fail\" but returned CompositorResult(success=True).",
+    "file": "skyyrose/elite_studio/agents/compositor/orchestrator.py",
+    "root_cause": "The final result assembly unconditionally set success=True after recording the QA verdict, so a failed QA gate did not control the caller-visible success contract.",
+    "fix": "Made success an explicit QA allowlist (pass/warn only), retaining qa_status, qa_details, output_path, and audit_log_path without raising. Added a parametrized pass/warn/fail regression test and updated stale full-pipeline mocks to stub the current QA gate and orchestrator upload binding.",
+    "tags": [
+      "compositor",
+      "qa",
+      "fail-closed",
+      "regression"
+    ],
+    "related_bugs": [
+      "bug-179",
+      "bug-230"
+    ],
+    "occurrences": 1,
+    "last_seen": "2026-08-03T15:53:39-07:00"
+  }
 ]

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -5518,5 +5518,26 @@
     ],
     "occurrences": 1,
     "last_seen": "2026-08-03T15:53:39-07:00"
+  },
+  {
+    "id": "bug-320",
+    "timestamp": "2026-08-03T16:21:00-07:00",
+    "error_message": "A parseable compositor QA response without status defaulted to warn and returned a successful result.",
+    "file": "skyyrose/elite_studio/agents/compositor/orchestrator.py",
+    "root_cause": "_visual_qa used parsed.get(\"status\") or \"warn\", so absent and falsey provider verdicts bypassed the explicit success allowlist.",
+    "fix": "Changed the parser fallback to fail and added a regression test for a successful provider response whose JSON omits status.",
+    "tags": [
+      "compositor",
+      "qa",
+      "fail-closed",
+      "parser",
+      "regression"
+    ],
+    "related_bugs": [
+      "bug-319",
+      "bug-230"
+    ],
+    "occurrences": 1,
+    "last_seen": "2026-08-03T16:21:00-07:00"
   }
 ]

--- a/.wolf/cerebrum.md
+++ b/.wolf/cerebrum.md
@@ -436,3 +436,4 @@ loads directly from repo (no cache).
 ## 2026-08-03 — Compositor QA verdicts are caller-visible success gates
 
 - **Key Learning**: In `CompositorAgent.composite`, preserve the completed artifact, QA details, and audit log for every verdict, but derive `CompositorResult.success` from the explicit QA allowlist: `pass`/`warn` only. A `fail` (or unrecognized status) is a non-raising, fail-closed result so callers can inspect and route the retained evidence. (bug-319)
+- **Key Learning**: `_visual_qa` must normalize absent or falsey provider verdicts to `fail`; only explicit `pass` and `warn` statuses may reach the success allowlist. (bug-320)

--- a/.wolf/cerebrum.md
+++ b/.wolf/cerebrum.md
@@ -433,3 +433,6 @@ loads directly from repo (no cache).
 - **Do-Not-Repeat — audit probes:** `querySelector('a, .b, [class*=c]')` returns the first match in DOCUMENT order, not selector order — caused the false "pre-order missing footer" P1 (matched .po-card__footer). Probe for a SPECIFIC selector (#colophon.site-footer) or query each selector separately. Likewise: rect.right > viewport does NOT mean an element causes horizontal scroll — position:fixed subtrees can't extend scrollWidth; filter them before naming culprits.
 - **Do-Not-Repeat — screenshot harnesses on this theme:** the site sets `scroll-behavior:smooth`; `window.scrollTo(0,0)` animates and a fixed 1s settle captures mid-scroll on long pages. Wait on `scrollY===0`, not a timer.
 
+## 2026-08-03 — Compositor QA verdicts are caller-visible success gates
+
+- **Key Learning**: In `CompositorAgent.composite`, preserve the completed artifact, QA details, and audit log for every verdict, but derive `CompositorResult.success` from the explicit QA allowlist: `pass`/`warn` only. A `fail` (or unrecognized status) is a non-raising, fail-closed result so callers can inspect and route the retained evidence. (bug-319)

--- a/skyyrose/elite_studio/agents/compositor/orchestrator.py
+++ b/skyyrose/elite_studio/agents/compositor/orchestrator.py
@@ -740,7 +740,7 @@ class CompositorAgent(FluxProviderMixin):
         text = result.get("text", "")
         try:
             parsed = _safe_json_extract(text)
-            status = parsed.get("status") or "warn"
+            status = parsed.get("status") or "fail"
             return {**parsed, "status": status, "model": COMPOSITOR_QA_MODEL}
         except Exception:
             return {

--- a/skyyrose/elite_studio/agents/compositor/orchestrator.py
+++ b/skyyrose/elite_studio/agents/compositor/orchestrator.py
@@ -388,7 +388,7 @@ class CompositorAgent(FluxProviderMixin):
             result_kwargs["output_path"] = shadow_path
             result_kwargs["alpha_path"] = alpha_path
             result_kwargs["stages_completed"] = stages_done
-            result_kwargs["success"] = True
+            result_kwargs["success"] = result_kwargs["qa_status"] in {"pass", "warn"}
             result_kwargs["provider"] = result_kwargs.get("provider", "fal-fill")
 
             result = CompositorResult(**result_kwargs)

--- a/skyyrose/elite_studio/agents/compositor/orchestrator.py
+++ b/skyyrose/elite_studio/agents/compositor/orchestrator.py
@@ -389,6 +389,10 @@ class CompositorAgent(FluxProviderMixin):
             result_kwargs["alpha_path"] = alpha_path
             result_kwargs["stages_completed"] = stages_done
             result_kwargs["success"] = result_kwargs["qa_status"] in {"pass", "warn"}
+            if not result_kwargs["success"]:
+                result_kwargs["error"] = str(
+                    qa.get("reason") or qa.get("error") or "QA rejected composite"
+                )
             result_kwargs["provider"] = result_kwargs.get("provider", "fal-fill")
 
             result = CompositorResult(**result_kwargs)

--- a/skyyrose/elite_studio/tests/test_compositor_agent.py
+++ b/skyyrose/elite_studio/tests/test_compositor_agent.py
@@ -470,7 +470,7 @@ class TestFullPipeline:
         tmp_scene,
         tmp_model_image,
     ):
-        """QA failure returns details and artifacts without reporting success."""
+        """Only pass/warn QA verdicts succeed; failures retain evidence and reason."""
         from PIL import Image
 
         alpha_path = str(tmp_path / "alpha.png")
@@ -509,6 +509,7 @@ class TestFullPipeline:
         assert result.success is expected_success
         assert result.qa_status == qa_status
         assert result.qa_details == qa
+        assert result.error == ("" if expected_success else "contract regression")
         assert result.output_path == shadow_path
         assert result.audit_log_path == audit_log_path
 
@@ -616,3 +617,22 @@ class TestAuditLog:
         assert data["sku"] == "br-001"
         assert data["scene_name"] == "test-scene"
         assert "stages" in data
+
+    def test_audit_log_persists_failed_qa_details(self, compositor, tmp_path):
+        qa = {"status": "fail", "reason": "garment fidelity mismatch"}
+        result = CompositorResult(
+            success=False,
+            provider="fal-fill",
+            scene_name="test-scene",
+            qa_status="fail",
+            qa_details=qa,
+            error=qa["reason"],
+            stages_completed=6,
+        )
+
+        log_path = compositor._write_audit_log(
+            "br-001", "test-scene", {"qa": {"details": qa}}, result, str(tmp_path)
+        )
+
+        data = json.loads(Path(log_path).read_text())
+        assert data["result"]["success"] is False

--- a/skyyrose/elite_studio/tests/test_compositor_agent.py
+++ b/skyyrose/elite_studio/tests/test_compositor_agent.py
@@ -380,6 +380,22 @@ class TestVisualQA:
         assert result["error_type"] == "qa_provider_error"
         assert "error" in result
 
+    @patch("skyyrose.elite_studio.agents.compositor_agent.analyze_vision")
+    def test_qa_missing_status_returns_fail(self, mock_gemini, compositor, tmp_path):
+        """A parseable QA response without a verdict fails closed."""
+        from PIL import Image
+
+        composite_path = str(tmp_path / "composite.png")
+        Image.new("RGB", (200, 300)).save(composite_path)
+        mock_gemini.return_value = {
+            "success": True,
+            "text": json.dumps({"lighting_match": {"score": 9}}),
+        }
+
+        result = compositor._visual_qa(composite_path, "scene", "collection")
+
+        assert result["status"] == "fail"
+
 
 # ---------------------------------------------------------------------------
 # Full Pipeline

--- a/skyyrose/elite_studio/tests/test_compositor_agent.py
+++ b/skyyrose/elite_studio/tests/test_compositor_agent.py
@@ -387,13 +387,13 @@ class TestVisualQA:
 
 
 class TestFullPipeline:
-    @patch("skyyrose.elite_studio.agents.compositor_agent.analyze_vision")
+    @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._maybe_apply_gate")
     @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._generate_shadows")
     @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._composite_with_flux")
     @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._relight_subject")
     @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._engineer_flux_prompt")
     @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._extract_alpha")
-    @patch("skyyrose.elite_studio.agents.compositor_agent.upload_to_fal")
+    @patch("skyyrose.elite_studio.agents.compositor.orchestrator.upload_to_fal")
     def test_full_pipeline_success(
         self,
         mock_upload,
@@ -424,10 +424,7 @@ class TestFullPipeline:
         mock_flux.return_value = (b"\x89PNG_FINAL", "fal-fill")
         mock_shadow.return_value = shadow_path
         mock_upload.return_value = "https://fal.cdn/uploaded.png"
-        mock_qa.return_value = {
-            "success": True,
-            "text": json.dumps({"status": "pass", "details": {}}),
-        }
+        mock_qa.return_value = {"status": "pass"}
 
         result = compositor.composite(
             sku="br-001",
@@ -442,6 +439,62 @@ class TestFullPipeline:
         assert result.success
         assert result.provider == "fal-fill"
         assert result.stages_completed == 6
+
+    @pytest.mark.parametrize(
+        ("qa_status", "expected_success"),
+        [("pass", True), ("warn", True), ("fail", False)],
+    )
+    def test_pipeline_success_fails_closed_on_qa_fail(
+        self,
+        qa_status,
+        expected_success,
+        compositor,
+        monkeypatch,
+        tmp_path,
+        tmp_scene,
+        tmp_model_image,
+    ):
+        """QA failure returns details and artifacts without reporting success."""
+        from PIL import Image
+
+        alpha_path = str(tmp_path / "alpha.png")
+        relit_path = str(tmp_path / "relit.png")
+        shadow_path = str(tmp_path / "shadow.png")
+        audit_log_path = str(tmp_path / "audit.json")
+        Image.new("RGBA", (100, 150)).save(alpha_path)
+        Image.new("RGBA", (100, 150)).save(relit_path)
+        Image.new("RGB", (100, 150)).save(shadow_path)
+
+        qa = {"status": qa_status, "reason": "contract regression"}
+        monkeypatch.setattr(compositor, "_extract_alpha", lambda *_: alpha_path)
+        monkeypatch.setattr(compositor, "_engineer_flux_prompt", lambda **_: "prompt")
+        monkeypatch.setattr(compositor, "_relight_subject", lambda *_: relit_path)
+        monkeypatch.setattr(
+            "skyyrose.elite_studio.agents.compositor.orchestrator.upload_to_fal",
+            lambda _: "https://fal.cdn/uploaded.png",
+        )
+        monkeypatch.setattr(
+            compositor, "_composite_with_flux", lambda **_: (b"\x89PNG_FINAL", "fal-fill")
+        )
+        monkeypatch.setattr(compositor, "_gimp_pixel_cleanup", lambda path, *_: path)
+        monkeypatch.setattr(compositor, "_generate_shadows", lambda *_: shadow_path)
+        monkeypatch.setattr(compositor, "_maybe_apply_gate", lambda *_: qa)
+        monkeypatch.setattr(compositor, "_write_audit_log", lambda *_: audit_log_path)
+
+        result = compositor.composite(
+            sku="br-001",
+            scene_image_path=str(tmp_scene),
+            model_image_path=str(tmp_model_image),
+            collection="black-rose",
+            scene_name="black-rose-rooftop-garden",
+            output_dir=str(tmp_path / "output"),
+        )
+
+        assert result.success is expected_success
+        assert result.qa_status == qa_status
+        assert result.qa_details == qa
+        assert result.output_path == shadow_path
+        assert result.audit_log_path == audit_log_path
 
     @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._extract_alpha")
     def test_pipeline_alpha_failure(
@@ -465,13 +518,13 @@ class TestFullPipeline:
 
 
 class TestCheckpointResume:
-    @patch("skyyrose.elite_studio.agents.compositor_agent.analyze_vision")
+    @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._maybe_apply_gate")
     @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._generate_shadows")
     @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._composite_with_flux")
     @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._relight_subject")
     @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._engineer_flux_prompt")
     @patch("skyyrose.elite_studio.agents.compositor_agent.CompositorAgent._extract_alpha")
-    @patch("skyyrose.elite_studio.agents.compositor_agent.upload_to_fal")
+    @patch("skyyrose.elite_studio.agents.compositor.orchestrator.upload_to_fal")
     def test_resume_from_stage_4(
         self,
         mock_upload,
@@ -495,10 +548,7 @@ class TestCheckpointResume:
         mock_flux.return_value = (b"\x89PNG", "fal-fill")
         mock_shadow.return_value = shadow_path
         mock_upload.return_value = "https://fal.cdn/uploaded.png"
-        mock_qa.return_value = {
-            "success": True,
-            "text": json.dumps({"status": "pass"}),
-        }
+        mock_qa.return_value = {"status": "pass"}
 
         # Pre-create checkpoint artifacts
         alpha_path = str(tmp_path / "br-001-alpha.png")


### PR DESCRIPTION
## **User description**
## Description

A compositor result whose Gemini QA verdict is `fail` previously reported `success=True`, allowing callers to treat a rejected render as approved. This change derives success from an explicit `pass`/`warn` allowlist while preserving the artifact path, QA details, and audit log for rejected renders.

A focused parametrized regression test covers `pass`, `warn`, and `fail` verdicts and verifies retained QA evidence.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🎨 Style/formatting change
- [ ] ♻️ Refactoring (no functional changes)
- [x] ✅ Test update

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [ ] I have run `make format-all` to format my code
- [ ] I have run `make lint-all` and fixed any issues
- [ ] I have run `make test-all` and all tests pass

### Testing

- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] Python tests pass: `make test`
- [ ] TypeScript tests pass: `make ts-test`

### Documentation

- [ ] I have updated the README if needed
- [ ] I have added/updated docstrings for new functions
- [ ] I have updated type hints where applicable

### Security

- [x] I have not introduced any hardcoded secrets or API keys
- [x] I have considered security implications of my changes
- [x] Any new dependencies have been reviewed for security

## Related Issues

Fixes #644

## Screenshots (if applicable)

N/A

## How to Test

```bash
rtk proxy pytest skyyrose/elite_studio/tests/test_compositor_agent.py -q
```

Expected result: 22 passed.

## Breaking Changes

N/A

## Additional Notes

`warn` remains a completed, reviewable result. `fail` is non-raising and fail-closed so downstream callers can inspect retained evidence and route it for remediation.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a security bug where the `CompositorAgent` was incorrectly reporting `success=True` even when the Gemini QA verdict was `fail`. The fix changes the success determination to explicitly allow only `pass` and `warn` verdicts, implementing a fail-closed approach. The change retains all artifact paths, QA details, and audit logs for failed renders so downstream callers can inspect the evidence and route rejected renders for remediation. A new parametrized regression test validates the behavior across `pass`, `warn`, and `fail` verdicts.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `skyyrose/elite_studio/agents/compositor/orchestrator.py` |
| 2 | `skyyrose/elite_studio/tests/test_compositor_agent.py` |
| 3 | `.wolf/buglog.json` |
| 4 | `.wolf/cerebrum.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the compositor fail closed on QA rejection and surface the rejection reason in `error`. `CompositorResult.success` is now true only for QA `pass` or `warn`; other or missing verdicts keep artifacts and QA details but return `success=False`.

- **Bug Fixes**
  - Derive success from QA allowlist `{"pass", "warn"}`; default absent/falsey verdicts to `fail` in `_visual_qa`.
  - On QA failure, set `error` from `qa.reason`/`qa.error` (fallback “QA rejected composite”) and retain `output_path`, `qa_status`, `qa_details`, and `audit_log_path`.
  - Tests: add pass/warn/fail and missing-status cases; update pipeline tests to stub `_maybe_apply_gate` and patch `skyyrose.elite_studio.agents.compositor.orchestrator.upload_to_fal`.

<sup>Written for commit b3b6ee0d3b9c20753165537b9134eb9144519160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SkyyRoseLLC/DevSkyy/pull/864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Fail compositor results when QA rejects a render

### What Changed
- Compositor results now report failure when the QA verdict is `fail` or unrecognized, while `pass` and `warn` remain successful
- Rejected renders still retain their output artifact, QA details, and audit log for review and follow-up
- Added coverage for pass, warn, and fail verdicts

### Impact
`✅ Fewer QA-rejected renders treated as approved`
`✅ Retained artifacts and evidence for failed renders`
`✅ Clearer caller-visible render status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Compositor results now report success accurately based on quality checks.
  - Approved outcomes (`pass` and `warn`) are marked successful, while failed or unrecognized outcomes remain unsuccessful.
  - Quality details, generated artifacts, and audit information are preserved for inspection even when a result is unsuccessful.

- **Tests**
  - Added coverage for passing, warning, and failing quality outcomes, including resumed workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->